### PR TITLE
chore: prepare release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,3 +185,8 @@
 * add workflow_dispatch trigger to release-please workflow ([#306](https://github.com/toshiki670/dotfiles/issues/306)) ([875bedf](https://github.com/toshiki670/dotfiles/commit/875bedf769334e17cfe35d89b0cc850ce3bfb220))
 * prepend Homebrew to fish PATH ([#301](https://github.com/toshiki670/dotfiles/issues/301)) ([04ed35c](https://github.com/toshiki670/dotfiles/commit/04ed35c1662d9f6a46c2c8e10cf95dcea3fc8161))
 * use PAT token for release-please to trigger CI on release PRs ([#307](https://github.com/toshiki670/dotfiles/issues/307)) ([69c8e7f](https://github.com/toshiki670/dotfiles/commit/69c8e7f03b1a6006ef686f19aca9ec9a0542b1fd))
+## 1.0.1 (2026-06-14)
+
+### Fixes
+
+- PSR v9 の branches 設定を辞書形式に修正 (#382)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name    = "dotfiles"
-version = "1.0.0"
+version = "1.0.1"
 
 [tool.ruff]
 line-length    = 88


### PR DESCRIPTION
Knope により作成された Release PR です。マージするとリリースが作成されます。

## Fixes

- PSR v9 の branches 設定を辞書形式に修正 (#382)