### PR TITLE
refactor(fish): gh abbreviation をグローバル略語に変更

### DIFF
--- a/home/dot_config/fish/conf.d/25-abbr.fish
+++ b/home/dot_config/fish/conf.d/25-abbr.fish
@@ -52,8 +52,8 @@ abbr --add --command git -- tags "for-each-ref --sort=-taggerdate --format='%(ta
 # Stacked PRs: open the parent PR (head = current PR base)
 # abbr --add --command gh -- pweb 'pr view "$(gh pr view --json baseRefName --jq \'.baseRefName\')" --web'
 # abbr --add --command gh -- switch 'pr checkout'
-abbr --add --command gh -- b browse
-abbr --add --command gh -- i issue
+abbr --add gb 'gh browse'
+abbr --add gi 'gh issue'
 # Pull Request
 abbr --add gp 'gh pr'
 abbr --add gpv 'gh pr view'


### PR DESCRIPTION
## Summary

- `gh b` / `gh i` という context-sensitive な abbr（`--command gh` 指定）を廃止
- `gb` (`gh browse`) / `gi` (`gh issue`) のグローバル略語に置き換え
- `gh` を先に入力しなくても直接呼び出せるようになり、既存の `gp` / `gpv` などと統一感が生まれる

## Test plan

- [ ] `gb` で `gh browse` が起動することを確認
- [ ] `gi` で `gh issue` が起動することを確認
- [ ] 既存の `gp` / `gpv` / `gpd` などに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)