### PR TITLE
fix: use PAT token for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,5 +17,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- `release-please.yml` で `GITHUB_TOKEN` の代わりに `RELEASE_PLEASE_TOKEN`（PAT）を使用
- PAT で PR を作成することで `lint.yml` がトリガーされ、CI チェックが実行される
- Ruleset の必須チェック（`Detect lint runner changes` / `Lint runner tests`）を満たしてマージ可能になる

## Root Cause

`GITHUB_TOKEN` で作成した PR は GitHub のセキュリティ仕様でワークフローをトリガーできないため、Status Checks が実行されず Ruleset を満たせなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)