### PR TITLE
fix(claude): use rtk hook claude instead of legacy rtk-rewrite.sh

### DIFF
--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -38,7 +38,7 @@ forced_json="$(cat <<'JSON'
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/rtk-rewrite.sh"
+            "command": "rtk hook claude"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Update the RTK PreToolUse:Bash hook in `modify_settings.json.tmpl` from the legacy `~/.claude/hooks/rtk-rewrite.sh` path to `rtk hook claude`
- Aligns dotfiles with rtk 0.42.x, which no longer installs the shell script hook and instead uses the native binary command
- Fixes frequent non-blocking `PreToolUse:Bash hook error` messages on every Bash tool call

## Test plan
- [x] `chezmoi apply ~/.claude/settings.json` updates `~/.claude/settings.json` to use `rtk hook claude`
- [x] `echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | rtk hook claude` rewrites the command successfully
- [ ] Restart Claude Code and confirm Bash tool calls no longer emit `rtk-rewrite.sh: No such file or directory`


Made with [Cursor](https://cursor.com)