### PR TITLE
fix: fzf キャンセル時にプロンプトが消える問題を修正

### DIFF
--- a/home/dot_config/fish/functions/_fzf_ghq_repo.fish
+++ b/home/dot_config/fish/functions/_fzf_ghq_repo.fish
@@ -13,6 +13,6 @@ function _fzf_ghq_repo
         set rel (string trim "$rel")
         set -l root (ghq root)
         cd "$root/$rel"
-        commandline -f repaint
     end
+    commandline -f repaint
 end

--- a/home/dot_config/fish/functions/_fzf_worktree.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree.fish
@@ -31,6 +31,6 @@ function _fzf_worktree
     if test -n "$selection"
         set -l parts (string split -m 1 -- $tab $selection)
         cd $parts[2]
-        commandline -f repaint
     end
+    commandline -f repaint
 end


### PR DESCRIPTION
## 概要

`ctrl-j,ctrl-g`（ghq）や `ctrl-j,ctrl-w`（worktree）で fzf を開き、**何も選択せずに終了したときにプロンプト `❯` が消える**バグを修正します。

## 原因

`_fzf_ghq_repo` と `_fzf_worktree` では `commandline -f repaint`（プロンプト再描画）を**選択時の `if` ブロック内でしか実行していなかった**ため、キャンセル時に再描画されずプロンプトが消えていました。

`ctrl-j,ctrl-h`（`_fzf_history`）で発生しなかったのは、こちらは `repaint` を `if` の外で無条件に実行していたためです。

## 修正内容

`_fzf_ghq_repo` / `_fzf_worktree` の `commandline -f repaint` を `if` ブロックの外へ移動し、選択の有無にかかわらず必ず再描画するようにしました（`_fzf_history` / `_fzf_file` と同じパターン）。

## 確認方法

`chezmoi apply` 後、新しい fish セッションで `Ctrl+J Ctrl+G` / `Ctrl+J Ctrl+W` を開き、`Esc` で選択せず終了してもプロンプトが残ることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)