### PR TITLE
refactor: settings.json テンプレから effortLevel を削除

### DIFF
--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -1,5 +1,4 @@
 {
-  "effortLevel": "medium",
   "voiceEnabled": true,
   "language": "日本語",
   "statusLine": {


### PR DESCRIPTION
## Summary

- `settings.json.tmpl` から `effortLevel` を削除し、グローバルテンプレートを全プロジェクト共通の設定（`hooks` / `statusLine` / `language` / `voiceEnabled`）のみに絞る
- プロジェクト固有の設定（`effortLevel` / `enabledPlugins` / `model`）は各リポジトリの `.claude/settings.json` で管理する方針に変更
- これに伴い `~/.claude/settings.json`（実ファイル）からも `effortLevel: "high"`・`enabledPlugins.rust-analyzer-lsp`・`model: "opus"` を削除し、`chezmoi diff` の常時差分を解消

Closes #293

## 決定の経緯

対話形式で3項目を比較して以下の通り決定:

| 設定 | 旧 Dotfiles | 旧 Local | 新方針 |
|---|---|---|---|
| `effortLevel` | `medium` | `high` | 両方削除、プロジェクトごとに指定 |
| `enabledPlugins` | （なし） | rust-analyzer-lsp | 両方削除、Rust プロジェクトでのみ有効化 |
| `model` | （なし） | `opus` | 両方削除、`/model` やプロジェクト単位で指定 |

## Test plan

- [x] `chezmoi diff ~/.claude/settings.json` で差分が出ないことを確認
- [ ] 各 Rust プロジェクトで `.claude/settings.json` に `rust-analyzer-lsp` を設定し直す（フォローアップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)