### PR TITLE
feat: fzf のカラーをシステム外観追従（light/dark）に対応

### DIFF
--- a/COLOR.md
+++ b/COLOR.md
@@ -17,6 +17,7 @@
 | **Fish**（構文色） | `dot_config/fish/conf.d/90-fish-theme.fish` + `dot_config/fish/themes/OneHalfLight-Ayu.theme` | `[light]` セクション | `[dark]` セクション | `fish_terminal_color_theme`（OSC 11）→ `fish_config theme choose` が変数変化に追従 | `fish_config theme list` |
 | **Neovim** | `dot_config/nvim/lua/plugins/colorscheme.lua` | `onehalflight`（`sonph/onehalf`） | `ayu-dark`（`Shatur/neovim-ayu`） | `&background`（**起動時**に OSC 11 検出）→ `OptionSet` で colorscheme 切替 | `:colorscheme <Tab>` |
 | **eza** | `dot_config/fish/conf.d/40-eza.fish`（`EZA_COLORS`） | グレー明度（濃いめ） | グレー明度（薄いめ） | 色付き要素は Ghostty パレット追従（ANSI）。グレーのメタデータのみ `fish_terminal_color_theme` で明度切替 | `man eza_colors` |
+| **fzf** | `dot_config/fish/conf.d/05-fzf-env.fish`（`FZF_DEFAULT_OPTS` の `--color`） | ANSI 追従 | ANSI 追従 | `--color` を ANSI 番号（`-1`=端末デフォルト / `0`〜`15`）で指定。Ghostty パレット追従でシェル配線不要 | `man fzf` の COLOR セクション |
 | **git-delta** | `dot_config/git/configs/delta`（`[delta "theme-light/dark"]`）+ `dot_config/fish/conf.d/50-delta.fish`（`DELTA_FEATURES`） | `OneHalfLight` | `ayu-dark` | `DELTA_FEATURES` を `fish_terminal_color_theme` に追従。git 実行ごとに反映 | `delta --list-syntax-themes` |
 | **bat** | `dot_config/bat/config`（`--theme-light/dark`） | `OneHalfLight` | `ayu-dark` | bat ネイティブ `--theme="auto"`（bat 自身が OSC 11 検出）。シェル配線不要 | `bat --list-themes` |
 
@@ -29,6 +30,7 @@
 
 - **Ghostty が起点**：OS 外観 → 端末の背景色 + ANSI 16 色パレットを切替。
 - **Fish / eza / delta** は `fish_terminal_color_theme`（fish が最初の対話プロンプト以降、OSC 11 で背景を検出して `light`/`dark`/`unknown` を設定する read-only 変数）を共有して追従する。
+- **fzf** は `--color` を ANSI 番号（`-1`/`0`〜`15`）で指定するだけで Ghostty のパレット切替に追従する。シェル変数にもネイティブ検出にも依存しない（eza の色付き要素と同じ ANSI 追従）。
 - **nvim** は標準機能で **起動時のみ** `&background` を検出（起動中の OS 切替は次回起動で反映）。
 - **bat** は `--theme=auto` で自前検出するため、シェル変数に依存しない。
 
@@ -44,9 +46,11 @@ light / dark を別のテーマセットに変える手順。**上から順に**
    プラグイン（`Shatur/neovim-ayu` / `sonph/onehalf`）と、`apply()` 内の `onehalflight` / `ayu-dark` を新 colorscheme 名に変更。プラグインを変えたら `nvim --headless "+Lazy! sync" +qa` と `lazy-lock.json` の更新を忘れずに。
 4. **eza**（任意）`dot_config/fish/conf.d/40-eza.fish`
    グレー系メタデータの明度だけ。色付き要素は Ghostty 追従なので通常は触らなくてよい。
-5. **git-delta** `dot_config/git/configs/delta`
+5. **fzf**（任意）`dot_config/fish/conf.d/05-fzf-env.fish`
+   `--color` は ANSI 番号で Ghostty 追従するため通常は触らなくてよい。アクセント色の色相を変えたい場合のみ `--color` の ANSI 番号（`-1`/`0`〜`15`）を調整（`man fzf` の COLOR セクション）。
+6. **git-delta** `dot_config/git/configs/delta`
    `[delta "theme-light"]` / `[delta "theme-dark"]` の `syntax-theme` を変更（名前は `delta --list-syntax-themes`）。
-6. **bat** `dot_config/bat/config`
+7. **bat** `dot_config/bat/config`
    `--theme-light` / `--theme-dark` を変更（名前は `bat --list-themes`）。
 
 > **標準に無いテーマ**（今回の Ayu のような）を使う場合:

--- a/home/dot_config/fish/conf.d/05-fzf-env.fish
+++ b/home/dot_config/fish/conf.d/05-fzf-env.fish
@@ -1,14 +1,20 @@
 # fzf configuration (Phase 2: match zsh config)
 # https://github.com/junegunn/fzf
 
+# --color uses ANSI palette indices (-1 = terminal default, 0-15 = ANSI) so the
+# colors follow Ghostty's per-appearance palette (light:One Half Light /
+# dark:Ayu), matching the eza approach. No shell wiring needed.
+# Exception: the selected line uses fg+:15 (white), not -1. palette 8 (bg+) is a
+# mid grey in both themes (#686868 / #4f525e), too close to the default fg
+# (#bfbdb6 / #383a42) to read; white keeps the highlighted row legible on both.
 set -gx FZF_DEFAULT_OPTS '
   --height 50%
   --layout=reverse
   --inline-info
-  --color=fg:#d0d0d0,bg:#121212,hl:#5f87af
-  --color=fg+:#d0d0d0,bg+:#262626,hl+:#5fd7ff
-  --color=info:#afaf87,prompt:#d7005f,pointer:#af5fff
-  --color=marker:#87ff00,spinner:#af5fff,header:#87afaf
+  --color=fg:-1,bg:-1,hl:4
+  --color=fg+:15,bg+:8,hl+:12
+  --color=info:3,prompt:5,pointer:13
+  --color=marker:2,spinner:13,header:6
 '
 
 if command -q fd


### PR DESCRIPTION
## 概要

fzf のカラーテーマが COLOR.md の「システム外観追従（light:One Half Light / dark:Ayu）」の対象から漏れていた。`FZF_DEFAULT_OPTS` は固定の dark 向け hex カラーがハードコードされており、light に切り替えても fzf だけ暗い配色のまま残っていた。これを ANSI パレット追従へ移行し、COLOR.md の対応漏れも解消する。

## 変更内容

- **`home/dot_config/fish/conf.d/05-fzf-env.fish`**
  - `--color` を固定 hex（dark 専用）から ANSI パレット番号（`-1` = 端末デフォルト / `0`〜`15`）へ置き換え。Ghostty が light/dark で切り替える 16 色パレットに自動追従する（eza の色付き要素と同じ哲学、`--on-variable` ハンドラ不要）。
  - 選択行の文字色のみ `fg+:15`（白）で固定。palette 8（`bg+`）は両テーマで中間グレー（`#686868` / `#4f525e`）になりデフォルト前景（`#bfbdb6` / `#383a42`）と明度が近くコントラスト不足になるため、白で固定して両テーマで読めるようにした。理由はコメントに明記。
- **`COLOR.md`**
  - インデックス表に fzf 行を追加
  - 「追従の仕組み（要点）」に fzf の追従方式を追記
  - 「テーマを変更するには」に fzf を項目として追加（番号を振り直し）

## 検証

- `fish -n` 構文チェック OK
- `mise run lint` 0 error（追加のフォーマット変更なし）
- `chezmoi apply` 後、`$FZF_DEFAULT_OPTS` が ANSI 番号で反映されることを確認、fzf が新しい `--color` 値をパースして正常動作することを確認
- 実機で zoxide (`zi`) / ファイルピッカーの選択行が light / dark 両方で読めることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)