### PR TITLE
docs: add chezmoi installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,21 +97,55 @@ The following tools may already be installed in your environment:
 
 # Installation
 
-## 1. Clone Repository
+## Using chezmoi (Recommended)
+
+### 1. Install chezmoi
+
+```bash
+$ brew install chezmoi
+```
+
+### 2. Initialize with this repository
+
+```bash
+$ chezmoi init --ssh toshiki670
+```
+
+### 3. Preview changes (optional)
+
+```bash
+$ chezmoi diff
+```
+
+### 4. Apply the dotfiles
+
+```bash
+$ chezmoi apply
+```
+
+### 5. Restart Shell
+
+```bash
+$ exec $SHELL -l
+```
+
+## Old Installation
+
+### 1. Clone Repository
 
 ```bash
 $ cd ~
 $ git clone https://github.com/toshiki670/dotfiles.git
 ```
 
-## 2. Run Install Script
+### 2. Run Install Script
 
 ```bash
 $ cd ~/dotfiles
 $ ./install
 ```
 
-## 3. Restart Shell
+### 3. Restart Shell
 
 ```bash
 $ exec $SHELL -l


### PR DESCRIPTION
## Summary
- Add recommended installation method using chezmoi
- Use SSH shorthand syntax (`chezmoi init --ssh toshiki670`)
- Include preview step with `chezmoi diff` before applying changes
- Rename manual installation section to "Old Installation"

## Changes
- Added "Using chezmoi (Recommended)" section with step-by-step instructions
- Reorganized existing installation method as "Old Installation"
- Emphasized chezmoi as the preferred approach for dotfiles management

## Benefits
- Easier dotfiles management with chezmoi
- Preview changes before applying with `chezmoi diff`
- Simple updates with `chezmoi update`
- Template support for environment-specific configurations