### PR TITLE
Fetch remote tags before checking out latest version

### DIFF
--- a/zsh/config/dotfiles.zsh
+++ b/zsh/config/dotfiles.zsh
@@ -20,6 +20,13 @@ dotfiles-latest() {
     return 1
   fi
 
+  # Fetch the latest tags from remote
+  echo "Fetching latest tags from remote..."
+  if ! git -C "$DOTFILES" fetch --tags 2>&1; then
+    echo "Error: Failed to fetch tags from remote" >&2
+    return 1
+  fi
+
   # Get the latest version tag
   local latest_tag
   latest_tag=$(git -C "$DOTFILES" tag --sort=-v:refname | head -1)


### PR DESCRIPTION
## Summary
- Add `git fetch --tags` to `dotfiles-latest()` function before retrieving the latest version tag
- Ensures that newly pushed tags on remote are available in the local repository
- Prevents outdated tag information when checking out the latest version

## Test plan
- [x] Verify the function still works correctly when tags are already up to date
- [x] Test with a repository that has new tags on remote but not locally
- [x] Confirm error handling works when fetch fails