### PR TITLE
Update .chezmoiignore to include install script and tmux config

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -4,9 +4,6 @@ CONTRIBUTING.md
 VERSIONING.md
 LICENSE
 
-# Installation scripts
-install
-
 # Plugin documentation
 **/PLUGINS.md
 **/note.md
@@ -19,8 +16,8 @@ install
 .config/zsh/configs/
 
 # Configuration directories (not ready to deploy yet)
-tmux
 bin
 
 # Development tools
 mise.toml
+


### PR DESCRIPTION
## Summary
- Remove exclusion for `install` script from .chezmoiignore
- Remove exclusion for `tmux` directory from .chezmoiignore

This allows these files to be managed by chezmoi.

## Test plan
- [ ] Verify chezmoi apply works correctly
- [ ] Confirm install script is now managed
- [ ] Confirm tmux config is now managed