### PR TITLE
refactor: fzf fish 関数を実態に合わせてリネーム

### DIFF
--- a/home/.chezmoiremove.tmpl
+++ b/home/.chezmoiremove.tmpl
@@ -4,3 +4,6 @@
 */ -}}
 {{/* issue #341 (mise 二重 activate 解消: 手動 activate を削除し mise vendor 自動 activate に一本化) */}}
 .config/fish/conf.d/10-mise.fish
+{{/* fzf fish 関数のリネーム (_fzf_worktree → _fzf_worktree_remove / _fzf_ghq_repo → _fzf_ghq_cd) に伴う旧ファイル削除 */}}
+.config/fish/functions/_fzf_worktree.fish
+.config/fish/functions/_fzf_ghq_repo.fish

--- a/home/dot_config/fish/conf.d/20-fzf-bindings.fish
+++ b/home/dot_config/fish/conf.d/20-fzf-bindings.fish
@@ -3,9 +3,9 @@
 
 bind -M default ctrl-j,ctrl-h _fzf_history
 bind -M default ctrl-j,ctrl-t _fzf_file
-bind -M default ctrl-j,ctrl-g _fzf_ghq_repo
-bind -M default ctrl-j,ctrl-w _fzf_worktree
+bind -M default ctrl-j,ctrl-g _fzf_ghq_cd
+bind -M default ctrl-j,ctrl-w _fzf_worktree_remove
 bind -M insert ctrl-j,ctrl-h _fzf_history
 bind -M insert ctrl-j,ctrl-t _fzf_file
-bind -M insert ctrl-j,ctrl-g _fzf_ghq_repo
-bind -M insert ctrl-j,ctrl-w _fzf_worktree
+bind -M insert ctrl-j,ctrl-g _fzf_ghq_cd
+bind -M insert ctrl-j,ctrl-w _fzf_worktree_remove

--- a/home/dot_config/fish/functions/_fzf_ghq_cd.fish
+++ b/home/dot_config/fish/functions/_fzf_ghq_cd.fish
@@ -1,4 +1,4 @@
-function _fzf_ghq_repo
+function _fzf_ghq_cd
     if not command -v ghq >/dev/null 2>&1
         echo "ghq: command not found"
         return 1

--- a/home/dot_config/fish/functions/_fzf_worktree_remove.fish
+++ b/home/dot_config/fish/functions/_fzf_worktree_remove.fish
@@ -1,4 +1,4 @@
-function _fzf_worktree
+function _fzf_worktree_remove
     if not git rev-parse --is-inside-work-tree >/dev/null 2>&1
         echo "not in a git repository"
         return 1


### PR DESCRIPTION
## 概要

fzf 用 fish 関数の名前が処理の実態と乖離していたためリネームする。fish のオートロード仕様に合わせ、ファイル名・関数定義名・キーバインドの参照を一括で揃えた。

| 旧 | 新 | 実態 |
|---|---|---|
| `_fzf_worktree` | `_fzf_worktree_remove` | worktree を選んで `git worktree remove` で削除 |
| `_fzf_ghq_repo` | `_fzf_ghq_cd` | ghq リポジトリ＋worktree をツリー表示して `cd` |

## 変更点

- `home/dot_config/fish/functions/` の2ファイルをリネーム＋関数定義名を更新
- `home/dot_config/fish/conf.d/20-fzf-bindings.fish` のバインド先を新関数名へ（default / insert の計4行）
- `home/.chezmoiremove.tmpl` に旧ターゲットを追記し、`chezmoi apply` 時に各端末（このマシン含む）から旧ファイルを削除

## 削除エントリの後始末

全端末に新ファイルが行き渡ったら、`.chezmoiremove.tmpl` の以下エントリを削除すること。

- `.config/fish/functions/_fzf_worktree.fish`
- `.config/fish/functions/_fzf_ghq_repo.fish`

## 確認

- `fish --no-execute` で変更3ファイルの構文チェック済み
- git 上は2件とも rename 検出（履歴維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)