### PR TITLE
fix: manage completions directory with chezmoi instead of manual creation

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -17,7 +17,6 @@ install
 
 # Zsh includeTemplate sources
 .config/zsh/configs/
-.config/zsh/completions/
 
 # Configuration directories (not ready to deploy yet)
 tmux

--- a/dot_config/zsh/configs/docker.zsh
+++ b/dot_config/zsh/configs/docker.zsh
@@ -5,14 +5,12 @@ completions=${DOTFILES}/zsh/completions
 # For docker
 comp_docker=${completions}/_docker
 if [[ ! -e ${comp_docker} ]] && type "docker" > /dev/null 2>&1; then
-  mkdir -p "$(dirname "${comp_docker}")"
   curl -L https://raw.githubusercontent.com/docker/cli/master/contrib/completion/zsh/_docker > ${comp_docker}
 fi
 
 # For docker-compose
 comp_docker_compose=${completions}/_docker-compose
 if [[ ! -e ${comp_docker_compose} ]] && type "docker-compose" > /dev/null 2>&1; then
-  mkdir -p "$(dirname "${comp_docker_compose}")"
   curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/zsh/_docker-compose > ${comp_docker_compose}
 fi
 


### PR DESCRIPTION
## Problem
The docker.zsh script failed when the completions directory didn't exist, causing curl to fail when trying to write the downloaded completion files.

## Root Cause
The `.config/zsh/completions/` directory was listed in `.chezmoiignore`, preventing chezmoi from managing and creating the directory structure automatically.

## Solution
Removed `.config/zsh/completions/` from `.chezmoiignore` to allow chezmoi to manage the completions directory. This ensures the directory structure is automatically created during chezmoi apply, eliminating the need for manual directory creation in the script.

## Changes
1. Removed `.config/zsh/completions/` entry from `.chezmoiignore`
2. Removed unnecessary `mkdir -p` commands from `docker.zsh`

This is a more elegant solution that leverages chezmoi's directory management capabilities instead of adding error-prone manual directory creation logic.