### PR TITLE
feat: suppress detached HEAD warning in dotfiles-latest command

### DIFF
--- a/zsh/config/dotfiles.zsh
+++ b/zsh/config/dotfiles.zsh
@@ -31,7 +31,7 @@ dotfiles-latest() {
 
   # Checkout the latest tag
   echo "Checking out latest version: $latest_tag"
-  if git -C "$DOTFILES" checkout "$latest_tag" 2>&1; then
+  if git -C "$DOTFILES" -c advice.detachedHead=false checkout "$latest_tag" 2>&1; then
     echo "Successfully checked out $latest_tag"
     return 0
   else


### PR DESCRIPTION
## Summary
- Suppress the detached HEAD warning when using `dotfiles-latest` command
- Add `-c advice.detachedHead=false` flag to the git checkout command

## Motivation
The `dotfiles-latest` command intentionally checks out a version tag, which puts the repository in detached HEAD state. The warning message from Git is expected behavior and adds unnecessary noise to the command output.

## Changes
- Modified `zsh/config/dotfiles.zsh` to use a temporary Git config flag that suppresses the detached HEAD advice only for this specific checkout operation
- This does not affect any global or repository-wide Git settings

## Test plan
- [x] Run `dotfiles-latest` and verify the detached HEAD warning is no longer displayed
- [x] Verify the command still successfully checks out the latest version tag
- [x] Confirm the suppression only affects this specific command