### PR TITLE
feat: add merge-ready config and convert starship.toml to template

### DIFF
--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,0 +1,41 @@
+version = 1
+
+[merge_ready]
+symbol = "󰄬"
+label = "merge-ready"
+
+[conflict]
+symbol = ""
+label = "conflict"
+
+[update_branch]
+symbol = "󰚰"
+label = "update-branch"
+
+[sync_unknown]
+symbol = ""
+label = "sync-unknown"
+
+[ci_fail]
+symbol = ""
+label = "ci-fail"
+
+[ci_action]
+symbol = "󰀦"
+label = "ci-action"
+
+[review]
+symbol = "󰀦"
+label = "review"
+
+[error.auth_required]
+symbol = ""
+label = "gh auth login"
+
+[error.rate_limited]
+symbol = ""
+label = "rate-limited"
+
+[error.api_error]
+symbol = ""
+label = "api-error"

--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,41 +1,41 @@
 version = 1
 
 [merge_ready]
+label  = "merge-ready"
 symbol = "󰄬"
-label = "merge-ready"
 
 [conflict]
+label  = "conflict"
 symbol = ""
-label = "conflict"
 
 [update_branch]
+label  = "update-branch"
 symbol = "󰚰"
-label = "update-branch"
 
 [sync_unknown]
+label  = "sync-unknown"
 symbol = ""
-label = "sync-unknown"
 
 [ci_fail]
+label  = "ci-fail"
 symbol = ""
-label = "ci-fail"
 
 [ci_action]
+label  = "ci-action"
 symbol = "󰀦"
-label = "ci-action"
 
 [review]
+label  = "review"
 symbol = "󰀦"
-label = "review"
 
 [error.auth_required]
+label  = "gh auth login"
 symbol = ""
-label = "gh auth login"
 
 [error.rate_limited]
+label  = "rate-limited"
 symbol = ""
-label = "rate-limited"
 
 [error.api_error]
+label  = "api-error"
 symbol = ""
-label = "api-error"

--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -251,3 +251,14 @@ symbol = " "
 
 [zig]
 symbol = " "
+
+{{ if lookPath "merge-ready" }}
+[custom.merge_ready]
+command = "merge-ready prompt"
+when = true
+require_repo = true
+shell = ["/bin/zsh"]
+format = "[($output )]($style)"
+style = "bold yellow"
+{{ end -}}
+


### PR DESCRIPTION
## Summary

- `~/.config/merge-ready.toml` を dotfiles で管理対象に追加
- `starship.toml` をテンプレートに変換し、`merge-ready` がインストールされている場合のみ `[custom.merge_ready]` セクションを含めるよう条件分岐を追加

## Test plan

- [ ] `chezmoi diff` で starship.toml の差分が意図通りか確認
- [ ] `merge-ready` がない環境で `chezmoi apply` し、`[custom.merge_ready]` が含まれないことを確認
- [ ] `merge-ready` がある環境で `chezmoi apply` し、`[custom.merge_ready]` が含まれることを確認
- [ ] `merge-ready.toml` が正しく deploy されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)