### PR TITLE
Add new git aliases in alias.config

### DIFF
--- a/git/alias.config
+++ b/git/alias.config
@@ -18,17 +18,25 @@
 
   b = branch
 
-  sw = switch
-  swi = switch
-
-  new = switch -c
-
-  main = !git switch main && git pull
-  master = !git switch master && git pull
-
   pull-re = pull --rebase
   pull-rebase = pull --rebase
 
   reset-hard = reset --hard HEAD
 
   rebase-previous = rebase -i HEAD~
+
+  # Switch
+  sw = switch
+  swi = switch
+
+  new = switch -c
+  prev = switch -
+
+  main = !git switch main && git pull
+  master = !git switch master && git pull
+
+  # Get PR base branch (merge target) for current branch
+  base-branch = !"gh pr view $(git branch --show-current) --json baseRefName --jq '.baseRefName'"
+
+  # Switch to PR target branch and pull
+  base = !"pr_target=$(git base-branch) && [ -n \"$pr_target\" ] && git switch \"$pr_target\" && git pull"


### PR DESCRIPTION
- Introduced 'prev' for switching to the previous branch
- Added 'base-branch' to get the PR base branch for the current branch
- Implemented 'base' to switch to the PR target branch and pull

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds convenient workflow aliases for navigating between branches and PR targets.
> 
> - New `prev` alias to switch back to the previous branch (`git switch -`)
> - New `base-branch` alias to fetch the PR base branch name for the current branch via `gh pr view`
> - New `base` alias to switch to the PR’s base branch and pull latest changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96b06c4271c6fdaf08d1953f3c009c880c5a0e41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->