### PR TITLE
Fix git alias command path

### DIFF
--- a/git/config/alias
+++ b/git/config/alias
@@ -1,6 +1,6 @@
 [alias]
   # Alias Management ===================================
-  alias = !"cat \"${DOTFILES}/git/alias.config\" | grep -v '^\\[' | sed 's/^  //'"
+  alias = !"cat \"${DOTFILES}/git/config/alias\" | grep -v '^\\[' | sed 's/^  //'"
 
   # Status & Information ===============================
   s = status


### PR DESCRIPTION
## Summary
- Fixed the `alias` git command to reference the correct config file path
- Updated path from `git/alias.config` (non-existent) to `git/config/alias` (actual file location)

## Test plan
- [x] Run `git alias` command to verify it displays the alias list correctly
- [x] Confirm no errors about missing file