### PR TITLE
chore: release-please に changelog-sections を追加し refactor をリリース対象にする

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,19 @@
   "release-type": "simple",
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Background

[run 25980340856](https://github.com/toshiki670/dotfiles/actions/runs/25980340856) で release-please がスキップした原因調査の結果、以下が判明:

\`\`\`
✔ No user facing commits found since 8a9016f8d605a3fc77b126a05855efc2dcb8465f - skipping
\`\`\`

release-please のデフォルトでは `feat` / `fix` のみが user-facing として扱われ、`refactor` は CHANGELOG にも載らずリリースを trigger しない。実際 v0.58.0 リリースでも、含まれていた `refactor: settings.json テンプレから effortLevel を削除 (#321)` は changelog から外されていた。

本リポジトリでは内部設定の整理 (例: #323 / #326 の Zsh 撤去) も `refactor:` で記述しつつリリース対象にしたいので、設定を見直す。

## Change

`release-please-config.json` に `changelog-sections` を追加:

- visible (リリースを trigger / changelog に掲載): `feat`, `fix`, `refactor`, `perf`, `revert`
- hidden (リリースを trigger しない / changelog 非掲載): `docs`, `style`, `chore`, `test`, `build`, `ci`

## バージョンバンプの挙動 (release-please [DefaultVersioningStrategy](https://github.com/googleapis/release-please/blob/main/src/versioning-strategies/default.ts) 準拠)

| コミット種別 | bump |
| --- | --- |
| BREAKING CHANGE / `!` 付き | major |
| `feat` / `feature` | minor |
| visible なその他 (`fix`, `refactor`, `perf`, `revert`) | patch |
| hidden のみ | リリース無し |

## マージ後の期待動作

- main への push で release-please workflow が再走
- マージ済み refactor (#323, #326) を検出して **v0.58.1** のリリース PR が作成される

## Test plan

- [ ] マージ後、`Release Please` workflow が走り、release PR が作成されることを確認
- [ ] release PR の CHANGELOG に #323 / #326 が `Code Refactoring` セクションで列挙されることを確認
- [ ] release PR をマージし v0.58.1 タグが切られることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)