### PR TITLE
Add mise support for bash

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -1,3 +1,23 @@
 PS1="\[\e[0;36m\]\u@\H \W\[\e[0m\]\$ "
 
 export HISTCONTROL=ignoredups
+
+# mise config
+eval "$(mise activate bash)"
+
+# Homebrew PATH configuration
+# Ensure Homebrew paths come before mise-managed paths
+# mise can reorder PATH, so we need to fix it in PROMPT_COMMAND
+# This must be loaded AFTER mise initialization
+if [[ "$OSTYPE" == "darwin"* ]] && [[ -d "/opt/homebrew/bin" ]]; then
+  _fix_homebrew_path() {
+    if [[ "$PATH" != "/opt/homebrew/bin:"* ]]; then
+      local clean_path="${PATH}"
+      clean_path="${clean_path//:\/opt\/homebrew\/bin/}"
+      clean_path="${clean_path//:\/opt\/homebrew\/sbin/}"
+      clean_path="${clean_path//:\/opt\/homebrew\/opt\/coreutils\/libexec\/gnubin/}"
+      export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/opt/coreutils/libexec/gnubin:${clean_path#:}"
+    fi
+  }
+  PROMPT_COMMAND="_fix_homebrew_path${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+fi


### PR DESCRIPTION
## Summary

This PR adds mise support for bash shell environments, bringing feature parity with the existing zsh configuration.

## Changes

- Added mise activation in `bash/bashrc`
- Added Homebrew PATH configuration to ensure Homebrew-installed tools take priority over mise-managed paths
- Used `PROMPT_COMMAND` (bash equivalent of zsh's `precmd_functions`) to maintain proper PATH ordering

## Implementation Details

The implementation follows the same pattern as the zsh configuration:

- **mise activation**: `eval "$(mise activate bash)"`
- **Homebrew PATH prioritization**: Similar to `zsh/config/brew.zsh`, ensures `/opt/homebrew/bin` and related paths are always at the front of PATH, even when mise reorders it

## Testing

After applying these changes, bash users can:
- Use mise-managed tools automatically
- Have Homebrew tools properly prioritized in PATH
- Experience consistent behavior with zsh configuration

Closes #124