### PR TITLE
Add Go language support to Neovim LSP

### DIFF
--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -36,6 +36,7 @@ return {
           -- "solargraph", -- Ruby (install manually via: gem install solargraph)
           "rust_analyzer", -- Rust
           "pyright",       -- Python
+          "gopls",         -- Go
           "jsonls",        -- JSON
           "yamlls",        -- YAML
           "bashls",        -- Bash
@@ -190,6 +191,19 @@ return {
       -- Python
       vim.lsp.config("pyright", default_config)
 
+      -- Go
+      vim.lsp.config("gopls", vim.tbl_extend("force", default_config, {
+        settings = {
+          gopls = {
+            analyses = {
+              unusedparams = true,
+            },
+            staticcheck = true,
+            gofumpt = true,
+          },
+        },
+      }))
+
       -- JSON
       vim.lsp.config("jsonls", default_config)
 
@@ -206,6 +220,7 @@ return {
       vim.lsp.enable("solargraph")
       vim.lsp.enable("rust_analyzer")
       vim.lsp.enable("pyright")
+      vim.lsp.enable("gopls")
       vim.lsp.enable("jsonls")
       vim.lsp.enable("yamlls")
       vim.lsp.enable("bashls")


### PR DESCRIPTION
## Summary
- Add gopls (Go language server) to Neovim LSP configuration
- Enable code navigation, completion, and other LSP features for Go development

## Changes
- Added gopls to Mason's `ensure_installed` list for automatic installation
- Configured gopls with recommended settings:
  - `unusedparams` analysis enabled
  - `staticcheck` enabled for enhanced static analysis
  - `gofumpt` enabled for stricter formatting
- Enabled gopls for Go filetypes using `vim.lsp.enable()`

## Test plan
- [ ] Open Neovim and run `:Mason` to verify gopls is installed
- [ ] Open a `.go` file and verify LSP features work:
  - [ ] `gd` - go to definition
  - [ ] `gr` - find references
  - [ ] `K` - hover documentation
  - [ ] `<leader>rn` - rename symbol
  - [ ] Code completion works