### PR TITLE
Remove bat alias configuration

### DIFF
--- a/zsh/config/bat.zsh
+++ b/zsh/config/bat.zsh
@@ -1,5 +1,0 @@
-# bat - cat command replacement
-if type "bat" > /dev/null 2>&1; then
-  alias cat='bat'
-  alias scat='command cat'
-fi

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -29,9 +29,6 @@ require 'config/sheldon.zsh'
 # eza command config
 require 'config/eza.zsh'
 
-# bat config
-require 'config/bat.zsh'
-
 # zoxide config
 require 'config/zoxide.zsh'
 


### PR DESCRIPTION
## Summary
- Remove `bat.zsh` configuration file that was aliasing `cat` to `bat`
- Remove the corresponding require statement from `zshrc`

## Rationale
While `bat` provides useful syntax highlighting, `cat`'s primary purpose is file concatenation (as the name suggests). Aliasing `cat` to `bat` can:
- Break scripts that depend on `cat`'s original behavior
- Cause confusion about which command is actually being executed
- Override a fundamental Unix utility's expected behavior

Users who want to use `bat` should explicitly call it rather than having it masquerade as `cat`.

## Test plan
- [ ] Verify zsh still loads without errors
- [ ] Confirm `cat` command works with its original behavior
- [ ] Check that other zsh configurations are not affected