### PR TITLE
Refactor zsh config: rename files and reorganize setopt

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -26,8 +26,8 @@ require 'zshrc/completion.zsh'
 # Initialize and Load Sheldon
 require 'zshrc/sheldon.zsh'
 
-# ls or exa command config
-require 'zshrc/ls.zsh'
+# eza command config
+require 'zshrc/eza.zsh'
 
 # bat config
 require 'zshrc/bat.zsh'
@@ -75,8 +75,9 @@ export PATH="${DOTFILES}/bin:$PATH"
 
 # Printable 8bit
 setopt print_eight_bit
-setopt auto_cd
-setopt auto_pushd
+
+
+# Enable command spell correction
 setopt correct
 
 

--- a/zsh/zshrc/bat.zsh
+++ b/zsh/zshrc/bat.zsh
@@ -1,4 +1,4 @@
-# cat command replacement with bat
+# bat - cat command replacement
 if type "bat" > /dev/null 2>&1; then
   alias cat='bat'
   alias scat='command cat'

--- a/zsh/zshrc/eza.zsh
+++ b/zsh/zshrc/eza.zsh
@@ -1,4 +1,4 @@
-# ls command series
+# eza - ls command replacement
 if type "eza" > /dev/null 2>&1; then
   alias ls='eza --icons=always -l -gh --time-style long-iso --git'
   alias la='eza --icons=always -la -gh --time-style long-iso --git'

--- a/zsh/zshrc/zoxide.zsh
+++ b/zsh/zshrc/zoxide.zsh
@@ -1,4 +1,7 @@
-# zoxide initialization
+# zoxide - Smarter cd command with frecency-based directory jumping
 if type "zoxide" > /dev/null 2>&1; then
   eval "$(zoxide init zsh)"
 fi
+
+# Enable directory stack with cd
+setopt auto_pushd


### PR DESCRIPTION
## Summary
- Rename `ls.zsh` to `eza.zsh` for consistent tool-based naming convention
- Update file comments to clearly indicate command replacements (bat, eza, zoxide)
- Move `setopt auto_pushd` from `.zshrc` to `zoxide.zsh` (better organization for cd-related functionality)
- Remove `setopt auto_cd` (zoxide provides superior directory navigation)

## Changes
- `zsh/zshrc/ls.zsh` → `zsh/zshrc/eza.zsh`
- `zsh/zshrc/bat.zsh`: Updated comment format
- `zsh/zshrc/zoxide.zsh`: Enhanced comment and added `setopt auto_pushd`
- `zsh/.zshrc`: Updated require path and removed `auto_cd`/`auto_pushd` options

## Rationale
- Maintains naming consistency with other config files (`brew.zsh`, `mise.zsh`, `sheldon.zsh`)
- Groups related functionality together (directory navigation settings with zoxide)
- Reduces redundancy (zoxide's `z` command is more powerful than `auto_cd`)

## Test plan
- [ ] Verify shell loads without errors: `zsh -l`
- [ ] Test eza aliases work: `ls`, `la`, `lt`
- [ ] Test bat alias works: `cat`
- [ ] Test zoxide navigation: `z <directory>`
- [ ] Verify directory stack works: `cd <dir>` then `cd -`