### PR TITLE
refactor: use create_ prefix for mise config instead of template logic

### DIFF
--- a/create_dot_mise.toml
+++ b/create_dot_mise.toml
@@ -1,0 +1,6 @@
+# mise configuration (machine-specific)
+# Uncomment and set values for work environment
+
+# [env]
+# DOTFILES_GIT_EMAIL = "your-work-email@company.com"
+# DOTFILES_GIT_NAME = "Your Work Name"


### PR DESCRIPTION
## Summary
- Simplifies the mise configuration by using chezmoi's `create_` prefix
- Removes complex stat checking from template
- File only created if it doesn't exist, never overwrites

## Changes
- Renamed from `dot_mise.local.toml.tmpl` to `create_dot_mise.toml`
- Removed `.tmpl` suffix as template variables are not used
- Removed `.local` from filename to avoid global gitignore pattern (`*.LOCAL.*`)

## Test plan
- [x] Run `chezmoi apply` on a fresh machine
- [x] Verify `.mise.toml` is created if it doesn't exist
- [x] Verify existing `.mise.toml` is not overwritten