### PR TITLE
feat: Ctrl-j Ctrl-w で worktree を fzf 切り替えできるようにする (#318)

### DIFF
--- a/home/dot_config/fish/conf.d/20-fzf-bindings.fish
+++ b/home/dot_config/fish/conf.d/20-fzf-bindings.fish
@@ -4,6 +4,8 @@
 bind -M default ctrl-j,ctrl-h _fzf_history
 bind -M default ctrl-j,ctrl-t _fzf_file
 bind -M default ctrl-j,ctrl-g _fzf_ghq_repo
+bind -M default ctrl-j,ctrl-w _fzf_worktree
 bind -M insert ctrl-j,ctrl-h _fzf_history
 bind -M insert ctrl-j,ctrl-t _fzf_file
 bind -M insert ctrl-j,ctrl-g _fzf_ghq_repo
+bind -M insert ctrl-j,ctrl-w _fzf_worktree

--- a/home/dot_config/fish/functions/_fzf_worktree.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree.fish
@@ -1,0 +1,36 @@
+function _fzf_worktree
+    if not git rev-parse --is-inside-work-tree >/dev/null 2>&1
+        echo "not in a git repository"
+        commandline -f repaint
+        return 1
+    end
+
+    set -l tab (printf '\t')
+    set -l selection (
+        git worktree list --porcelain | awk -v OFS='\t' '
+            function flush() {
+                if (path == "") return
+                label = (branch != "") ? branch : (det ? "(detached)" : "")
+                if (idx == 0) label = "* " label
+                print label, path
+                idx++
+                path = ""; branch = ""; det = 0
+            }
+            BEGIN { idx = 0; path = ""; branch = ""; det = 0 }
+            /^worktree / { flush(); path = substr($0, 10); next }
+            /^branch refs\/heads\// { branch = substr($0, 19); next }
+            /^detached/ { det = 1; next }
+            END { flush() }
+        ' | fzf \
+            --delimiter=$tab \
+            --with-nth=1 \
+            --preview "git -C {2} log --oneline -20" \
+            --preview-window=right:60%
+    )
+
+    if test -n "$selection"
+        set -l parts (string split -m 1 -- $tab $selection)
+        cd $parts[2]
+        commandline -f repaint
+    end
+end


### PR DESCRIPTION
Closes #318

## Summary
- カレントリポジトリの `git worktree list` を fzf で選択して切り替える関数 `_fzf_worktree` を追加
- `Ctrl-j, Ctrl-w` を default / insert 両モードに追加 (既存 `Ctrl-j, Ctrl-g` と並列)
- 表示はブランチ名のみ、Root (main worktree) は `* {branch}` で最上段固定、detached HEAD は `(detached)`
- preview は `git log --oneline -20`、選択後はそのパスへ `cd`

## Test plan
- [x] fish 構文チェック (`fish --no-execute`)
- [x] awk パース: シングル worktree (Root マーク付与)
- [x] awk パース: 複数 worktree + detached HEAD 混在
- [ ] `chezmoi apply` 後、実環境で `Ctrl-j, Ctrl-w` の挙動確認 (preview / cd)
- [ ] git リポジトリ外で実行した場合のエラーメッセージ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)