### PR TITLE
Add pbcopy-path zsh function for macOS

### DIFF
--- a/home/dot_config/zsh/configs/pbcopy.zsh
+++ b/home/dot_config/zsh/configs/pbcopy.zsh
@@ -1,0 +1,10 @@
+# pbcopy-path: copy absolute path of a file to clipboard (macOS only)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  function pbcopy-path {
+    if (( $# != 1 )); then
+      echo "usage: pbcopy-path <file>" 1>&2
+      return 1
+    fi
+    readlink -f "$1" | pbcopy
+  }
+fi

--- a/home/dot_config/zsh/dot_zshrc.tmpl
+++ b/home/dot_config/zsh/dot_zshrc.tmpl
@@ -71,6 +71,9 @@ export BASH_ENV="$HOME/.bashenv"
 # Common config
 {{ includeTemplate "dot_config/zsh/configs/common.zsh" }}
 
+# pbcopy (macOS clipboard)
+{{ includeTemplate "dot_config/zsh/configs/pbcopy.zsh" }}
+
 # ターミナル起動時に実行
 
 # Daily package check


### PR DESCRIPTION
## Summary
Add `pbcopy-path` to copy a file's absolute path to the clipboard (macOS only).

## Changes
- **configs/pbcopy.zsh** (new): Defines `pbcopy-path <file>` only when `OSTYPE == darwin*`. Uses `readlink -f` and `pbcopy`.
- **dot_zshrc.tmpl**: Load `pbcopy.zsh` after `common.zsh`.

## Usage
```
pbcopy-path file.name.txt
```
Then paste to get the absolute path.

## Notes
- Function is defined only on macOS (pbcopy is macOS-only).
- Kept clipboard config separate from common.zsh (cp/mv aliases).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated shell config addition gated to `darwin*`, with minimal impact beyond adding a new helper function.
> 
> **Overview**
> Adds a new `configs/pbcopy.zsh` that defines `pbcopy-path`, a macOS-only Zsh function that copies a given file’s absolute path to the clipboard via `readlink -f` piped to `pbcopy` (with basic argument count validation).
> 
> Updates `dot_zshrc.tmpl` to include this new clipboard config after `common.zsh` so the function is available in interactive shells.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5edeb1e53140575d6a9232a94a374c7f2a6777a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->