### PR TITLE
Disable major version option in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         options:
           - patch
           - minor
-          - major
+          # - major
         default: patch
 
 permissions:


### PR DESCRIPTION
## Summary
- Comment out the major version option in the manual workflow dispatch to prevent accidental major version bumps

## Test plan
- [ ] Verify that the workflow dispatch UI only shows patch and minor options
- [ ] Confirm that the default value (patch) is still correctly set