### PR TITLE
Remove unused zshrc alias

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -95,10 +95,6 @@ alias -s html='open'
 alias -s php='php -f'
 
 
-# Dotfiles Config
-alias zshrc="vim ${DOTFILES}/zsh/.zshrc"
-
-
 # Process grep
 function ps-grep {
   ps aux | grep $1 | grep -v grep


### PR DESCRIPTION
## Summary
- Remove the `zshrc` alias that pointed to the old `.zshrc` file path
- This alias became obsolete after the refactoring that removed leading dots from config files

## Test plan
- Verify that zsh still loads correctly
- Confirm no references to the old `.zshrc` path remain