### PR TITLE
Simplify eza aliases and add tree function

### DIFF
--- a/zsh/zshrc/ls.zsh
+++ b/zsh/zshrc/ls.zsh
@@ -1,32 +1,16 @@
-# # Theme configure
-# # Install location
-# DIRCOLORS=${DOTFILES}/zsh/bundle/dircolors-solarized
-
-# # Dircolors installation
-# if $(type "git" > /dev/null 2>&1) && [[ ! -d $DIRCOLORS ]]; then
-#   git clone https://github.com/seebi/dircolors-solarized.git $DIRCOLORS
-# fi
-
-# # Dircolors activation
-# if [[ -d $DIRCOLORS ]]; then
-#   eval $(dircolors $DIRCOLORS)
-#   eval $(dircolors $DIRCOLORS/dircolors.ansi-universal)
-# fi
-
-
 # ls command series
 if type "eza" > /dev/null 2>&1; then
-  # pacman -S eza
-  alias ls='eza'
-  alias ll='eza  -l  -gh --time-style long-iso --git'
-  alias la='eza  -a'
-  alias lla='eza -la -gh --time-style long-iso --git'
+  alias ls='eza --icons=always -l -gh --time-style long-iso --git'
+  alias la='eza --icons=always -la -gh --time-style long-iso --git'
 
-  # Standard ls (always use standard ls command)
-  alias sls='command ls --color=auto'
+  lt() {
+    local level="${1:-2}"  # デフォルトは2
+    eza --icons=always -la -gh --time-style long-iso --git --tree --level="$level"
+  }
 else
-  alias ls='ls  --color=auto'
-  alias ll='ls  -lh'
-  alias la='ls  -a'
-  alias lla='ls -lah'
+  alias ls='ls --color=auto -lh'
+  alias la='ls --color=auto -lah'
 fi
+
+# Standard ls (always use standard ls command)
+alias sls='command ls'


### PR DESCRIPTION
## Summary
- Remove commented dircolors configuration that is no longer needed
- Simplify ls/la aliases with `--icons=always` flag for better visual output
- Add `lt()` function for tree view with configurable depth (default: 2 levels)
- Remove redundant `ll` and `lla` aliases in favor of simpler `ls` and `la`
- Move `sls` alias outside conditional block for consistency

## Test plan
- [x] Verify `ls` command shows icons and detailed info
- [x] Verify `la` command shows hidden files with icons
- [x] Verify `lt` command displays tree view (default 2 levels)
- [x] Verify `lt 3` command displays tree view with custom depth
- [x] Verify `sls` command uses standard ls regardless of eza installation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines shell `ls` ergonomics and adds a tree view.
> 
> - Remove legacy commented `dircolors` setup from `ls.zsh`
> - Consolidate `eza` aliases: `ls` and `la` now include `--icons=always`, long listing, git/time flags; drop `ll`/`lla`
> - Add `lt()` to display an `eza` tree with configurable `--level` (default 2)
> - Standardize non-`eza` fallback: `ls`/`la` use `--color=auto` with `-lh`/`-lah`
> - Move `sls` alias outside the conditional to always invoke `command ls`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba46657d9a974368a483aa673358e2267f912e01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->