### PR TITLE
chore: add Dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要

GitHub Actions の依存更新を自動化するため `.github/dependabot.yml` を追加する。

## 方針

- 対象は **`github-actions` エコシステムのみ**。
  - `flake.nix` (Nix) / `mise.toml` / `pyproject.toml` は Dependabot 未対応、または更新対象の依存宣言が無いため対象外。
- スケジュールは **weekly**（毎週月曜 / Asia/Tokyo）。
- `groups` で全アクション更新を **1 つの PR に集約**してノイズを抑制。
- `commit-message.prefix: chore` で release-please のリリース対象外にする（Conventional Commits 運用に適合）。

## 監視対象アクション

- `actions/checkout`
- `cachix/install-nix-action`
- `dorny/paths-filter`
- `googleapis/release-please-action`
- `nix-community/cache-nix-action`（SHA pin）

🤖 Generated with [Claude Code](https://claude.com/claude-code)