### PR TITLE
feat: add dotfiles-latest command to checkout latest version tag

### DIFF
--- a/zsh/config/dotfiles.zsh
+++ b/zsh/config/dotfiles.zsh
@@ -1,0 +1,41 @@
+# Dotfiles version management
+# Checkout the latest version tag in the dotfiles repository
+
+dotfiles-latest() {
+  # Check if DOTFILES environment variable is set
+  if [[ -z "$DOTFILES" ]]; then
+    echo "Error: DOTFILES environment variable is not set" >&2
+    return 1
+  fi
+
+  # Check if the directory exists
+  if [[ ! -d "$DOTFILES" ]]; then
+    echo "Error: Directory $DOTFILES does not exist" >&2
+    return 1
+  fi
+
+  # Check if it's a git repository
+  if ! git -C "$DOTFILES" rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: $DOTFILES is not a git repository" >&2
+    return 1
+  fi
+
+  # Get the latest version tag
+  local latest_tag
+  latest_tag=$(git -C "$DOTFILES" tag --sort=-v:refname | head -1)
+
+  if [[ -z "$latest_tag" ]]; then
+    echo "Error: No version tags found in the repository" >&2
+    return 1
+  fi
+
+  # Checkout the latest tag
+  echo "Checking out latest version: $latest_tag"
+  if git -C "$DOTFILES" checkout "$latest_tag" 2>&1; then
+    echo "Successfully checked out $latest_tag"
+    return 0
+  else
+    echo "Error: Failed to checkout $latest_tag" >&2
+    return 1
+  fi
+}

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -44,6 +44,9 @@ require 'config/c.zsh'
 # git config
 require 'config/git.zsh'
 
+# dotfiles version management config
+require 'config/dotfiles.zsh'
+
 # vim config
 require 'config/vim.zsh'
 


### PR DESCRIPTION
## Summary

- Add `dotfiles-latest` shell function in `zsh/config/dotfiles.zsh`
- Automatically finds and checks out the latest semantic version tag
- Uses existing `$DOTFILES` environment variable
- Includes comprehensive error handling

## Features

The `dotfiles-latest` command:
- Verifies `$DOTFILES` environment variable is set
- Checks if the directory exists and is a git repository
- Finds the latest version tag using semantic versioning sort
- Checks out the latest tag with user feedback

## Test Plan

- [ ] Verify `dotfiles-latest` command is available after sourcing zshrc
- [ ] Test command successfully checks out latest version tag
- [ ] Verify error handling for missing `$DOTFILES` variable
- [ ] Verify error handling for non-git directories
- [ ] Check that command works from any directory location