### PR TITLE
feat: merge-ready の全ステータスの format に PR ID を追加

### DIFF
--- a/home/dot_config/merge-ready.toml
+++ b/home/dot_config/merge-ready.toml
@@ -1,5 +1,5 @@
 [merge_ready]
-format = "[$symbol $label](bold green)"
+format = "[$symbol $label( #$pr_id)](bold green)"
 symbol = "󰄬"
 
 [no_pull_request]
@@ -8,47 +8,47 @@ label  = "Create PR"
 symbol = "󰎔"
 
 [conflict]
-format = "[$symbol $label](bold red)"
+format = "[$symbol $label( #$pr_id)](bold red)"
 symbol = ""
 
 [update_branch]
-format = "[$symbol $label](yellow)"
+format = "[$symbol $label( #$pr_id)](yellow)"
 symbol = "󰚰"
 
 [sync_unknown]
-format = "[$symbol $label](yellow)"
+format = "[$symbol $label( #$pr_id)](yellow)"
 symbol = ""
 
 [ci_fail]
-format = "[$symbol $label](bold red)"
+format = "[$symbol $label( #$pr_id)](bold red)"
 symbol = ""
 
 [ci_action]
-format = "[$symbol $label](yellow)"
+format = "[$symbol $label( #$pr_id)](yellow)"
 symbol = "󰀦"
 
 [ci_pending]
-format = "[$symbol $label](cyan)"
+format = "[$symbol $label( #$pr_id)](cyan)"
 symbol = ""
 
 [changes_requested]
-format = "[$symbol $label](yellow)"
+format = "[$symbol $label( #$pr_id)](yellow)"
 symbol = "󰀦"
 
 [review_required]
-format = "[$symbol $label](cyan)"
+format = "[$symbol $label( #$pr_id)](cyan)"
 symbol = ""
 
 [draft]
-format = "[$symbol $label](dimmed)"
+format = "[$symbol $label( #$pr_id)](dimmed)"
 symbol = ""
 
 [status_calculating]
-format = "[$symbol $label](dimmed)"
+format = "[$symbol $label( #$pr_id)](dimmed)"
 symbol = ""
 
 [blocked_unknown]
-format = "[$symbol $label](yellow)"
+format = "[$symbol $label( #$pr_id)](yellow)"
 symbol = ""
 
 [error]


### PR DESCRIPTION
## Summary

- `merge-ready.toml` の全ステータス（12件）の `format` テンプレートに `( #$pr_id)` を追加
- PR が存在する場合にステータス表示へ PR 番号が付与されるようになる

## Test plan

- [ ] `chezmoi apply` で設定をデプロイし、各ステータスで PR 番号が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)