### PR TITLE
feat: merge-ready の全ステータスに format と新規ステート追加

### DIFF
--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,26 +1,56 @@
 [merge_ready]
 symbol = "󰄬"
-
-[conflict]
-symbol = ""
-
-[update_branch]
-symbol = "󰚰"
-
-[sync_unknown]
-symbol = ""
-
-[ci_fail]
-symbol = ""
-
-[ci_action]
-symbol = "󰀦"
-
-[changes_requested]
-symbol = "󰀦"
+format = "[$symbol $label](bold green)"
 
 [no_pull_request]
 symbol = "󰎔"
+label = "Create PR"
+format = "[$symbol $label](cyan)"
+
+[conflict]
+symbol = ""
+format = "[$symbol $label](bold red)"
+
+[update_branch]
+symbol = "󰚰"
+format = "[$symbol $label](yellow)"
+
+[sync_unknown]
+symbol = ""
+format = "[$symbol $label](yellow)"
+
+[ci_fail]
+symbol = ""
+format = "[$symbol $label](bold red)"
+
+[ci_action]
+symbol = "󰀦"
+format = "[$symbol $label](yellow)"
+
+[ci_pending]
+symbol = ""
+format = "[$symbol $label](cyan)"
+
+[changes_requested]
+symbol = "󰀦"
+format = "[$symbol $label](yellow)"
+
+[review_required]
+symbol = ""
+format = "[$symbol $label](cyan)"
+
+[draft]
+symbol = ""
+format = "[$symbol $label](dimmed)"
+
+[status_calculating]
+symbol = ""
+format = "[$symbol $label](dimmed)"
+
+[blocked_unknown]
+symbol = ""
+format = "[$symbol $label](yellow)"
 
 [error]
 symbol = ""
+format = "[$symbol $message](bold red)"

--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,56 +1,56 @@
 [merge_ready]
-symbol = "󰄬"
 format = "[$symbol $label](bold green)"
+symbol = "󰄬"
 
 [no_pull_request]
-symbol = "󰎔"
-label = "Create PR"
 format = "[$symbol $label](cyan)"
+label  = "Create PR"
+symbol = "󰎔"
 
 [conflict]
-symbol = ""
 format = "[$symbol $label](bold red)"
+symbol = ""
 
 [update_branch]
-symbol = "󰚰"
 format = "[$symbol $label](yellow)"
+symbol = "󰚰"
 
 [sync_unknown]
-symbol = ""
 format = "[$symbol $label](yellow)"
+symbol = ""
 
 [ci_fail]
-symbol = ""
 format = "[$symbol $label](bold red)"
+symbol = ""
 
 [ci_action]
-symbol = "󰀦"
 format = "[$symbol $label](yellow)"
+symbol = "󰀦"
 
 [ci_pending]
-symbol = ""
 format = "[$symbol $label](cyan)"
+symbol = ""
 
 [changes_requested]
-symbol = "󰀦"
 format = "[$symbol $label](yellow)"
+symbol = "󰀦"
 
 [review_required]
-symbol = ""
 format = "[$symbol $label](cyan)"
+symbol = ""
 
 [draft]
-symbol = ""
 format = "[$symbol $label](dimmed)"
+symbol = ""
 
 [status_calculating]
-symbol = ""
 format = "[$symbol $label](dimmed)"
+symbol = ""
 
 [blocked_unknown]
-symbol = ""
 format = "[$symbol $label](yellow)"
+symbol = ""
 
 [error]
-symbol = ""
 format = "[$symbol $message](bold red)"
+symbol = ""

--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -258,7 +258,6 @@ command = "merge-ready-prompt"
 when = true
 require_repo = true
 shell = ["/bin/zsh"]
-format = "[($output )]($style)"
-style = "bold yellow"
+format = "($output )"
 {{ end -}}
 


### PR DESCRIPTION
## Summary

- `merge-ready.toml` の全ステータスに `format` フィールドを追加し、ステータスごとに色付き表示へ統一
- `ci_pending` / `review_required` / `draft` / `status_calculating` / `blocked_unknown` の新規ステートを追加
- `starship.toml.tmpl` の merge-ready-prompt フォーマットをシンプル化（`style` 削除、出力フォーマットをプレーンに）

## Test plan

- [ ] `chezmoi apply` を実行してエラーがないことを確認
- [ ] `merge-ready-prompt` コマンドの出力が各ステータスで正しく色付き表示されることを確認
- [ ] starship プロンプトで merge-ready の出力が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)