### PR TITLE
Add git done alias for post-merge workflow

### DIFF
--- a/git/alias.config
+++ b/git/alias.config
@@ -25,6 +25,9 @@
 
   rebase-previous = rebase -i HEAD~
 
+  # Cleaning up blanches
+  clean-blanch = !git branch --merged | egrep -v '(^\\*|master|main)' | xargs git branch -d && git fetch --prune
+
   # Switch
   sw = switch
   swi = switch


### PR DESCRIPTION
## Changes

- Add `current` alias to get current branch name
- Add `merged` alias to check if PR is merged
- Rename `prev` to `pre` for brevity
- Rename `base-branch` to `base` and simplify implementation
- Add `done` alias to automate post-merge cleanup:
  - Checks if PR is merged
  - Switches to base branch and pulls
  - Deletes merged branch locally
  - Prunes remote-tracking branches

## Usage

After a PR is merged:
```bash
git done
```

This will automatically:
1. Verify the PR is merged
2. Switch to the base branch
3. Pull latest changes
4. Delete the merged branch
5. Prune stale remote branches