### PR TITLE
Fix: Enable git alias command to work from any directory

### DIFF
--- a/git/alias.config
+++ b/git/alias.config
@@ -1,6 +1,6 @@
 [alias]
   # Alias Management ===================================
-  alias = !"cat \"$(git rev-parse --show-toplevel)/git/alias.config\" | grep -v '^\\[' | sed 's/^  //'"
+  alias = !"cat \"${DOTFILES}/git/alias.config\" | grep -v '^\\[' | sed 's/^  //'"
 
   # Status & Information ===============================
   s = status


### PR DESCRIPTION
## Overview
Fix the `g alias` command to work from any directory, not just inside git repositories.

## Problem
The `g alias` command was using `git rev-parse --show-toplevel` to locate the alias.config file, which only works inside git repositories.

When running `g alias` outside of a git repository:
```
fatal: not a git repository (or any of the parent directories): .git
cat: /git/alias.config: No such file or directory
```

## Solution
Replace `git rev-parse --show-toplevel` with the `$DOTFILES` environment variable (defined in `.zshrc`).

**Before:**
```bash
alias = !"cat \"$(git rev-parse --show-toplevel)/git/alias.config\" | grep -v '^\\[' | sed 's/^  //'"
```

**After:**
```bash
alias = !"cat \"${DOTFILES}/git/alias.config\" | grep -v '^\\[' | sed 's/^  //'"
```

## Benefits
- ✅ Works from any directory (not just git repositories)
- ✅ Consistent with dotfiles environment setup
- ✅ More reliable and predictable behavior

## Testing
- [x] Verified `g alias` works from dotfiles directory
- [x] Verified `g alias` works from non-git directories
- [x] Verified `g alias` works from other git repositories