### PR TITLE
fix-brew

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -54,6 +54,7 @@ require 'zshrc/pacman.zsh'
 export PATH="${DOTFILES}/bin:$PATH"
 
 if type 'brew' > /dev/null 2>&1; then
+  export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
   export PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
 fi
 


### PR DESCRIPTION
- Add Homebrew paths to the beginning of the PATH variable
- Update yt-dlp alias to use Chrome's default profile instead of Firefox

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes Homebrew-installed binaries on macOS.
> 
> - In `zsh/.zshrc`, when `brew` exists, prepends `/opt/homebrew/bin:/opt/homebrew/sbin` to `PATH` before adding Coreutils `gnubin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e5187a823ebc73703449f9c8a4e902a636cd89c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->