### PR TITLE
Add mise tasks for GitHub Actions workflow management

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -21,3 +21,6 @@ install
 # Configuration directories (not ready to deploy yet)
 tmux
 bin
+
+# Development tools
+mise.toml

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,13 @@
+[tasks.release-patch]
+description = "Create a patch release (e.g., v1.0.0 -> v1.0.1)"
+run = """
+echo "Create a patch release?"
+read -q "REPLY?Continue? (y/n): " && echo && gh workflow run release.yml -f release_type=patch || echo "\nCancelled."
+"""
+
+[tasks.release-minor]
+description = "Create a minor release (e.g., v1.0.0 -> v1.1.0)"
+run = """
+echo "Create a minor release?"
+read -q "REPLY?Continue? (y/n): " && echo && gh workflow run release.yml -f release_type=minor || echo "\nCancelled."
+"""


### PR DESCRIPTION
## Summary
- Add `mise.toml` with tasks to manage GitHub Actions release workflow
- Release tasks (`release-patch`, `release-minor`) include confirmation prompts using `read -q`
- Add `mise.toml` to `.chezmoiignore` to keep it as a development tool

## Benefits
- Convenient interface for triggering releases without typing full `gh` commands
- Safety: confirmation prompts prevent accidental releases
- Kept in repository but not deployed to home directory via chezmoi

## Usage
```bash
# Create releases (with confirmation)
mise run release-patch
mise run release-minor
```