### PR TITLE
fix: browser-use の PATH を末尾追加にして mise Python を優先 (#279)

### DIFF
--- a/bash/common.sh
+++ b/bash/common.sh
@@ -16,6 +16,6 @@ fi
 
 # browser-use
 for _browser_use_dir in "$HOME/.browser-use/bin" "$HOME/.browser-use-env/bin"; do
-  [[ -d "$_browser_use_dir" ]] && export PATH="$_browser_use_dir:$PATH"
+  [[ -d "$_browser_use_dir" ]] && export PATH="$PATH:$_browser_use_dir"
 done
 unset _browser_use_dir

--- a/home/dot_config/fish/conf.d/12-browser-use.fish
+++ b/home/dot_config/fish/conf.d/12-browser-use.fish
@@ -1,4 +1,4 @@
 # browser-use
 for dir in $HOME/.browser-use/bin $HOME/.browser-use-env/bin
-    test -d $dir && fish_add_path $dir
+    test -d $dir && fish_add_path --append --move $dir
 end


### PR DESCRIPTION
## Summary
- `bash/common.sh` と `home/dot_config/fish/conf.d/12-browser-use.fish` で `~/.browser-use/bin` / `~/.browser-use-env/bin` を PATH **先頭**に追加していたため、mise の Python shim より優先されていた問題を修正
- bash 側: `PATH="$_browser_use_dir:$PATH"` → `PATH="$PATH:$_browser_use_dir"`（末尾追加）
- fish 側: `fish_add_path $dir` → `fish_add_path --append --move $dir`
  - `--move` は既に universal variable (`fish_user_paths`) に登録済みのパスを末尾へ**移動**させるために必要

Closes #279

## Test plan
- [ ] `chezmoi apply` 後、新しい shell を開く
- [ ] `which python3` が `~/.local/share/mise/installs/python/3.14.4/bin/python3` を返す
- [ ] `python3 --version` が mise 管理のバージョン（3.14.4）を返す
- [ ] `echo $PATH` で `.browser-use-env/bin` が mise の path より後ろにあることを確認
- [ ] browser-use 配下のコマンドが従来通り PATH から呼び出せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)