### PR TITLE
fix: exclude worktree branches from clean-blanch alias

### DIFF
--- a/git/alias.config
+++ b/git/alias.config
@@ -49,7 +49,7 @@
   rebase-previous = rebase -i HEAD~
 
   # Cleanup ============================================
-  clean-blanch = !git branch --merged | egrep -v '(^\\*|master|main)' | xargs git branch -d && git fetch --prune
+  clean-blanch = !git branch --merged | egrep -v '(^[*+]|master|main)' | xargs git branch -d && git fetch --prune
 
   # GitHub PR Workflow =================================
   # Check if current branch's PR is merged (returns exit code 0 if merged, 1 otherwise)


### PR DESCRIPTION
## Summary
- Fixed the `clean-blanch` git alias to properly exclude worktree branches (marked with `+`) from deletion
- Changed the egrep pattern from `(^\\*|master|main)` to `(^[*+]|master|main)` to filter out both current (`*`) and worktree (`+`) branches

## Problem
The `clean-blanch` alias was causing errors when attempting to delete merged branches:
- `error: branch '+' not found` - occurred because the `+` symbol from worktree branches was being passed as a separate argument to `git branch -d`
- Worktree branches couldn't be deleted and generated error messages

## Test plan
- [x] Verify the alias correctly identifies and excludes worktree branches
- [x] Test that merged branches (not in worktrees) are properly deleted
- [x] Confirm no more "branch '+' not found" errors occur