### PR TITLE
feat: introduce rtk for LLM token reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ brew install zsh sheldon deno
 ## Optional Tools
 
 ```bash
-brew install ffmpeg marp-cli gitui ghostty zellij smartmontools
+brew install ffmpeg marp-cli gitui ghostty zellij smartmontools rtk
 ```
 
 ### Optional Homebrew tool descriptions
@@ -61,6 +61,13 @@ brew install ffmpeg marp-cli gitui ghostty zellij smartmontools
 - `ghostty` - Terminal emulator; config lives under `~/.config/ghostty/` (see [Configuration](#configuration))
 - `zellij` - Terminal multiplexer; config under `~/.config/zellij/`
 - `smartmontools` - S.M.A.R.T. disk health monitoring (`smartctl`)
+- `rtk` - CLI proxy that reduces LLM token usage by 60–90% ([rtk-ai/rtk](https://github.com/rtk-ai/rtk)); after install, run `rtk init -g` to configure Claude Code hooks
+
+After installing `rtk`, initialize the Claude Code hook:
+
+```bash
+rtk init -g
+```
 
 # Installation
 

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -1,4 +1,5 @@
 {
+  "effortLevel": "medium",
   "voiceEnabled": true,
   "language": "日本語",
   "statusLine": {
@@ -16,6 +17,17 @@
           }
         ]
       }
-    ]
+    ]{{ if lookPath "rtk" }},
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/rtk-rewrite.sh"
+          }
+        ]
+      }
+    ]{{ end }}
   }
 }


### PR DESCRIPTION
## Summary

- `rtk` を Optional Tools に追加（README に `brew install` コマンドと `rtk init -g` の手順を記載）
- `home/dot_claude/settings.json` → `settings.json.tmpl` に変換し chezmoi テンプレート化
- `{{ if lookPath "rtk" }}` で rtk がインストール済みの環境のみ `PreToolUse` フック（`rtk-rewrite.sh`）を出力
- `effortLevel: "medium"` を設定に追加

Closes #280

## Test plan

- [ ] rtk インストール済み環境で `chezmoi cat ~/.claude/settings.json` に `PreToolUse` ブロックが含まれることを確認
- [ ] rtk 未インストール環境で `PreToolUse` ブロックが除外され valid な JSON が生成されることを確認
- [ ] `chezmoi apply` で `~/.claude/settings.json` が正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)