### PR TITLE
fix: simplify merge-ready config

### DIFF
--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,39 +1,27 @@
 [merge_ready]
-label  = "merge-ready"
 symbol = "󰄬"
 
 [conflict]
-label  = "conflict"
 symbol = ""
 
 [update_branch]
-label  = "update-branch"
 symbol = "󰚰"
 
 [sync_unknown]
-label  = "sync-unknown"
 symbol = ""
 
 [ci_fail]
-label  = "ci-fail"
 symbol = ""
 
 [ci_action]
-label  = "ci-action"
 symbol = "󰀦"
 
-[review]
-label  = "review"
+[changes_requested]
 symbol = "󰀦"
 
-[error.auth_required]
-label  = "gh auth login"
-symbol = ""
+[no_pull_request]
+symbol = "󰎔"
 
-[error.rate_limited]
-label  = "rate-limited"
+[error]
 symbol = ""
 
-[error.api_error]
-label  = "api-error"
-symbol = ""

--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -24,4 +24,3 @@ symbol = "󰎔"
 
 [error]
 symbol = ""
-


### PR DESCRIPTION
## Summary

- 各セクションから `label` フィールドをすべて削除
- `[review]` セクションを `[changes_requested]` にリネーム
- `[error.auth_required]` / `[error.rate_limited]` / `[error.api_error]` の3セクションを `[error]` に統合
- `[no_pull_request]` セクションを新規追加

## Test plan

- [ ] `chezmoi apply` を実行して `~/.config/merge-ready.toml` が正しく更新されることを確認
- [ ] merge-ready コマンドが各ステータスで正しいシンボルを表示することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)