### PR TITLE
feat(fish): nvim プラグインを同期する v-sync 関数を追加

### DIFF
--- a/home/dot_config/fish/functions/v-sync.fish
+++ b/home/dot_config/fish/functions/v-sync.fish
@@ -1,0 +1,21 @@
+function v-sync --description 'Sync nvim plugins (Lazy sync) and re-add lazy-lock.json into chezmoi source'
+    if not command -q nvim
+        echo "v-sync: nvim command not found." >&2
+        return 127
+    end
+
+    if not command -q chezmoi
+        echo "v-sync: chezmoi command not found." >&2
+        return 127
+    end
+
+    echo "v-sync: syncing nvim plugins..."
+    command nvim --headless "+Lazy! sync" +qa
+    if test $status -ne 0
+        echo "v-sync: nvim plugin sync failed." >&2
+        return $status
+    end
+
+    echo "v-sync: re-adding lazy-lock.json into chezmoi source..."
+    command chezmoi re-add "$HOME/.config/nvim/lazy-lock.json"
+end


### PR DESCRIPTION
## 概要

nvim プラグインの更新と chezmoi への反映を 1 コマンドで行う fish 関数 `v-sync` を追加する。

```fish
v-sync
```

処理内容:

1. `nvim --headless "+Lazy! sync" +qa` でプラグインを sync（install + clean + update）
2. `chezmoi re-add ~/.config/nvim/lazy-lock.json` で更新後の lock をソースへ反映

既存 fish 関数のスタイルに合わせ、`nvim` / `chezmoi` の存在チェックと `$status` チェックを行う。

## メモ

- 反映には `chezmoi apply` でのデプロイが必要
- 動作確認は未実施（`fish -n` 構文チェックと `fish_indent` フォーマットは確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)