### PR TITLE
feat(ghostty): カーソルを常に block 表示にする

### DIFF
--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -20,6 +20,8 @@ keybind = super+left=goto_split:left
 keybind = super+up=goto_split:up
 keybind = ctrl+page_down=next_tab
 keybind = ctrl+page_up=previous_tab
+# シェル統合の cursor 機能はプロンプト上でカーソルを bar に変えるため無効化（常に block にする）
+shell-integration-features = no-cursor
 mouse-shift-capture = always
 macos-titlebar-style = tabs
 macos-option-as-alt = true


### PR DESCRIPTION
## 概要
新規タブを開いた直後にカーソルが bar になり、`exec fish -l` すると block に戻る問題を解消する。常に block で表示されるようにする。

## 原因
Ghostty のシェル統合 `cursor` 機能（`GHOSTTY_SHELL_FEATURES=cursor:blink`）が、fish のプロンプト表示ごとに `\e[5 q`（点滅 bar）を送出していた。`exec fish -l` 後は `fish_preexec` で default(block) にリセットされ、その後フックが再登録されないため block に見えていた。

## 対応
`shell-integration-features = no-cursor` を追加し、cursor 機能のみ無効化。`cursor-style` のデフォルト `block` が常に適用される。他のシェル統合機能（title / path 等）は維持される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
