### PR TITLE
feat: add copy-obj to copy file as file object to clipboard

### DIFF
--- a/home/dot_config/fish/conf.d/25-abbr.fish
+++ b/home/dot_config/fish/conf.d/25-abbr.fish
@@ -8,6 +8,7 @@ abbr --add reload 'exec fish -l'
 if test (uname -s) = Darwin
     abbr --add p-path --set-cursor 'path resolve % | pbcopy; echo (pbpaste)'
     abbr --add p-file --set-cursor 'pbcopy < %'
+    abbr --add p-obj --set-cursor 'pbcopy-obj %'
 end
 
 # ========== docker ==========

--- a/home/dot_config/fish/conf.d/25-abbr.fish
+++ b/home/dot_config/fish/conf.d/25-abbr.fish
@@ -3,12 +3,12 @@
 # ========== shell / misc ==========
 abbr --add reload 'exec fish -l'
 
-# ========== pbcopy (macOS only; one-liner + --set-cursor, see abbr -h) ==========
+# ========== clipboard (macOS only; one-liner + --set-cursor, see abbr -h) ==========
 # Default % marker is removed; cursor lands there after expand.
 if test (uname -s) = Darwin
-    abbr --add p-path --set-cursor 'path resolve % | pbcopy; echo (pbpaste)'
-    abbr --add p-file --set-cursor 'pbcopy < %'
-    abbr --add p-obj --set-cursor 'pbcopy-obj %'
+    abbr --add c-path --set-cursor 'path resolve % | pbcopy; echo (pbpaste)'
+    abbr --add c-file --set-cursor 'pbcopy < %'
+    abbr --add c-obj --set-cursor 'copy-obj %'
 end
 
 # ========== docker ==========

--- a/home/dot_config/fish/functions/copy-obj.fish
+++ b/home/dot_config/fish/functions/copy-obj.fish
@@ -1,15 +1,15 @@
-function pbcopy-obj --description 'Copy file as file object to clipboard (Finder-pasteable, macOS only)'
+function copy-obj --description 'Copy file as file object to clipboard (Finder-pasteable, macOS only)'
     if test (uname -s) != Darwin
-        echo "pbcopy-obj: macOS only" >&2
+        echo "copy-obj: macOS only" >&2
         return 1
     end
     if test (count $argv) -ne 1
-        echo "usage: pbcopy-obj <file>" >&2
+        echo "usage: copy-obj <file>" >&2
         return 1
     end
     set -l abspath (path resolve $argv[1])
     if not test -e $abspath
-        echo "pbcopy-obj: not found: $abspath" >&2
+        echo "copy-obj: not found: $abspath" >&2
         return 1
     end
     osascript -e "set the clipboard to POSIX file \"$abspath\""

--- a/home/dot_config/fish/functions/pbcopy-obj.fish
+++ b/home/dot_config/fish/functions/pbcopy-obj.fish
@@ -1,0 +1,16 @@
+function pbcopy-obj --description 'Copy file as file object to clipboard (Finder-pasteable, macOS only)'
+    if test (uname -s) != Darwin
+        echo "pbcopy-obj: macOS only" >&2
+        return 1
+    end
+    if test (count $argv) -ne 1
+        echo "usage: pbcopy-obj <file>" >&2
+        return 1
+    end
+    set -l abspath (path resolve $argv[1])
+    if not test -e $abspath
+        echo "pbcopy-obj: not found: $abspath" >&2
+        return 1
+    end
+    osascript -e "set the clipboard to POSIX file \"$abspath\""
+end

--- a/home/dot_config/zsh/configs/pbcopy.zsh
+++ b/home/dot_config/zsh/configs/pbcopy.zsh
@@ -16,11 +16,4 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     pbcopy < "$1"
   }
 
-  function copy-obj {
-    if (( $# != 1 )); then
-      echo "usage: copy-obj <file>" 1>&2
-      return 1
-    fi
-    osascript -e "set the clipboard to POSIX file \"$(readlink -f "$1")\""
-  }
 fi

--- a/home/dot_config/zsh/configs/pbcopy.zsh
+++ b/home/dot_config/zsh/configs/pbcopy.zsh
@@ -15,4 +15,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     fi
     pbcopy < "$1"
   }
+
+  function pbcopy-obj {
+    if (( $# != 1 )); then
+      echo "usage: pbcopy-obj <file>" 1>&2
+      return 1
+    fi
+    osascript -e "set the clipboard to POSIX file \"$(readlink -f "$1")\""
+  }
 fi

--- a/home/dot_config/zsh/configs/pbcopy.zsh
+++ b/home/dot_config/zsh/configs/pbcopy.zsh
@@ -16,9 +16,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     pbcopy < "$1"
   }
 
-  function pbcopy-obj {
+  function copy-obj {
     if (( $# != 1 )); then
-      echo "usage: pbcopy-obj <file>" 1>&2
+      echo "usage: copy-obj <file>" 1>&2
       return 1
     fi
     osascript -e "set the clipboard to POSIX file \"$(readlink -f "$1")\""


### PR DESCRIPTION
## Summary

- Fish 関数 `copy-obj` を追加。`osascript` でファイルオブジェクトをクリップボードにセットし、Finder で Cmd+V するとファイルを貼り付けられる
- クリップボード系 abbreviation のプレフィックスを `p-` から `c-` に統一（`c-path`, `c-file`, `c-obj`）
- `copy-obj` は Fish 専用のため Zsh には追加しない

Closes #254

## Test plan

- [x] `copy-obj <file>` → exit 0、クリップボードに `«class furl»` 型でファイルが格納される
- [x] Finder で Cmd+V するとファイルが貼り付けられる
- [x] `copy-obj`（引数なし）→ `usage: copy-obj <file>` / exit 1
- [x] `copy-obj /no/such/file` → `copy-obj: not found: ...` / exit 1
- [x] `mise run check` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)