### PR TITLE
fix(fish): gcm のプロンプトでコードフェンス出力を抑止する

### DIFF
--- a/home/dot_config/fish/functions/gcm.fish
+++ b/home/dot_config/fish/functions/gcm.fish
@@ -21,7 +21,11 @@ Analyze the staged diff and split into the minimum number of semantically indepe
 - Single concern → one entry
 - Multiple independent concerns (e.g. feat + fix, or unrelated files) → multiple entries
 
-Output ONLY a JSON array — no markdown fences, no extra text:
+CRITICAL — output format:
+- Respond with raw JSON ONLY. The first character MUST be '[' and the last MUST be ']'.
+- Do NOT wrap the output in markdown code fences (no ```json, no ```).
+- Do NOT add any prose, comment, or explanation before or after the JSON.
+
 [{\"message\": \"<type>[scope]: <description>\", \"files\": [\"path/to/file\"]}, ...]
 
 Rules:


### PR DESCRIPTION
## 概要

`gcm` 実行時に `claude -p`（haiku）が JSON を ` ```json ... ``` ` の Markdown コードフェンスで囲んで返すことがあり、`jq` のパースに失敗して「不正なJSON出力を受け取りました」エラーで中断していた。

```
❯ gcm
コミットを生成中...
不正なJSON出力を受け取りました:
```json [{"message": "chore(attendance): ...", "files": [...]}] ```
```

## 変更内容

`home/dot_config/fish/functions/gcm.fish` の system prompt を強化し、フェンスを付けさせないようにした。

- 出力の先頭が `[`・末尾が `]` であることを明示（小型モデルが従いやすい具体的な制約）
- `CRITICAL — output format` セクションとして独立させ、コードフェンス禁止・前後の説明文禁止を明記

## 検証

- `fish -n` で構文チェック OK
- fish のダブルクォート内でバックティックがそのまま渡ることを確認（エスケープ不要）
- 実機で `gcm` が成功することをユーザーが確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)