### PR TITLE
feat: starship の gcloud に account/domain/region 表示の format を追加

### DIFF
--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -63,6 +63,7 @@ symbol = " "
 symbol = " "
 
 [gcloud]
+format = '[$symbol$account(@$domain)(\($region\))]($style) '
 symbol = " "
 
 [git_branch]


### PR DESCRIPTION
## Summary
- `[gcloud]` セクションに `format = '[$symbol$account(@$domain)(\($region\))]($style) '` を追加し、prompt 上で gcloud の account / domain / region を可視化する

## Test plan
- [ ] `chezmoi apply` 後にシェルを再起動し starship prompt に gcloud 情報が想定通り表示されること
- [ ] gcloud 設定が無い環境で format がエラーや崩れを起こさないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)