### PR TITLE
fix: use deployed directory path for completions instead of source directory

### DIFF
--- a/dot_config/zsh/configs/docker.zsh
+++ b/dot_config/zsh/configs/docker.zsh
@@ -1,6 +1,6 @@
 # Completions
-# Setting completions
-completions=${DOTFILES}/zsh/completions
+# Setting completions (deployed location, not source directory)
+completions=${HOME}/.config/zsh/completions
 
 # For docker
 comp_docker=${completions}/_docker


### PR DESCRIPTION
## Problem
After merging PR #150, discovered the real issue: the completions directory path was pointing to the chezmoi source directory instead of the deployed location.

`completions=${DOTFILES}/zsh/completions` references the **source directory** (`~/.local/share/chezmoi/dot_config/zsh/completions`), but completion files should be downloaded to the **deployed location** (`~/.config/zsh/completions`).

## Solution
Changed the completions path from `${DOTFILES}/zsh/completions` to `${HOME}/.config/zsh/completions`.

This ensures:
- Docker and docker-compose completions are downloaded to the correct deployed directory
- The completions are accessible to the shell in the actual config location
- Files are not incorrectly written to the chezmoi source directory

## Changes
- Updated completions path in `docker.zsh` to use `${HOME}/.config/zsh/completions`
- Added clarifying comment about using deployed location, not source directory