### PR TITLE
Add dotfiles alias for chezmoi command

### DIFF
--- a/dot_config/zsh/configs/dotfiles.zsh
+++ b/dot_config/zsh/configs/dotfiles.zsh
@@ -1,6 +1,9 @@
 # Dotfiles version management
 # Checkout the latest version tag in the dotfiles repository
 
+# Alias chezmoi as dotfiles for convenience
+alias dotfiles='chezmoi'
+
 dotfiles-latest() {
   # Check if DOTFILES environment variable is set
   if [[ -z "$DOTFILES" ]]; then


### PR DESCRIPTION
This PR adds a convenient alias to use 'dotfiles' as a shorthand for 'chezmoi' command.