### PR TITLE
Add bz alias to zoxide config

### DIFF
--- a/home/dot_config/zsh/configs/zoxide.zsh.tmpl
+++ b/home/dot_config/zsh/configs/zoxide.zsh.tmpl
@@ -2,6 +2,9 @@
 {{ if lookPath "zoxide" -}}
 {{ output "zoxide" "init" "zsh" -}}
 
+# Jump to parent directory
+alias bz='z ..'
+
 # Custom widget for zoxide interactive mode
 # Using ^j^f to match other fzf keybindings and avoid Zellij conflicts
 __zoxide_zi_widget() {


### PR DESCRIPTION
Adds `alias bz='z ..'` in `zoxide.zsh.tmpl` so that `bz` jumps to the parent directory via zoxide. Only defined when zoxide is available (inside the existing `lookPath"zoxide"` block).

Made with [Cursor](https://cursor.com)