### PR TITLE
feat(fish): bat + fzf のファイル選択ショートカット bf を追加

### DIFF
--- a/home/dot_config/fish/conf.d/25-abbr.fish
+++ b/home/dot_config/fish/conf.d/25-abbr.fish
@@ -70,6 +70,7 @@ abbr --add gpup 'gh pr update-branch && git pull'
 
 # ========== bat ==========
 abbr --add b bat
+abbr --add bf 'bat (fzf)'
 
 # ========== claude ==========
 abbr --add c claude


### PR DESCRIPTION
## Summary

- `abbr --add bf 'bat (fzf)'` を追加
- `fzf` でファイルを選択し、`bat` でプレビュー表示するショートカット

## Test plan

- [ ] `bf` を実行して fzf が起動し、選択したファイルを bat で表示できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)