### PR TITLE
Remove exa aliases from .bashrc

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -1,18 +1,3 @@
 PS1="\[\e[0;36m\]\u@\H \W\[\e[0m\]\$ "
 
-# ls command series
-if type "exa" > /dev/null 2>&1; then
-  # pacman -S exa
-  alias ls='exa'
-  alias ll='exa  -l  -gh --time-style long-iso --git'
-  alias la='exa  -a'
-  alias lla='exa -la -gh --time-style long-iso --git'
-else
-  alias ls='ls  --color=auto'
-  alias ll='ls  -l'
-  alias la='ls  -a'
-  alias lla='ls -la'
-fi
-
-
 export HISTCONTROL=ignoredups


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes alias configuration from `bash/.bashrc`, simplifying the shell setup.
> 
> - Deletes the conditional `exa`/`ls` alias block (`ls`, `ll`, `la`, `lla`)
> - Retains prompt (`PS1`) and history control (`HISTCONTROL`) settings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e78ddddad478dede5a80fdbcafcb79842ef05ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->