### PR TITLE
feat: ghq/worktree ピッカーを統合し WT 削除ショートカットを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # Dotfiles
+## Claude Code
+.claude/worktrees/
+.claude/settings.local.json
+
 ## Zsh
 zsh/bundle/*
 !.keep

--- a/home/dot_config/fish/functions/__fzf_picker_preview.fish
+++ b/home/dot_config/fish/functions/__fzf_picker_preview.fish
@@ -1,0 +1,7 @@
+function __fzf_picker_preview --argument-names type path rel
+    if test "$type" = repo
+        __fzf_ghq_readme_preview "$rel"
+    else
+        git -C "$path" log --oneline -20
+    end
+end

--- a/home/dot_config/fish/functions/__fzf_worktree_list.fish
+++ b/home/dot_config/fish/functions/__fzf_worktree_list.fish
@@ -1,0 +1,15 @@
+function __fzf_worktree_list --argument-names repo
+    git -C "$repo" worktree list --porcelain 2>/dev/null | awk -v OFS='\t' '
+        function flush() {
+            if (path == "") return
+            label = (branch != "") ? branch : (det ? "(detached)" : "")
+            print (idx == 0 ? 1 : 0), path, label
+            idx++; path = ""; branch = ""; det = 0
+        }
+        BEGIN { idx = 0; path = ""; branch = ""; det = 0 }
+        /^worktree / { flush(); path = substr($0, 10); next }
+        /^branch refs\/heads\// { branch = substr($0, 19); next }
+        /^detached/ { det = 1; next }
+        END { flush() }
+    '
+end

--- a/home/dot_config/fish/functions/_fzf_ghq_repo.fish
+++ b/home/dot_config/fish/functions/_fzf_ghq_repo.fish
@@ -1,7 +1,6 @@
 function _fzf_ghq_repo
     if not command -v ghq >/dev/null 2>&1
         echo "ghq: command not found"
-        commandline -f repaint
         return 1
     end
 

--- a/home/dot_config/fish/functions/_fzf_ghq_repo.fish
+++ b/home/dot_config/fish/functions/_fzf_ghq_repo.fish
@@ -4,15 +4,44 @@ function _fzf_ghq_repo
         commandline -f repaint
         return 1
     end
-    set -l rel (
-    ghq list 2>/dev/null | fzf \
-      --preview 'fish -c "__fzf_ghq_readme_preview {}"' \
-      --preview-window=right:60%
-  )
-    if test -n "$rel"
-        set rel (string trim "$rel")
-        set -l root (ghq root)
-        cd "$root/$rel"
+
+    set -l tab (printf '\t')
+    set -l root (ghq root)
+
+    set -l lines
+    for rel in (ghq list 2>/dev/null)
+        set -l repo_path "$root/$rel"
+        # repo 行: 表示 / 種別 / 対象パス / ghq 相対パス
+        set -a lines (printf '%s\t%s\t%s\t%s' "$rel" repo "$repo_path" "$rel")
+
+        # リンク worktree（ismain=0）のみ repo 行直下にツリー表示
+        set -l linked
+        for w in (__fzf_worktree_list "$repo_path")
+            set -l p (string split -- $tab $w)
+            test "$p[1]" = 0; and set -a linked "$w"
+        end
+        set -l n (count $linked)
+        set -l i 0
+        for w in $linked
+            set i (math $i + 1)
+            set -l p (string split -- $tab $w)
+            set -l marker '├─'
+            test $i -eq $n; and set marker '└─'
+            set -a lines (printf '%s %s\t%s\t%s\t%s' "$marker" "$p[3]" worktree "$p[2]" "")
+        end
+    end
+
+    set -l selection (
+        printf '%s\n' $lines | fzf \
+            --delimiter=$tab \
+            --with-nth=1 \
+            --preview 'fish -c "__fzf_picker_preview {2} {3} {4}"' \
+            --preview-window=right:60%
+    )
+
+    if test -n "$selection"
+        set -l parts (string split -- $tab $selection)
+        cd "$parts[3]"
     end
     commandline -f repaint
 end

--- a/home/dot_config/fish/functions/_fzf_worktree.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree.fish
@@ -6,31 +6,65 @@ function _fzf_worktree
     end
 
     set -l tab (printf '\t')
+    set -l toplevel (git rev-parse --show-toplevel 2>/dev/null)
+
+    set -l lines
+    for w in (__fzf_worktree_list .)
+        set -l p (string split -- $tab $w)
+        set -l label $p[3]
+        test "$p[1]" = 1; and set label "* $label"
+        # 表示 / パス / ismain
+        set -a lines (printf '%s\t%s\t%s' "$label" "$p[2]" "$p[1]")
+    end
+
     set -l selection (
-        git worktree list --porcelain | awk -v OFS='\t' '
-            function flush() {
-                if (path == "") return
-                label = (branch != "") ? branch : (det ? "(detached)" : "")
-                if (idx == 0) label = "* " label
-                print label, path
-                idx++
-                path = ""; branch = ""; det = 0
-            }
-            BEGIN { idx = 0; path = ""; branch = ""; det = 0 }
-            /^worktree / { flush(); path = substr($0, 10); next }
-            /^branch refs\/heads\// { branch = substr($0, 19); next }
-            /^detached/ { det = 1; next }
-            END { flush() }
-        ' | fzf \
+        printf '%s\n' $lines | fzf \
             --delimiter=$tab \
             --with-nth=1 \
             --preview "git -C {2} log --oneline -20" \
             --preview-window=right:60%
     )
 
-    if test -n "$selection"
-        set -l parts (string split -m 1 -- $tab $selection)
-        cd $parts[2]
+    if test -z "$selection"
+        commandline -f repaint
+        return
+    end
+
+    set -l parts (string split -- $tab $selection)
+    set -l wpath $parts[2]
+    set -l ismain $parts[3]
+
+    # メイン / 現在地の worktree は削除不可（force でも不可）。事前にはじく
+    if test "$ismain" = 1
+        echo "メイン worktree は削除できません: $wpath"
+        commandline -f repaint
+        return 1
+    end
+    if test -n "$toplevel"
+        set -l cur (path resolve "$toplevel")
+        set -l sel (path resolve "$wpath")
+        if test "$cur" = "$sel"
+            echo "現在地の worktree は削除できません（別のディレクトリへ移動してから実行してください）: $wpath"
+            commandline -f repaint
+            return 1
+        end
+    end
+
+    read -l -P "WT を削除しますか? [y/N] " confirm
+    if not string match -qri '^y' -- "$confirm"
+        commandline -f repaint
+        return
+    end
+
+    if git worktree remove "$wpath"
+        echo "削除しました: $wpath"
+        commandline -f repaint
+        return
+    end
+
+    read -l -P "強制削除しますか? [y/N] " force
+    if string match -qri '^y' -- "$force"
+        git worktree remove --force "$wpath"; and echo "強制削除しました: $wpath"
     end
     commandline -f repaint
 end

--- a/home/dot_config/fish/functions/_fzf_worktree.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree.fish
@@ -1,7 +1,6 @@
 function _fzf_worktree
     if not git rev-parse --is-inside-work-tree >/dev/null 2>&1
         echo "not in a git repository"
-        commandline -f repaint
         return 1
     end
 
@@ -22,7 +21,6 @@ function _fzf_worktree
 
     if test (count $lines) -eq 0
         echo "削除できる worktree がありません"
-        commandline -f repaint
         return
     end
 

--- a/home/dot_config/fish/functions/_fzf_worktree.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree.fish
@@ -20,7 +20,7 @@ function _fzf_worktree
     end
 
     if test (count $lines) -eq 0
-        echo "削除できる worktree がありません"
+        echo "No worktrees to delete"
         return
     end
 

--- a/home/dot_config/fish/functions/_fzf_worktree.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree.fish
@@ -6,15 +6,24 @@ function _fzf_worktree
     end
 
     set -l tab (printf '\t')
-    set -l toplevel (git rev-parse --show-toplevel 2>/dev/null)
 
+    # メイン worktree はパスだけ控え、削除候補リストには含めない
+    set -l main_path
     set -l lines
     for w in (__fzf_worktree_list .)
         set -l p (string split -- $tab $w)
-        set -l label $p[3]
-        test "$p[1]" = 1; and set label "* $label"
-        # 表示 / パス / ismain
-        set -a lines (printf '%s\t%s\t%s' "$label" "$p[2]" "$p[1]")
+        if test "$p[1]" = 1
+            set main_path $p[2]
+            continue
+        end
+        # リンク worktree のみ: 表示 / パス
+        set -a lines (printf '%s\t%s' "$p[3]" "$p[2]")
+    end
+
+    if test (count $lines) -eq 0
+        echo "削除できる worktree がありません"
+        commandline -f repaint
+        return
     end
 
     set -l selection (
@@ -32,28 +41,19 @@ function _fzf_worktree
 
     set -l parts (string split -- $tab $selection)
     set -l wpath $parts[2]
-    set -l ismain $parts[3]
-
-    # メイン / 現在地の worktree は削除不可（force でも不可）。事前にはじく
-    if test "$ismain" = 1
-        echo "メイン worktree は削除できません: $wpath"
-        commandline -f repaint
-        return 1
-    end
-    if test -n "$toplevel"
-        set -l cur (path resolve "$toplevel")
-        set -l sel (path resolve "$wpath")
-        if test "$cur" = "$sel"
-            echo "現在地の worktree は削除できません（別のディレクトリへ移動してから実行してください）: $wpath"
-            commandline -f repaint
-            return 1
-        end
-    end
 
     read -l -P "WT を削除しますか? [y/N] " confirm
     if not string match -qri '^y' -- "$confirm"
         commandline -f repaint
         return
+    end
+
+    # 現在地が削除対象 worktree の内側なら、削除前にメインへ移動する
+    # （現在地の worktree を消すと cwd が無効なディレクトリを指すため）
+    set -l cur (path resolve -- $PWD)
+    set -l target (path resolve -- $wpath)
+    if test "$cur" = "$target"; or string match -q -- "$target/*" "$cur"
+        test -n "$main_path"; and cd $main_path
     end
 
     if git worktree remove "$wpath"


### PR DESCRIPTION
## 概要

Issue #348 に対応。fish の fzf ショートカットを「移動の一本化」と「削除の分離」で再編する。

- **`Ctrl-j, Ctrl-g`（移動）**: ghq リポジトリ一覧の中に各リポジトリの worktree をツリー表示する統合ピッカーに拡張。リポジトリ行・worktree 行のどちらを選んでもそのパスへ `cd`。
- **`Ctrl-j, Ctrl-w`（削除）**: worktree を「移動」から「削除」に変更。二段階確認付き。

バインド（`20-fzf-bindings.fish`）は既に意図どおりのため変更なし。

## 変更内容

| ファイル | 操作 |
| --- | --- |
| `__fzf_worktree_list.fish` | **新規**: `git worktree list --porcelain` のパース共通ヘルパー（`<ismain>\t<path>\t<label>`）。移動/削除ピッカーで共用 |
| `__fzf_picker_preview.fish` | **新規**: 統合ピッカーの行種別 preview ディスパッチャ（repo=README / worktree=`git log`） |
| `_fzf_ghq_repo.fish` | 統合ピッカー（移動）に拡張。repo 行 + リンク worktree を `├─`/`└─` でツリー表示 |
| `_fzf_worktree.fish` | cd → 削除に改修。メイン worktree は候補から除外、現在地 WT も削除可（削除前にルートへ移動）、二段階確認 |
| `.gitignore` | `.claude/worktrees/`・`.claude/settings.local.json` を除外（`.claude/` 自体は Skill 配置のため追跡を維持） |

## 動作確認で見つけて修正した点

実装初版に対する動作確認で 2 件の不具合を発見し修正:

1. **削除ピッカーにメイン worktree が表示されていた** → 削除不可のメイン worktree を候補一覧から除外（候補が無ければ `No worktrees to delete` を表示）。
2. **現在地の worktree を削除できなかった** → 現在地が削除対象の内側なら、削除前にリポジトリルートへ `cd` してから remove。削除が成功し、削除後も cwd が無効化されずルートに留まる。
3. **候補なし等のメッセージが一瞬で消えていた** → 候補なし / リポジトリ外 / ghq 未インストールの早期 return（fzf 起動前）では、直後の `commandline -f repaint` がメッセージ行を再描画で潰していた。これらでは `repaint` を呼ばないようにする（fzf キャンセル時のプロンプト復帰用 `repaint`（#346）は fzf 起動後のため維持）。

あわせて、worktree を `.claude/worktrees/` に置くと `mise run lint` が worktree 内を走査して落ちる問題を `.gitignore` 追加で解消。

## 検証

- `mise run lint`: **0 error**（`.claude/worktrees/` 除外後も green）
- `__fzf_worktree_list` の出力形式（`<ismain>\t<path>\t<label>`）を確認
- 削除ピッカーの候補にメインが出ず、リンク worktree のみ表示されることを確認
- 現在地判定（対象そのもの / サブディレクトリ → 移動、無関係 → 移動しない）を確認
- end-to-end: dirty worktree を「ルートへ移動 → remove 拒否 → `--force` 成功」、cwd がルートに保持されることを確認
- 統合ピッカー（移動）のツリー生成・preview 分岐を非対話で確認
- 実機（公式 EnterWorktree で `.claude/worktrees/` に作成）で `Ctrl-j,Ctrl-w` 削除が成功することを確認

## 受け入れ条件

- [x] `Ctrl-j, Ctrl-g` でリポジトリ + worktree の統合ピッカーが開く
- [x] worktree を持つリポジトリが `├─` / `└─` でツリー表示される
- [x] 統合ピッカーの preview がリポジトリ行 = README、worktree 行 = `git log --oneline -20` になる
- [x] 統合ピッカーでリポジトリ行・worktree 行のいずれを選んでもそのパスへ `cd` する
- [x] `Ctrl-j, Ctrl-w` が worktree 削除ショートカットになる（cd しない）
- [x] 削除は Yes/No → 拒否時に force するかの二段階確認になる
- [x] メイン worktree は削除候補に表示されない（動作確認で「表示しない」に改善）
- [x] 現在地の worktree も削除でき、削除後はリポジトリルートへ移動する（動作確認で改善）

## 備考（要検証）

統合ピッカーは全リポジトリに対し `git worktree list` を実行するため、リポジトリ数が多い環境では起動コストが増える可能性がある。実環境での体感を見て、遅延が問題なら遅延化・キャッシュを別途検討する。

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
