### PR TITLE
Add pbcopy-file zsh function for macOS

### DIFF
--- a/home/dot_config/zsh/configs/pbcopy.zsh
+++ b/home/dot_config/zsh/configs/pbcopy.zsh
@@ -1,4 +1,4 @@
-# pbcopy-path: copy absolute path of a file to clipboard (macOS only)
+# pbcopy-path / pbcopy-file: clipboard helpers (macOS only)
 if [[ "$OSTYPE" == "darwin"* ]]; then
   function pbcopy-path {
     if (( $# != 1 )); then
@@ -6,5 +6,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
       return 1
     fi
     readlink -f "$1" | pbcopy
+  }
+
+  function pbcopy-file {
+    if (( $# != 1 )); then
+      echo "usage: pbcopy-file <file>" 1>&2
+      return 1
+    fi
+    pbcopy < "$1"
   }
 fi


### PR DESCRIPTION
## Summary
Add `pbcopy-file` to copy a file's **contents** to the clipboard (macOS only). Separate from `pbcopy-path` (which copies the absolute path).

## Changes
- **configs/pbcopy.zsh**: Add `pbcopy-file <file>` in the same darwin-only block. Uses `pbcopy < "$1"`.

## Usage
```
pbcopy-file file.txt
```
Then paste to get the file contents.

## Notes
- macOS only (pbcopy). Same file as pbcopy-path, separate PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, darwin-gated shell helper addition with no impact outside macOS and minimal behavioral surface area.
> 
> **Overview**
> Adds a new macOS-only Zsh helper `pbcopy-file <file>` to copy a file’s *contents* to the clipboard via `pbcopy`.
> 
> Updates the header comment in `configs/pbcopy.zsh` to reflect both `pbcopy-path` (path copy) and the new `pbcopy-file` function, with basic single-argument usage validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c46f08cc88c43e34a3c00c598927fa0b150c9aa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->