### PR TITLE
Add ghq configuration

### DIFF
--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -12,6 +12,9 @@
 ### Git Fast Forward Config ###
 {{- includeTemplate "dot_config/git/configs/fast_forward" | nindent 0 }}
 
+### Git GHQ Config ###
+{{- includeTemplate "dot_config/git/configs/ghq" | nindent 0 }}
+
 ### Git Push Config ###
 {{- includeTemplate "dot_config/git/configs/push" | nindent 0 }}
 

--- a/home/dot_config/git/configs/ghq
+++ b/home/dot_config/git/configs/ghq
@@ -1,0 +1,2 @@
+[ghq]
+	root = ~/Repositories


### PR DESCRIPTION
## Summary
- Add ghq configuration file to manage repository root directory
- Configure ghq root path as `~/Repositories`

## Test plan
- [x] Run `chezmoi apply`
- [x] Verify configuration with `git config --get ghq.root`