### PR TITLE
fix(release): PSR v9 の branches 設定を辞書形式に修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build_command = ""
 major_on_zero = false
 version_toml  = [ "pyproject.toml:project.version" ]
 
-[[tool.semantic_release.branches]]
+[tool.semantic_release.branches.main]
 match      = "main"
 prerelease = false
 


### PR DESCRIPTION
## 原因

`[[tool.semantic_release.branches]]`（TOML 配列）は PSR v9 が期待する辞書型と不一致でエラーになっていた。

```
1 validation error for RawConfig
branches
  Input should be a valid dictionary
```

## 修正

```toml
# Before (array of tables → list → NG)
[[tool.semantic_release.branches]]
match = "main"

# After (table → dict → OK)
[tool.semantic_release.branches.main]
match = "main"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)