### PR TITLE
Add tab navigation keybindings for Ghostty

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -35,6 +35,8 @@ palette = 15=#ffffff
 font-size = 15
 font-thicken = true
 font-family = "BIZ UDGothic Bold"
+keybind = ctrl+page_down=next_tab
+keybind = ctrl+page_up=previous_tab
 mouse-shift-capture = always
 macos-titlebar-style = tabs
 macos-option-as-alt = true


### PR DESCRIPTION
## Summary
- Add `Ctrl+Page Down` keybinding to navigate to next tab
- Add `Ctrl+Page Up` keybinding to navigate to previous tab

## Test plan
- [ ] Apply dotfiles with chezmoi
- [ ] Open Ghostty and create multiple tabs
- [ ] Test `Ctrl+Page Down` to move to next tab
- [ ] Test `Ctrl+Page Up` to move to previous tab