### PR TITLE
fix: correct merge-ready command name and remove version field

### DIFF
--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,5 +1,3 @@
-version = 1
-
 [merge_ready]
 label  = "merge-ready"
 symbol = "󰄬"
@@ -39,3 +37,4 @@ symbol = ""
 [error.api_error]
 label  = "api-error"
 symbol = ""
+

--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -37,4 +37,3 @@ symbol = ""
 [error.api_error]
 label  = "api-error"
 symbol = ""
-

--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -254,7 +254,7 @@ symbol = " "
 
 {{ if lookPath "merge-ready" }}
 [custom.merge_ready]
-command = "merge-ready prompt"
+command = "merge-ready-prompt"
 when = true
 require_repo = true
 shell = ["/bin/zsh"]


### PR DESCRIPTION
## Summary

- `starship.toml.tmpl`: コマンド名を `merge-ready prompt` から `merge-ready-prompt` に修正
- `merge-ready.toml`: 不要な `version = 1` フィールドを削除

## Test plan

- [ ] `chezmoi apply` でデプロイが正常に行われること
- [ ] `merge-ready-prompt` コマンドが starship プロンプトで正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)