### PR TITLE
fix: derive seven_day window duration from cached prev resets_at

### DIFF
--- a/home/dot_claude/statusline-command.py
+++ b/home/dot_claude/statusline-command.py
@@ -26,17 +26,6 @@ def _save_resets_at(resets_at: int) -> None:
     _CACHE_FILE.write_text(json.dumps({"resets_at": resets_at}))
 
 
-def seven_day_pace_color(used_pct: float, resets_at: int) -> str:
-    prev = _load_prev_resets_at()
-    if prev is not None and resets_at != prev:
-        window_secs = resets_at - prev
-        color = pace_color(used_pct, resets_at, window_secs)
-    else:
-        color = COLOR_RESET
-    _save_resets_at(resets_at)
-    return color
-
-
 def pace_color(used_pct: float, resets_at: int, total_secs: int) -> str:
     """Return ANSI color based on pace: actual usage vs expected usage given elapsed time.
 
@@ -129,7 +118,12 @@ def main() -> None:
     if seven_day is not None and seven_day_resets is not None:
         week_int = round(seven_day)
         bar = make_bar(week_int)
-        color = seven_day_pace_color(week_int, seven_day_resets)
+        prev_resets_at = _load_prev_resets_at()
+        _save_resets_at(seven_day_resets)
+        if prev_resets_at is not None and seven_day_resets != prev_resets_at:
+            color = pace_color(week_int, seven_day_resets, seven_day_resets - prev_resets_at)
+        else:
+            color = COLOR_RESET
         remaining = fmt_remaining(seven_day_resets)
         out.append(
             f"  │  \U000f00f0 {remaining}/7d {color}{bar} {week_int}%{COLOR_RESET}"

--- a/home/dot_claude/statusline-command.py
+++ b/home/dot_claude/statusline-command.py
@@ -4,11 +4,37 @@
 import json
 import sys
 import time
+from pathlib import Path
+
+_CACHE_FILE = Path("~/.cache/claude/seven_day_resets_at.json").expanduser()
 
 COLOR_RESET = "\033[0m"
 COLOR_GREEN = "\033[32m"
 COLOR_YELLOW = "\033[33m"
 COLOR_RED = "\033[31m"
+
+
+def _load_prev_resets_at() -> int | None:
+    try:
+        return json.loads(_CACHE_FILE.read_text()).get("resets_at")
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return None
+
+
+def _save_resets_at(resets_at: int) -> None:
+    _CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _CACHE_FILE.write_text(json.dumps({"resets_at": resets_at}))
+
+
+def seven_day_pace_color(used_pct: float, resets_at: int) -> str:
+    prev = _load_prev_resets_at()
+    if prev is not None and resets_at != prev:
+        window_secs = resets_at - prev
+        color = pace_color(used_pct, resets_at, window_secs)
+    else:
+        color = COLOR_RESET
+    _save_resets_at(resets_at)
+    return color
 
 
 def pace_color(used_pct: float, resets_at: int, total_secs: int) -> str:
@@ -103,7 +129,7 @@ def main() -> None:
     if seven_day is not None and seven_day_resets is not None:
         week_int = round(seven_day)
         bar = make_bar(week_int)
-        color = pace_color(week_int, seven_day_resets, 604800)
+        color = seven_day_pace_color(week_int, seven_day_resets)
         remaining = fmt_remaining(seven_day_resets)
         out.append(
             f"  │  \U000f00f0 {remaining}/7d {color}{bar} {week_int}%{COLOR_RESET}"

--- a/home/dot_claude/statusline-command.py
+++ b/home/dot_claude/statusline-command.py
@@ -121,7 +121,9 @@ def main() -> None:
         prev_resets_at = _load_prev_resets_at()
         _save_resets_at(seven_day_resets)
         if prev_resets_at is not None and seven_day_resets != prev_resets_at:
-            color = pace_color(week_int, seven_day_resets, seven_day_resets - prev_resets_at)
+            color = pace_color(
+                week_int, seven_day_resets, seven_day_resets - prev_resets_at
+            )
         else:
             color = COLOR_RESET
         remaining = fmt_remaining(seven_day_resets)


### PR DESCRIPTION
## Summary

- `seven_day` レートリミットのウィンドウ秒数 `604800`（7日固定）を廃止し、`~/.cache/claude/seven_day_resets_at.json` にキャッシュした前回の `resets_at` との差分で動的算出するよう変更
- キャッシュが存在しない初回、または同一ウィンドウ内（`resets_at` が変化していない）は pace color をニュートラル（`COLOR_RESET`）にフォールバック
- `seven_day_pace_color` ラッパーを削除し、キャッシュ読み書きと `pace_color` 呼び出しを `main()` に集約

Closes #298

## Test plan

- [ ] `chezmoi apply` でデプロイし、statusline が正常に表示されることを確認
- [ ] `~/.cache/claude/seven_day_resets_at.json` が生成されることを確認
- [ ] ウィンドウリセット後の最初の実行で pace color が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)