### PR TITLE
refactor(nvim): align telescope keybindings with fd/rg commands

### DIFF
--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -15,8 +15,8 @@ return {
     },
     keys = {
       -- File navigation (replacing denite file commands)
-      { "<Space>df", "<cmd>Telescope find_files<cr>", desc = "Find Files" },
-      { "<Space>dg", "<cmd>Telescope live_grep<cr>", desc = "Live Grep" },
+      { "<Space>fd", "<cmd>Telescope find_files<cr>", desc = "Find Files (fd)" },
+      { "<Space>rg", "<cmd>Telescope live_grep<cr>", desc = "Live Grep (rg)" },
       { "<Space>db", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
       { "<Space>do", "<cmd>Telescope lsp_document_symbols<cr>", desc = "Document Symbols" },
       { "<Space>dh", "<cmd>Telescope help_tags<cr>", desc = "Help Tags" },


### PR DESCRIPTION
## Changes

- Change `<Space>df` to `<Space>fd` (matches fd command)
- Change `<Space>dg` to `<Space>rg` (matches ripgrep command)
- Update descriptions to reference underlying commands

## Motivation

Align keybindings with the actual underlying commands (fd and rg) for better intuitiveness and consistency.