### PR TITLE
fix: gpup abbr に git pull を追加

### DIFF
--- a/home/dot_config/fish/conf.d/25-abbr.fish
+++ b/home/dot_config/fish/conf.d/25-abbr.fish
@@ -67,7 +67,7 @@ abbr --add gpc 'gh pr checkout'
 abbr --add gpswitch 'gh pr checkout'
 abbr --add gpci 'gh pr checks'
 abbr --add gpciw 'gh pr checks --watch --fail-fast'
-abbr --add gpup 'gh pr update-branch && reload'
+abbr --add gpup 'gh pr update-branch && git pull'
 
 # ========== bat ==========
 abbr --add b bat


### PR DESCRIPTION
## Summary

- `gpup` の abbreviation が `reload` を呼んでいたが、`git pull` に修正

Closes #309