### PR TITLE
Fix git alias command path reference

### DIFF
--- a/dot_config/git/configs/alias
+++ b/dot_config/git/configs/alias
@@ -1,6 +1,6 @@
 [alias]
   # Alias Management ===================================
-  alias = !"cat \"${DOTFILES}/git/config/alias\" | grep -v '^\\[' | sed 's/^  //'"
+  alias = !"cat \"${DOTFILES}/dot_config/git/configs/alias\" | grep -v '^\\[' | sed 's/^  //'"
 
   # Status & Information ===============================
   s = status


### PR DESCRIPTION
## Summary
- Fix `git alias` command to display the correct alias list
- Updated path from `${DOTFILES}/git/config/alias` to `${DOTFILES}/dot_config/git/configs/alias`

## Test plan
- [x] Run `g alias` and verify it displays all git aliases correctly
- [x] Verify the path points to the chezmoi source directory