### PR TITLE
Add diff-base alias for comparing with PR base branch

### DIFF
--- a/git/alias.config
+++ b/git/alias.config
@@ -11,6 +11,7 @@
   d = diff
   ds = diff --staged
   diff-base = !"git diff $(git base)...HEAD"
+  d-base = diff-base
 
   # Log ================================================
   l = log --graph --all --pretty=format:'%C(yellow)%h%C(cyan)%d%Creset %s %C(white)- %an, %ar%Creset'


### PR DESCRIPTION
## Summary
- Add `diff-base` alias to easily compare the current branch with its PR base branch
- Uses three-dot diff syntax to show changes from the branch point

## Usage
```bash
git diff-base
```

This command will show the diff between the current branch and its PR base branch (e.g., `main` or `master`).