### PR TITLE
feat: merge-ready の fish completion を追加

### DIFF
--- a/home/dot_config/fish/completions/merge-ready.fish.tmpl
+++ b/home/dot_config/fish/completions/merge-ready.fish.tmpl
@@ -1,0 +1,3 @@
+{{ if lookPath "merge-ready" -}}
+{{ output "merge-ready" "completions" "fish" }}
+{{- end }}


### PR DESCRIPTION
## Summary

- `home/dot_config/fish/completions/merge-ready.fish.tmpl` を追加
- `bat.fish.tmpl` / `docker.fish.tmpl` と同じパターンで実装
- `merge-ready` がインストール済みの環境でのみ `merge-ready completions fish` の出力を展開

## Test plan

- [x] `chezmoi apply` 後に `~/.config/fish/completions/merge-ready.fish` が生成されることを確認
- [x] fish で `merge-ready <Tab>` が補完されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)