### PR TITLE
Add Ghostty split pane navigation keybinds (super+arrow keys)

### DIFF
--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -37,6 +37,10 @@ palette = 15=#ffffff
 font-size = 15
 font-thicken = true
 font-family = "JetBrains Mono Light"
+keybind = super+right=goto_split:right
+keybind = super+down=goto_split:down
+keybind = super+left=goto_split:left
+keybind = super+up=goto_split:up
 keybind = ctrl+page_down=next_tab
 keybind = ctrl+page_up=previous_tab
 mouse-shift-capture = always


### PR DESCRIPTION
## Summary
Add keybindings for navigating between split panes in Ghostty terminal.

## Changes
- `super+right` → `goto_split:right`
- `super+down` → `goto_split:down`
- `super+left` → `goto_split:left`
- `super+up` → `goto_split:up`

These keybinds allow moving focus between split panes using Super (Cmd) + arrow keys.