### PR TITLE
feat: set CLAUDE_CODE_NO_FLICKER=1 in Fish shell

### DIFF
--- a/home/dot_config/fish/conf.d/08-claude.fish
+++ b/home/dot_config/fish/conf.d/08-claude.fish
@@ -1,0 +1,2 @@
+# Claude Code
+set -gx CLAUDE_CODE_NO_FLICKER 1


### PR DESCRIPTION
## Summary

- `conf.d/08-claude.fish` を追加し、`CLAUDE_CODE_NO_FLICKER=1` を環境変数として設定

## Test plan

- [ ] `chezmoi apply` 後、`echo $CLAUDE_CODE_NO_FLICKER` で `1` が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)