### PR TITLE
fix: add workflow_dispatch trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- `release-please.yml` に `workflow_dispatch` トリガーを追加
- `mise run release-prepare` で手動トリガーできるようにする

## Root Cause

`gh workflow run release-please.yml` は `workflow_dispatch` トリガーがないと HTTP 422 を返す。`push` トリガーのみでは手動実行不可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)