### PR TITLE
Fix mise tasks to use bash-compatible syntax

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,12 +2,24 @@
 description = "Create a patch release (e.g., v1.0.0 -> v1.0.1)"
 run = """
 echo "Create a patch release?"
-read -q "REPLY?Continue? (y/n): " && echo && gh workflow run release.yml -f release_type=patch || echo "\nCancelled."
+read -p "Continue? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  gh workflow run release.yml -f release_type=patch
+else
+  echo "Cancelled."
+fi
 """
 
 [tasks.release-minor]
 description = "Create a minor release (e.g., v1.0.0 -> v1.1.0)"
 run = """
 echo "Create a minor release?"
-read -q "REPLY?Continue? (y/n): " && echo && gh workflow run release.yml -f release_type=minor || echo "\nCancelled."
+read -p "Continue? (y/n): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  gh workflow run release.yml -f release_type=minor
+else
+  echo "Cancelled."
+fi
 """


### PR DESCRIPTION
## Summary
- Replace zsh-specific `read -q` with bash-compatible `read -p -n 1 -r`
- Use standard if statement for y/n validation that works in both bash and zsh

## Problem
The previous implementation used `read -q` which is zsh-specific, causing errors when mise runs tasks in sh/bash:
```
sh: line 1: read: -q: invalid option
```

## Solution
Use bash-compatible syntax:
- `read -p "prompt" -n 1 -r` for single character input
- `[[ $REPLY =~ ^[Yy]$ ]]` for y/Y validation

This works in both bash and zsh environments.