### PR TITLE
Refactor: remove current alias and simplify PR workflow

### DIFF
--- a/git/alias.config
+++ b/git/alias.config
@@ -5,7 +5,6 @@
   # Status & Information ===============================
   s = status
   b = branch
-  current = branch --show-current
 
   # Diff ===============================================
   d = diff
@@ -46,11 +45,11 @@
 
   # GitHub PR Workflow =================================
   # Check if current branch's PR is merged (returns exit code 0 if merged, 1 otherwise)
-  merged = !"[ \"$(gh pr view $(git current) --json state --jq '.state')\" = \"MERGED\" ]"
+  merged = !"[ \"$(gh pr view --json state --jq '.state')\" = \"MERGED\" ]"
 
   # Get PR base branch (merge target) for current branch
-  base = !"gh pr view $(git current) --json baseRefName --jq '.baseRefName'"
+  base = !"gh pr view --json baseRefName --jq '.baseRefName'"
 
   # Switch to PR base branch and pull (only if PR is merged)
   # Also deletes the merged branch and prunes remote-tracking branches
-  done = !"git merged && current=$(git current) && base=$(git base) && [ -n \"$base\" ] && git switch \"$base\" && git pull && git branch -d \"$current\" && git fetch --prune"
+  done = !"git merged && current=$(git branch --show-current) && base=$(git base) && [ -n \"$base\" ] && git switch \"$base\" && git pull && git branch -d \"$current\" && git fetch --prune"


### PR DESCRIPTION
## Summary
- Replace `gh pr view $(git current)` with `gh pr view` in `merged` and `base` aliases
- Remove `current` alias as it's now only used in one place
- Update `done` alias to use `git branch --show-current` directly

## Changes
This refactoring simplifies the codebase by:
1. Leveraging `gh pr view`'s default behavior to automatically detect the current branch
2. Removing the unnecessary `current` alias abstraction
3. Using `git branch --show-current` directly in the `done` alias where it's still needed

## Benefits
- Reduces code duplication
- Simplifies the alias configuration
- Maintains the same functionality with less indirection

## Test plan
- [x] `git merged` still works correctly to check if PR is merged
- [x] `git base` still retrieves the PR base branch name
- [x] `git done` still switches to base branch and cleans up after PR merge