### PR TITLE
Change Zellij lock mode keybinding to Ctrl+Esc

### DIFF
--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -1,6 +1,6 @@
 keybinds clear-defaults=true {
     locked {
-        bind "Ctrl g" { SwitchToMode "normal"; }
+        bind "Ctrl Esc" { SwitchToMode "normal"; }
     }
     pane {
         bind "left" { MoveFocus "left"; }
@@ -144,7 +144,7 @@ keybinds clear-defaults=true {
         bind "Alt [" { PreviousSwapLayout; }
         bind "Alt ]" { NextSwapLayout; }
         bind "Alt f" { ToggleFloatingPanes; }
-        bind "Ctrl g" { SwitchToMode "locked"; }
+        bind "Ctrl Esc" { SwitchToMode "locked"; }
         bind "Alt h" { MoveFocusOrTab "left"; }
         bind "Alt i" { MoveTab "left"; }
         bind "Alt j" { MoveFocus "down"; }


### PR DESCRIPTION
## Summary
- Changed Zellij lock mode toggle keybinding from `Ctrl+g` to `Ctrl+Esc`

## Changes
- Lock mode entry: `Ctrl+g` → `Ctrl+Esc`
- Lock mode exit: `Ctrl+g` → `Ctrl+Esc`

## Rationale
The `Ctrl+Esc` combination provides easier access and avoids potential conflicts with other common shortcuts.