### PR TITLE
feat: bin に cleanup-env コマンドを追加

### DIFF
--- a/bin/cleanup-env
+++ b/bin/cleanup-env
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Cleanup caches and unused versions from installed package managers
+#
+# Usage:
+#   cleanup-env            # interactive, actually deletes
+#   cleanup-env -n|--dry-run  # show what would be removed
+
+set -e
+
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--dry-run) DRY_RUN=true; shift ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: cleanup-env [OPTIONS]
+
+Prompt-then-cleanup for installed package managers.
+
+Options:
+  -n, --dry-run    Show what would be removed without removing
+  -h, --help       Show this help message
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+header() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  $1"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+}
+
+run() {
+  local label="$1"
+  shift
+  echo "=== $label ==="
+  "$@" || echo "⚠️  $label failed, continuing..."
+  echo ""
+}
+
+confirm() {
+  local reply
+  read -r -p "$1 [y/N] " reply
+  [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+header "Cleaning Up Environment"
+if $DRY_RUN; then
+  echo "(dry-run: nothing will actually be removed)"
+  echo ""
+fi
+
+if command -v brew &>/dev/null; then
+  if confirm "Run brew cleanup?"; then
+    if $DRY_RUN; then
+      run "Homebrew cleanup (dry-run)" brew cleanup --dry-run
+    else
+      run "Homebrew cleanup" brew cleanup
+    fi
+  fi
+  if confirm "Run brew autoremove?"; then
+    if $DRY_RUN; then
+      run "Homebrew autoremove (dry-run)" brew autoremove --dry-run
+    else
+      run "Homebrew autoremove" brew autoremove
+    fi
+  fi
+fi
+
+if command -v mise &>/dev/null; then
+  if confirm "Run mise prune?"; then
+    if $DRY_RUN; then
+      run "mise prune (dry-run)" mise prune --dry-run
+    else
+      run "mise prune" mise prune
+    fi
+  fi
+fi
+
+if command -v cargo &>/dev/null && command -v cargo-cache &>/dev/null; then
+  if confirm "Run cargo cache --autoclean?"; then
+    if $DRY_RUN; then
+      run "Cargo cache (dry-run)" cargo cache --dry-run --autoclean
+    else
+      run "Cargo cache" cargo cache --autoclean
+    fi
+  fi
+fi
+
+header "Done"

--- a/bin/cleanup-env
+++ b/bin/cleanup-env
@@ -10,8 +10,11 @@ set -e
 DRY_RUN=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -n|--dry-run) DRY_RUN=true; shift ;;
-    -h|--help)
+    -n | --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h | --help)
       cat <<'EOF'
 Usage: cleanup-env [OPTIONS]
 
@@ -23,7 +26,10 @@ Options:
 EOF
       exit 0
       ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
   esac
 done
 


### PR DESCRIPTION
## Summary
- `upgrade-env` と対になる手動クリーンアップコマンド `bin/cleanup-env` を新設。
- 対象: `brew cleanup` / `brew autoremove` / `mise prune` / `cargo cache --autoclean`。各セクションは `command -v` で導入済みかをチェック。
- 各セクション実行前に y/N プロンプトで都度確認、`-n` / `--dry-run` で削除候補のみ表示する。

## Test plan
- [x] `bin/cleanup-env --help` がヘルプを表示する
- [x] `bin/cleanup-env --bogus` が `Unknown option` で exit 1
- [x] `bin/cleanup-env --dry-run` で各セクションが y/N プロンプトを出す
- [x] dry-run で y を選ぶと `brew cleanup --dry-run` が削除候補を一覧表示する（実削除されない）
- [x] N を選んだセクションは静かにスキップされる
- [x] 実環境で `bin/cleanup-env`（実削除モード）を一通り回し、各ツールの動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)