### PR TITLE
Add git web alias to open PR in browser

### DIFF
--- a/dot_config/git/configs/alias
+++ b/dot_config/git/configs/alias
@@ -52,6 +52,9 @@
   clean-blanch = !git branch --merged | egrep -v '(^[*+]|master|main)' | xargs git branch -d && git fetch --prune
 
   # GitHub PR Workflow =================================
+  # Open current branch's PR in browser
+  web = !"gh pr view --web"
+
   # Check if current branch's PR is merged (returns exit code 0 if merged, 1 otherwise)
   merged = !"[ \"$(gh pr view --json state --jq '.state')\" = \"MERGED\" ]"
 


### PR DESCRIPTION
## Summary
- Add `git web` alias that opens the current branch's PR in the browser using `gh pr view --web`

## Test plan
- Run `git web` on a branch with an open PR to verify it opens the PR in the browser
- Verify the alias is properly integrated with the existing GitHub PR workflow aliases