### PR TITLE
Fix solargraph LSP installation error

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -202,7 +202,7 @@ nvim/
 
 - **lua_ls** - Lua
 - **ts_ls** - TypeScript/JavaScript
-- **solargraph** - Ruby
+- **solargraph** - Ruby (要手動インストール: `gem install solargraph`)
 - **rust_analyzer** - Rust
 - **pyright** - Python
 - **jsonls** - JSON
@@ -248,6 +248,27 @@ nvim
 :Mason
 :LspInfo
 :checkhealth
+```
+
+### solargraph（Ruby LSP）のインストールエラー
+
+solargraphはMason経由でのインストールが失敗することがあります。以下のコマンドで手動インストールしてください:
+
+```bash
+gem install solargraph
+```
+
+mise（またはrbenv）を使用している場合:
+
+```bash
+# miseの場合
+mise use ruby@latest
+gem install solargraph
+
+# rbenvの場合
+rbenv global 3.x.x
+gem install solargraph
+rbenv rehash
 ```
 
 ### 設定をリセット

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -33,7 +33,7 @@ return {
         ensure_installed = {
           "lua_ls",        -- Lua
           "ts_ls",         -- TypeScript/JavaScript
-          "solargraph",    -- Ruby
+          -- "solargraph", -- Ruby (install manually via: gem install solargraph)
           "rust_analyzer", -- Rust
           "pyright",       -- Python
           "jsonls",        -- JSON


### PR DESCRIPTION
## Summary

- Remove solargraph from Mason's `ensure_installed` list to prevent automatic installation failures
- Add manual installation instructions to README with troubleshooting section
- Update LSP server list to note that solargraph requires manual installation

## Background

Mason's automatic installation of solargraph often fails due to Ruby environment dependencies. Since solargraph is a Ruby gem, it's more reliable to install it manually using the system's gem command.

## Changes

- **nvim/lua/plugins/lsp.lua**: Comment out solargraph from `ensure_installed` list
- **nvim/README.md**: 
  - Add troubleshooting section for solargraph installation
  - Update LSP server list to indicate manual installation requirement
  - Include instructions for both gem, mise, and rbenv users

## Test Plan

- [x] Verify nvim starts without Mason installation errors
- [ ] Confirm solargraph works after manual installation with `gem install solargraph`
- [ ] Check that Ruby LSP features function correctly when solargraph is installed

## Related Issue

Fixes the error: `[mason-lspconfig.nvim] failed to install solargraph`