### PR TITLE
Enable transparent background for Neovim

### DIFF
--- a/nvim/lua/plugins/colorscheme.lua
+++ b/nvim/lua/plugins/colorscheme.lua
@@ -7,7 +7,7 @@ return {
     priority = 1000, -- Load before other plugins
     config = function()
       require("monokai-pro").setup({
-        transparent_background = false,
+        transparent_background = true,
         terminal_colors = true,
         devicons = true,
         styles = {


### PR DESCRIPTION
## Summary
- Enable transparent background in monokai-pro colorscheme configuration
- This allows terminal background to show through Neovim

## Changes
- Set `transparent_background` to `true` in `nvim/lua/plugins/colorscheme.lua`

## Test plan
- [x] Open Neovim and verify that the background is transparent
- [x] Verify that the terminal background shows through properly
- [x] Check that syntax highlighting still works correctly