### PR TITLE
chore: Rust edition を 2024 に更新 (#388)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "toshiki670/dotfiles の CLI コマンド群"
-edition     = "2021"
+edition     = "2024"
 license     = "MIT"
 name        = "dotfiles"
 publish     = false


### PR DESCRIPTION
エピック #388。`Cargo.toml` の `edition` を `2021` → **`2024`** に更新（rust 1.96 で対応済み）。

build / clippy `-D warnings` / test / fmt / taplo すべて通過を確認。

Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)