### PR TITLE
fix(fish): gcm でフェンス付き/単一オブジェクトの JSON 応答を許容

### DIFF
--- a/home/dot_config/fish/functions/gcm.fish
+++ b/home/dot_config/fish/functions/gcm.fish
@@ -21,10 +21,7 @@ Analyze the staged diff and split into the minimum number of semantically indepe
 - Single concern → one entry
 - Multiple independent concerns (e.g. feat + fix, or unrelated files) → multiple entries
 
-CRITICAL — output format:
-- Respond with raw JSON ONLY. The first character MUST be '[' and the last MUST be ']'.
-- Do NOT wrap the output in markdown code fences (no ```json, no ```).
-- Do NOT add any prose, comment, or explanation before or after the JSON.
+Output a JSON array of commit objects:
 
 [{\"message\": \"<type>[scope]: <description>\", \"files\": [\"path/to/file\"]}, ...]
 
@@ -86,7 +83,7 @@ function _gcm_call_claude
 
     set -l tmpfile (mktemp)
     printf '%s\n' "$conversation" >$tmpfile
-    set -l out (claude -p --model "$model" --system-prompt "$system_prompt" < $tmpfile 2>/dev/null)
+    set -l out (claude -p --model "$model" --system-prompt "$system_prompt" < $tmpfile 2>/dev/null | string collect)
     rm -f $tmpfile
 
     if test -z "$out"
@@ -94,13 +91,20 @@ function _gcm_call_claude
         return 1
     end
 
-    if not printf '%s' "$out" | jq '.' >/dev/null 2>&1
+    # The model may wrap the JSON in markdown code fences, and may return a single
+    # object instead of an array. Strip any ``` / ```json markers, then normalize a
+    # lone object into an array. Anything that is not an object/array is rejected.
+    set -l cleaned (printf '%s' "$out" \
+        | string replace -ra '```[a-zA-Z0-9]*' '' \
+        | jq -c 'if type == "object" then [.] elif type == "array" then . else empty end' 2>/dev/null)
+
+    if test -z "$cleaned"
         echo "不正なJSON出力を受け取りました:" >&2
         printf '%s\n' "$out" >&2
         return 1
     end
 
-    printf '%s' "$out"
+    printf '%s' "$cleaned"
 end
 
 function _gcm_display


### PR DESCRIPTION
## 概要

`gcm`（AI コミットメッセージ生成）で、`claude` が返す JSON を `jq` がパースできず失敗するバグを修正する。

## 問題

`claude` の応答が次のケースで `jq` パースに失敗していた:

1. **コードフェンス付き** — system_prompt で禁止していてもモデルが ```` ```json ... ``` ```` で囲むことがある。`不正なJSON出力を受け取りました` エラーになる。
2. **単一オブジェクト** — モデルが配列で包まず `{"message": ..., "files": [...]}` を返すと、`.[0].message` で `Cannot index string with string "message"` エラーになる。

## 修正

`_gcm_call_claude` で `claude` の出力を `string collect` で集約したうえで:

- `string replace` で Markdown コードフェンス（```` ``` ````/```` ```json ````）を除去
- `jq` で単一オブジェクトを配列へ正規化（`if type == "object" then [.] elif type == "array" then . else empty end`）
- オブジェクト/配列以外（不正な応答）は `empty` で弾き、既存の追加指示ループで再生成できるようにする

あわせて、フォーマット制約をコード側で吸収できるようになったため、system_prompt の出力フォーマット指示を簡潔化した。

## 検証

- 配列／単一オブジェクト × フェンス有無、値内の角括弧、不正文字列の拒否の各パターンを `fish` で確認
- `fish --no-execute` で構文 OK
- 実環境の `gcm` 実行で成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)