### PR TITLE
Add ~/.local/bin to PATH

### DIFF
--- a/dot_config/zsh/configs/common.zsh
+++ b/dot_config/zsh/configs/common.zsh
@@ -35,5 +35,8 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   alias mv='mv --verbose'
 fi
 
+# Local bin
+export PATH="$HOME/.local/bin:$PATH"
+
 # Rust env
 export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
## Summary
- Add `$HOME/.local/bin` to PATH in common.zsh

## Details
This change adds `~/.local/bin` to the PATH to make user-installed binaries accessible. The PATH is set in `common.zsh` (loaded via `.zshrc`) rather than `.zshenv` because:

- On macOS, `/etc/zprofile` runs `path_helper` after `.zshenv` is loaded
- `path_helper` reorganizes the PATH, potentially moving custom paths
- Setting PATH in `.zshrc` ensures it takes effect after `path_helper` runs