### PR TITLE
Remove unused yt-dlp aliases

### DIFF
--- a/zsh/zshrc/yt-dlp.zsh
+++ b/zsh/zshrc/yt-dlp.zsh
@@ -6,7 +6,4 @@
 YT_BROWSER="${YT_BROWSER:-chrome:Default}"
 
 alias yt="yt-dlp --cookies-from-browser \"${YT_BROWSER}\""
-alias yt-comment='yt --write-subs --write-comments'
 alias yt-chat='yt --write-subs --write-comments'
-alias yt-vr='yt "https://www.nhk.or.jp/radio/ondemand/detail.html?p=6N87LJL8ZM_01"'
-


### PR DESCRIPTION
## Summary
- Remove `yt-comment` alias (redundant with `yt-chat`)
- Remove `yt-vr` alias (no longer needed)

## Changes
- Keep `yt-chat` alias which serves the same purpose as `yt-comment`
- Clean up unused aliases from yt-dlp.zsh configuration