### PR TITLE
feat(fish): gh targeted commands に Fish ネイティブ補完を追加 (alternative)

### DIFF
--- a/home/dot_config/fish/completions/gh.fish
+++ b/home/dot_config/fish/completions/gh.fish
@@ -1,0 +1,71 @@
+# Context condition helpers
+
+function __gh_completing_issue_id
+    set -l cmd (commandline -po)
+    test (count $cmd) -ge 3
+        and test "$cmd[2]" = issue
+        and contains -- "$cmd[3]" view edit close reopen comment pin
+end
+
+function __gh_completing_pr_id
+    set -l cmd (commandline -po)
+    test (count $cmd) -ge 3
+        and test "$cmd[2]" = pr
+        and contains -- "$cmd[3]" view checkout review diff merge checks update-branch
+end
+
+function __gh_completing_run_id
+    set -l cmd (commandline -po)
+    test (count $cmd) -ge 3
+        and test "$cmd[2]" = run
+        and contains -- "$cmd[3]" view rerun cancel watch
+end
+
+function __gh_completing_release_id
+    set -l cmd (commandline -po)
+    test (count $cmd) -ge 3
+        and test "$cmd[2]" = release
+        and contains -- "$cmd[3]" view delete edit upload
+end
+
+function __gh_completing_gist_id
+    set -l cmd (commandline -po)
+    test (count $cmd) -ge 3
+        and test "$cmd[2]" = gist
+        and contains -- "$cmd[3]" view edit
+end
+
+# Candidate generators
+
+function __gh_issue_candidates
+    gh issue list --limit 100 --json number,title,state \
+        --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null
+end
+
+function __gh_pr_candidates
+    gh pr list --limit 100 --json number,title,state \
+        --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null
+end
+
+function __gh_run_candidates
+    gh run list --limit 50 --json databaseId,displayTitle,status \
+        --jq '.[] | "\(.databaseId)\t[\(.status)] \(.displayTitle)"' 2>/dev/null
+end
+
+function __gh_release_candidates
+    gh release list --limit 30 --json tagName,name,publishedAt \
+        --jq '.[] | "\(.tagName)\t\(.name) (\(.publishedAt))"' 2>/dev/null
+end
+
+function __gh_gist_candidates
+    gh gist list --limit 100 2>/dev/null \
+        | awk -F'\t' '{print $1 "\t" $2}'
+end
+
+# Completion rules: -f suppresses file completions when condition is met
+
+complete -c gh -n __gh_completing_issue_id -f -a '(__gh_issue_candidates)'
+complete -c gh -n __gh_completing_pr_id -f -a '(__gh_pr_candidates)'
+complete -c gh -n __gh_completing_run_id -f -a '(__gh_run_candidates)'
+complete -c gh -n __gh_completing_release_id -f -a '(__gh_release_candidates)'
+complete -c gh -n __gh_completing_gist_id -f -a '(__gh_gist_candidates)'

--- a/home/dot_config/fish/completions/gh.fish.tmpl
+++ b/home/dot_config/fish/completions/gh.fish.tmpl
@@ -1,4 +1,7 @@
-# Context condition helpers
+{{ if lookPath "gh" -}}
+{{ output "gh" "completion" "--shell" "fish" }}
+
+# Custom completions: ID selection for targeted commands
 
 function __gh_completing_issue_id
     set -l cmd (commandline -po)
@@ -35,8 +38,6 @@ function __gh_completing_gist_id
         and contains -- "$cmd[3]" view edit
 end
 
-# Candidate generators
-
 function __gh_issue_candidates
     gh issue list --limit 100 --json number,title,state \
         --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null
@@ -62,10 +63,9 @@ function __gh_gist_candidates
         | awk -F'\t' '{print $1 "\t" $2}'
 end
 
-# Completion rules: -f suppresses file completions when condition is met
-
 complete -c gh -n __gh_completing_issue_id -f -a '(__gh_issue_candidates)'
 complete -c gh -n __gh_completing_pr_id -f -a '(__gh_pr_candidates)'
 complete -c gh -n __gh_completing_run_id -f -a '(__gh_run_candidates)'
 complete -c gh -n __gh_completing_release_id -f -a '(__gh_release_candidates)'
 complete -c gh -n __gh_completing_gist_id -f -a '(__gh_gist_candidates)'
+{{- end }}


### PR DESCRIPTION
Alternative implementation for #361 — #362 との比較用

## Summary

- `completions/gh.fish` に `complete` ルールを追加
- Tab 押下で Fish ネイティブ補完 UI に issue/PR/run/release/gist の候補を表示
- 候補フォーマット: `番号/ID <Tab> [状態] タイトル`（番号が挿入され、タイトルは説明として表示）
- `-f` フラグで条件マッチ時はファイル補完を抑制

## 対応コマンド

| resource | targeted subcommands |
|---|---|
| `issue` | view / edit / close / reopen / comment / pin |
| `pr` | view / checkout / review / diff / merge / checks / update-branch |
| `run` | view / rerun / cancel / watch |
| `release` | view / delete / edit / upload |
| `gist` | view / edit |

## #362 との比較

| | このPR（Fish ネイティブ） | #362（fzf） |
|---|---|---|
| UI | Fish 組み込み補完リスト | fzf ピッカー |
| プレビュー | なし | あり |
| 追加依存 | なし | なし（fzf は既存） |
| Tab 上書き | なし | あり（default モード） |
| 変更ファイル | `completions/gh.fish` のみ | `functions/_fzf_gh_complete.fish` + `conf.d/20-fzf-bindings.fish` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)