### PR TITLE
feat: add --no-write-fetch-head to background git fetch

### DIFF
--- a/home/dot_config/fish/functions/_git_background_fetch_worker.fish
+++ b/home/dot_config/fish/functions/_git_background_fetch_worker.fish
@@ -25,5 +25,5 @@ function _git_background_fetch_worker
 
     echo $now >"$stamp_file"
 
-    env GIT_TERMINAL_PROMPT=0 command git -C "$top" fetch --quiet >/dev/null 2>&1
+    env GIT_TERMINAL_PROMPT=0 command git -C "$top" fetch --quiet --no-write-fetch-head >/dev/null 2>&1
 end


### PR DESCRIPTION
## Summary

- バックグラウンド定期 fetch の `git fetch` に `--no-write-fetch-head` を追加
- `FETCH_HEAD` への不要な書き込みをスキップし、ディスク I/O を削減
- 手動 fetch の `FETCH_HEAD` がバックグラウンド fetch で上書きされなくなる

Closes #291

## Test plan

- [ ] Fish シェルを起動し、git リポジトリ配下でコマンドを実行後、バックグラウンド fetch が正常に動作することを確認
- [ ] `FETCH_HEAD` が更新されないことを確認（fetch 前後で `stat FETCH_HEAD` のタイムスタンプが変わらない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)