### PR TITLE
Add clipboard as Tab completion candidate (macOS)

### DIFF
--- a/home/dot_config/zsh/configs/clipboard-completion.zsh
+++ b/home/dot_config/zsh/configs/clipboard-completion.zsh
@@ -1,0 +1,14 @@
+# Add clipboard (first line) as a completion candidate when pressing Tab (macOS only)
+if [[ "$OSTYPE" == "darwin"* ]] && command -v pbpaste &>/dev/null; then
+  _clipboard_candidate() {
+    # Only add when completing arguments, not the command name
+    (( CURRENT >= 2 )) || return 1
+    local clip
+    clip=$(pbpaste 2>/dev/null)
+    # Only add when clipboard is exactly one line (safer than using first line only)
+    [[ -n "$clip" && "$clip" != *$'\n'* ]] || return 1
+    compadd -X 'clipboard' -S '' -- "$clip"
+    return 1
+  }
+  zstyle ':completion:*' completer _clipboard_candidate _complete _prefix
+fi

--- a/home/dot_config/zsh/dot_zshrc.tmpl
+++ b/home/dot_config/zsh/dot_zshrc.tmpl
@@ -25,6 +25,9 @@ export BASH_ENV="$HOME/.bashenv"
 # Completion config (after sheldon to detect all completion plugins)
 {{ includeTemplate "dot_config/zsh/configs/completion.zsh" }}
 
+# Clipboard as completion candidate (macOS, after completion.zsh)
+{{ includeTemplate "dot_config/zsh/configs/clipboard-completion.zsh" }}
+
 # eza command config
 {{ includeTemplate "dot_config/zsh/configs/eza.zsh" }}
 


### PR DESCRIPTION
## Summary
When pressing Tab (fzf-tab), the clipboard content is shown as one of the completion candidates if it is **exactly one line**. Handy after `pbcopy-path` to paste the path without typing `$(pbpaste)`.

## Changes
- **configs/clipboard-completion.zsh** (new): `_clipboard_candidate` completer; only on macOS when `pbpaste` exists. Adds clipboard as a candidate only when completing arguments (not command name) and when clipboard has no newlines.
- **dot_zshrc.tmpl**: Load `clipboard-completion.zsh` after `completion.zsh`.

## Behavior
- Single-line clipboard → candidate appears with description "clipboard".
- Empty or multi-line clipboard → no clipboard candidate (safe).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, macOS-only shell completion change; main risk is minor UX impact or unexpected suggestions during completion.
> 
> **Overview**
> Adds a new macOS-gated Zsh completion plugin (`clipboard-completion.zsh`) that reads `pbpaste` and offers the clipboard as a completion candidate only when completing arguments and only when the clipboard is a single non-empty line.
> 
> Updates `dot_zshrc.tmpl` to load this completer after `completion.zsh`, making clipboard content appear in the completion list with the label `clipboard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f894a83ec66c28bda42b4d681d4abf3007f7f4f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->