### PR TITLE
feat(fish): gh targeted commands に fzf インタラクティブ補完を追加

### DIFF
--- a/home/dot_config/fish/conf.d/20-fzf-bindings.fish
+++ b/home/dot_config/fish/conf.d/20-fzf-bindings.fish
@@ -9,3 +9,8 @@ bind -M insert ctrl-j,ctrl-h _fzf_history
 bind -M insert ctrl-j,ctrl-t _fzf_file
 bind -M insert ctrl-j,ctrl-g _fzf_ghq_cd
 bind -M insert ctrl-j,ctrl-w _fzf_worktree_remove
+
+# gh targeted-command completion: Tab triggers fzf picker with preview
+# Activates only for: gh issue/pr/run/release <subcommand> (no ID yet)
+# Use default mode (not insert) — vi mode is not enabled in this config
+bind -M default tab _fzf_gh_complete

--- a/home/dot_config/fish/functions/_fzf_gh_complete.fish
+++ b/home/dot_config/fish/functions/_fzf_gh_complete.fish
@@ -1,0 +1,93 @@
+function _fzf_gh_complete
+    if not command -q gh
+        commandline -f complete
+        return
+    end
+
+    set -l tokens (commandline -po)
+    set -l tab (printf '\t')
+
+    # Activate only when: gh <resource> <targeted-subcommand> (no ID yet)
+    if test (count $tokens) -ne 3; or test "$tokens[1]" != gh
+        commandline -f complete
+        return
+    end
+
+    set -l resource $tokens[2]
+    set -l subcmd $tokens[3]
+
+    set -l candidates
+    set -l preview_cmd
+
+    if test "$resource" = issue
+        if not contains -- $subcmd view edit close reopen comment pin
+            commandline -f complete
+            return
+        end
+        set candidates (gh issue list --limit 100 --json number,title,state \
+            --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null)
+        set preview_cmd 'env GH_FORCE_TTY=100% gh issue view {1}'
+
+    else if test "$resource" = pr
+        if not contains -- $subcmd view checkout review diff merge checks update-branch
+            commandline -f complete
+            return
+        end
+        set candidates (gh pr list --limit 100 --json number,title,state \
+            --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null)
+        set preview_cmd 'env GH_FORCE_TTY=100% gh pr view {1}'
+
+    else if test "$resource" = run
+        if not contains -- $subcmd view rerun cancel watch
+            commandline -f complete
+            return
+        end
+        set candidates (gh run list --limit 50 --json databaseId,displayTitle,status \
+            --jq '.[] | "\(.databaseId)\t[\(.status)] \(.displayTitle)"' 2>/dev/null)
+        set preview_cmd 'env GH_FORCE_TTY=100% gh run view {1}'
+
+    else if test "$resource" = release
+        if not contains -- $subcmd view delete edit upload
+            commandline -f complete
+            return
+        end
+        set candidates (gh release list --limit 30 --json tagName,name,publishedAt \
+            --jq '.[] | "\(.tagName)\t\(.name) (\(.publishedAt))"' 2>/dev/null)
+        set preview_cmd 'env GH_FORCE_TTY=100% gh release view {1}'
+
+    else if test "$resource" = gist
+        if not contains -- $subcmd view edit
+            commandline -f complete
+            return
+        end
+        set candidates (gh gist list --limit 100 2>/dev/null \
+            | awk -F'\t' '{print $1 "\t[" $4 "] " $2}')
+        set preview_cmd 'env GH_FORCE_TTY=100% gh gist view {1}'
+
+    else
+        commandline -f complete
+        return
+    end
+
+    if test (count $candidates) -eq 0
+        echo -e "\n(no $resource found)" >&2
+        commandline -f repaint
+        return
+    end
+
+    set -l selected (
+        printf '%s\n' $candidates \
+        | fzf --delimiter=$tab \
+            --with-nth=2 \
+            --preview=$preview_cmd \
+            --preview-window='right:60%' \
+            --header="gh $resource $subcmd"
+    )
+
+    if test -n "$selected"
+        set -l id (string split $tab -- $selected)[1]
+        commandline -i "$id"
+    end
+
+    commandline -f repaint
+end


### PR DESCRIPTION
Closes #361

## Summary

- `gh issue/pr/run/release/gist` の ID を必要とするサブコマンドで Tab 押下時に fzf ピッカーを起動
- 右ペインに `gh <resource> view` のプレビューを表示
- 候補ゼロ時は `(no <resource> found)` を表示してリターン
- gh コンテキスト以外は通常の Fish 補完にフォールスルー

## 対応コマンド

| resource | targeted subcommands |
|---|---|
| `issue` | view / edit / close / reopen / comment / pin |
| `pr` | view / checkout / review / diff / merge / checks / update-branch |
| `run` | view / rerun / cancel / watch |
| `release` | view / delete / edit / upload |
| `gist` | view / edit |

## 実装詳細

- `functions/_fzf_gh_complete.fish` — メイン関数（コンテキスト判定 + fzf 起動）
- `conf.d/20-fzf-bindings.fish` — `bind -M default tab _fzf_gh_complete` を追加
- `gist` は `--json` 非対応のため `awk` でプレーンテキストを整形

🤖 Generated with [Claude Code](https://claude.com/claude-code)