### PR TITLE
fix: mise モジュールを無効化して Starship プロンプト呼び出しを削減

### DIFF
--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -137,7 +137,7 @@ threshold = 75
 symbol = "󰔷 "
 
 [mise]
-disabled         = false
+# disabled         = false
 format           = '[$symbol($health )]($style)'
 healthy_symbol   = ''
 symbol           = "󰭼 "


### PR DESCRIPTION
## 概要

Starship の `[mise]` モジュールの `disabled = false` をコメントアウトし、デフォルト（`disabled = true`）に追従して**無効化**する。

## 背景

Starship の `mise` モジュールはデフォルトで `disabled = true`。これまで `disabled = false` を明示してモジュールを有効化していたが、有効時はプロンプト描画ごとに `mise` を呼び出してツールの health 表示を行う。

これを無効化することで、毎プロンプトの `mise` 呼び出しが 1 つ減る。プロンプト遅延の調査（#341）に関連した変更。

## 変更内容

```diff
 [mise]
-disabled         = false
+# disabled         = false
 format           = '[$symbol($health )]($style)'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)