### PR TITLE
docs: update copyright and author name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Toshiki Kawazoe
+Copyright (c) 2016-2026 toshiki670
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/git/user.config
+++ b/git/user.config
@@ -1,4 +1,4 @@
 # For github account
 [user]
 	email = bushy.trivial.0o@icloud.com
-	name = Toshiki
+	name = toshiki670


### PR DESCRIPTION
## Summary
- Update copyright year range from 2020 to 2016-2026 (reflecting the actual first commit year)
- Change author name from "Toshiki Kawazoe" to GitHub username "toshiki670" for privacy protection
- Update git user.config to match the GitHub username for consistency

## Test plan
- [x] Verify LICENSE file has correct copyright information
- [x] Verify git/user.config has correct username
- [x] Confirm all references to author name are updated across the repository