### PR TITLE
feat(lint): lint オーケストレータを Rust 化し rumdl/mise を導入 (#388)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,3 +73,24 @@ jobs:
 
       - name: Lint runner tests
         run: nix run .#lint-tests
+
+  cargo-lint:
+    name: cargo lint (dotfiles-lint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup mise (rust + pinned linters)
+        uses: jdx/mise-action@v2
+
+      - name: Install fish (not supplied by mise)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fish
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run dotfiles-lint check
+        run: mise exec -- cargo run --quiet --bin dotfiles-lint -- check --summary

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,10 @@
+# rumdl: https://github.com/rvben/rumdl (markdownlint 互換の Rust 製 linter)
+# 旧 .markdownlint-cli2.yaml からの移行:
+#   MD013(行長) / MD033(インライン HTML) / MD041(先頭 H1) は README の
+#   バッジ/HTML・長行を許容するため無効。
+#   MD025(複数 H1) は README が `# Prerequisites` 等のセクション見出しに
+#   トップレベル見出しを意図的に使うため無効。
+# CHANGELOG.md は自動生成のため除外。
+[global]
+disable = [ "MD013", "MD025", "MD033", "MD041" ]
+exclude = [ "CHANGELOG.md" ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,12 +136,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "dotfiles"
 version = "0.68.0"
 dependencies = [
  "clap",
+ "ignore",
  "libc",
+ "tempfile",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -113,10 +246,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -125,10 +304,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -149,6 +362,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,16 +472,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-link"
@@ -191,3 +587,103 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ version     = "0.68.0"
 # （[[bin]] の明示は不要）。共有ロジックは src/lib.rs。
 
 [dependencies]
-clap = { version = "4", features = [ "derive" ] }
-libc = "0.2"
+clap     = { version = "4", features = [ "derive" ] }
+ignore   = "0.4"
+libc     = "0.2"
+tempfile = "3"
 
 [profile.release]
 strip = true

--- a/mise.toml
+++ b/mise.toml
@@ -3,13 +3,24 @@
 # fresh machine は mise で rust を取得してから chezmoi が cargo install する。
 rust = "latest"
 
+# lint オーケストレータが呼ぶフォーマッタ/リンタ群。
+# 再現性のため版をピンする（更新時は初回 `mise run lint` で差分を吸収）。
+# fish は brew 既存（mise では供給しない）。
+chezmoi    = "2.70.5"
+ruff       = "0.15.17"
+rumdl      = "0.2.16"
+shellcheck = "0.11.0"
+shfmt      = "3.13.1"
+stylua     = "2.5.2"
+taplo      = "0.10.0"
+
 [tasks.lint]
 description = "Run linter with auto-fix"
-run         = "nix run .#lint"
+run         = "cargo run --quiet --bin dotfiles-lint -- fix"
 
 [tasks.check]
 description = "Run linter check only"
-run         = "nix run .#check"
+run         = "cargo run --quiet --bin dotfiles-lint -- check"
 
 [tasks.release-prepare]
 description = "Trigger the Release Please workflow (creates a Release PR)"

--- a/src/bin/dotfiles-lint/main.rs
+++ b/src/bin/dotfiles-lint/main.rs
@@ -1,0 +1,86 @@
+//! dotfiles の lint オーケストレータ CLI。旧 `nix/lint.py` の移植。
+//!
+//! 使い方: `dotfiles-lint {fix|check} [--check-after-fix on|off] [--summary] [--json] [--verbose]`
+//! 通常は `mise run lint` / `mise run check` から `cargo run` 経由で呼ばれる。
+
+use std::process::ExitCode;
+
+use clap::{Parser, ValueEnum};
+
+use dotfiles::lint::{Mode, Orchestrator, collect_files, find_repo_root};
+
+#[derive(Clone, Copy, ValueEnum)]
+enum ModeArg {
+    Fix,
+    Check,
+}
+
+#[derive(Clone, Copy, ValueEnum, PartialEq, Eq)]
+enum Toggle {
+    On,
+    Off,
+}
+
+#[derive(Parser)]
+#[command(
+    name = "dotfiles-lint",
+    about = "dotfiles の lint/format オーケストレータ"
+)]
+struct Cli {
+    /// 実行モード。
+    mode: ModeArg,
+
+    /// fix の後に check を走らせるか（既定: on）。
+    #[arg(long, value_enum, default_value = "on")]
+    check_after_fix: Toggle,
+
+    /// 失敗サマリを表示する。
+    #[arg(long)]
+    summary: bool,
+
+    /// 失敗を JSON で表示する。
+    #[arg(long)]
+    json: bool,
+
+    /// 実行したコマンドを表示する。
+    #[arg(long)]
+    verbose: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
+    let repo_root = find_repo_root(&cwd);
+    let files = collect_files(&repo_root);
+
+    let tmp = match tempfile::tempdir() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("lint: failed to create temp dir: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mode = match cli.mode {
+        ModeArg::Fix => Mode::Fix,
+        ModeArg::Check => Mode::Check,
+    };
+    let check_after_fix = cli.check_after_fix == Toggle::On;
+
+    let mut orch = Orchestrator::new(repo_root, tmp.path().to_path_buf(), cli.verbose);
+    let failed = orch.run(mode, check_after_fix, &files);
+
+    if cli.summary {
+        orch.print_summary();
+    }
+    if cli.json {
+        orch.print_json(failed);
+    }
+
+    if failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! 各コマンドは `src/bin/<name>/main.rs` に置き、純粋に検証可能なロジックは
 //! ここへ切り出してユニットテスト対象にする。
 
+pub mod lint;
+
 /// `git remote` の出力（1 行 1 リモート名）に指定したリモートが含まれるか判定する。
 pub fn remote_exists(remotes_output: &str, name: &str) -> bool {
     remotes_output.lines().any(|line| line.trim() == name)

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,0 +1,571 @@
+//! dotfiles の lint オーケストレータ。旧 `nix/lint`（Python）の移植。
+//!
+//! ファイルを分類し、種別ごとに外部フォーマッタ/リンタを呼ぶ。chezmoi の
+//! `*.sh.tmpl` / `*.fish.tmpl` は `chezmoi execute-template` で展開してから検査する。
+//! ツール群（shfmt / shellcheck / taplo / stylua / rumdl / ruff / chezmoi / fish）は
+//! mise で供給される前提で、PATH 上の名前で実行する。
+
+mod classify;
+mod collect;
+
+pub use collect::{collect_files, find_repo_root};
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 実行モード。
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Fix,
+    Check,
+}
+
+/// 収集された 1 ファイル。
+pub struct FileContext {
+    pub rel_path: String,
+    pub abs_path: PathBuf,
+}
+
+/// 失敗 1 件の記録。
+pub struct Failure {
+    pub file: String,
+    pub rule: String,
+    pub phase: String,
+    pub command: String,
+    pub exit_code: i32,
+}
+
+/// lint 実行の文脈と失敗記録を保持する。
+pub struct Orchestrator {
+    repo_root: PathBuf,
+    tmp_dir: PathBuf,
+    verbose: bool,
+    pub failures: Vec<Failure>,
+}
+
+impl Orchestrator {
+    pub fn new(repo_root: PathBuf, tmp_dir: PathBuf, verbose: bool) -> Self {
+        Self {
+            repo_root,
+            tmp_dir,
+            verbose,
+            failures: Vec::new(),
+        }
+    }
+
+    /// fix / check を実行する。失敗があれば true を返す。
+    pub fn run(&mut self, mode: Mode, check_after_fix: bool, files: &[FileContext]) -> bool {
+        let mut failed = false;
+
+        if mode == Mode::Fix {
+            for f in files {
+                if self.fix_file(f) {
+                    failed = true;
+                }
+            }
+            println!("lint(fix): completed");
+        }
+
+        if mode == Mode::Check || check_after_fix {
+            for f in files {
+                if self.check_file(f) {
+                    failed = true;
+                }
+            }
+        }
+
+        failed
+    }
+
+    fn fix_file(&mut self, f: &FileContext) -> bool {
+        let mut failed = false;
+        if self.match_shell(f) && self.fix_shell(f) != 0 {
+            failed = true;
+        }
+        if classify::is_fish(&f.rel_path) && self.fix_fish(f) != 0 {
+            failed = true;
+        }
+        if classify::is_lua(&f.rel_path) && self.fix_lua(f) != 0 {
+            failed = true;
+        }
+        if self.match_python(f) && self.fix_python(f) != 0 {
+            failed = true;
+        }
+        if classify::is_toml(&f.rel_path) && self.fix_toml(f) != 0 {
+            failed = true;
+        }
+        if self.match_markdown(f) && self.fix_markdown(f) != 0 {
+            failed = true;
+        }
+        failed
+    }
+
+    fn check_file(&mut self, f: &FileContext) -> bool {
+        let mut failed = false;
+        if self.match_shell(f) && self.check_shell(f) != 0 {
+            failed = true;
+        }
+        if classify::is_fish(&f.rel_path) && self.check_fish(f) != 0 {
+            failed = true;
+        }
+        if classify::is_lua(&f.rel_path) && self.check_lua(f) != 0 {
+            failed = true;
+        }
+        if self.match_python(f) && self.check_python(f) != 0 {
+            failed = true;
+        }
+        if classify::is_toml(&f.rel_path) && self.check_toml(f) != 0 {
+            failed = true;
+        }
+        if self.match_markdown(f) && self.check_markdown(f) != 0 {
+            failed = true;
+        }
+        failed
+    }
+
+    // --- shell -------------------------------------------------------------
+
+    fn match_shell(&self, f: &FileContext) -> bool {
+        if !(classify::is_shell_ext(&f.rel_path) || classify::is_shell_path(&f.rel_path)) {
+            return false;
+        }
+        if classify::has_python_shebang(&f.abs_path) {
+            return false;
+        }
+        matches!(
+            classify::shell_flavor(&f.abs_path).as_str(),
+            "bash" | "sh" | ""
+        )
+    }
+
+    fn fix_shell(&mut self, f: &FileContext) -> i32 {
+        if classify::is_home_chezmoi_shell_template(&f.rel_path, &self.repo_root) {
+            return 0;
+        }
+        let abs = abs(f);
+        self.run_rule_cmd(
+            f,
+            "shell",
+            "fix",
+            &["shfmt", "-w", "-i", "2", "-ci", &abs],
+            None,
+            false,
+        )
+    }
+
+    fn check_shell(&mut self, f: &FileContext) -> i32 {
+        if classify::is_home_chezmoi_shell_template(&f.rel_path, &self.repo_root) {
+            let rendered = match self.render_template(&f.rel_path, ".sh") {
+                Some(p) => p.to_string_lossy().into_owned(),
+                None => return 1,
+            };
+            let mut failed = 0;
+            if self.run_rule_cmd(
+                f,
+                "shell",
+                "check",
+                &["shfmt", "-d", "-i", "2", "-ci", &rendered],
+                None,
+                false,
+            ) != 0
+            {
+                failed = 1;
+            }
+            if self.run_rule_cmd(f, "shell", "check", &["shellcheck", &rendered], None, true) != 0 {
+                failed = 1;
+            }
+            return failed;
+        }
+
+        let abs = abs(f);
+        let mut failed = 0;
+        if self.run_rule_cmd(
+            f,
+            "shell",
+            "check",
+            &["shfmt", "-d", "-i", "2", "-ci", &abs],
+            None,
+            false,
+        ) != 0
+        {
+            failed = 1;
+        }
+        if self.run_rule_cmd(f, "shell", "check", &["shellcheck", &abs], None, false) != 0 {
+            failed = 1;
+        }
+        failed
+    }
+
+    // --- fish --------------------------------------------------------------
+
+    fn fix_fish(&mut self, f: &FileContext) -> i32 {
+        if classify::is_home_chezmoi_fish_template(&f.rel_path, &self.repo_root) {
+            return 0;
+        }
+        let abs = abs(f);
+        let cmd = ["fish_indent", abs.as_str()];
+        if self.verbose {
+            println!("[fix:fish] {}: {}", f.rel_path, format_cmd(&cmd));
+        }
+        match capture(&cmd, None) {
+            Some((0, formatted, _)) => {
+                let current = std::fs::read(&f.abs_path)
+                    .map(|b| String::from_utf8_lossy(&b).into_owned())
+                    .unwrap_or_default();
+                if formatted != current {
+                    let _ = std::fs::write(&f.abs_path, formatted.as_bytes());
+                }
+                0
+            }
+            Some((code, _, _)) => {
+                self.record(f, "fish", "fix", &cmd, code);
+                1
+            }
+            None => {
+                self.record(f, "fish", "fix", &cmd, 1);
+                1
+            }
+        }
+    }
+
+    fn check_fish(&mut self, f: &FileContext) -> i32 {
+        let is_tmpl = classify::is_home_chezmoi_fish_template(&f.rel_path, &self.repo_root);
+        let target = if is_tmpl {
+            match self.render_template(&f.rel_path, ".fish") {
+                Some(p) => p.to_string_lossy().into_owned(),
+                None => return 1,
+            }
+        } else {
+            abs(f)
+        };
+
+        let mut failed = 0;
+        if !is_tmpl
+            && !classify::is_home_chezmoi_fish_completion_template(&f.rel_path, &self.repo_root)
+            && self.run_rule_cmd(
+                f,
+                "fish",
+                "check",
+                &["fish_indent", "--check", &target],
+                None,
+                false,
+            ) != 0
+        {
+            failed = 1;
+        }
+        if self.run_rule_cmd(
+            f,
+            "fish",
+            "check",
+            &["fish", "--no-execute", &target],
+            None,
+            false,
+        ) != 0
+        {
+            failed = 1;
+        }
+        failed
+    }
+
+    // --- lua ---------------------------------------------------------------
+
+    fn fix_lua(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "lua", "fix", &["stylua", &abs], None, false)
+    }
+
+    fn check_lua(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "lua", "check", &["stylua", "--check", &abs], None, false)
+    }
+
+    // --- python (ruff: Rust 製、Python ランタイム不要) ----------------------
+
+    fn match_python(&self, f: &FileContext) -> bool {
+        classify::is_python(&f.rel_path) || classify::has_python_shebang(&f.abs_path)
+    }
+
+    fn fix_python(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "python", "fix", &["ruff", "format", &abs], None, false)
+    }
+
+    fn check_python(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(
+            f,
+            "python",
+            "check",
+            &["ruff", "format", "--check", &abs],
+            None,
+            false,
+        )
+    }
+
+    // --- toml --------------------------------------------------------------
+
+    fn fix_toml(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "toml", "fix", &["taplo", "fmt", &abs], None, false)
+    }
+
+    fn check_toml(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        let mut failed = 0;
+        if self.run_rule_cmd(
+            f,
+            "toml",
+            "check",
+            &["taplo", "fmt", "--check", &abs],
+            None,
+            false,
+        ) != 0
+        {
+            failed = 1;
+        }
+        if self.run_rule_cmd(f, "toml", "check", &["taplo", "lint", &abs], None, false) != 0 {
+            failed = 1;
+        }
+        failed
+    }
+
+    // --- markdown (rumdl) --------------------------------------------------
+
+    /// CHANGELOG.md は自動生成のため除外する（.rumdl.toml の exclude と一致）。
+    fn match_markdown(&self, f: &FileContext) -> bool {
+        classify::is_markdown(&f.rel_path) && f.rel_path != "CHANGELOG.md"
+    }
+
+    fn fix_markdown(&mut self, f: &FileContext) -> i32 {
+        let root = self.repo_root.clone();
+        let rel = f.rel_path.clone();
+        self.run_rule_cmd(
+            f,
+            "markdown",
+            "fix",
+            &["rumdl", "check", "--fix", "--config", ".rumdl.toml", &rel],
+            Some(&root),
+            false,
+        )
+    }
+
+    fn check_markdown(&mut self, f: &FileContext) -> i32 {
+        let root = self.repo_root.clone();
+        let rel = f.rel_path.clone();
+        self.run_rule_cmd(
+            f,
+            "markdown",
+            "check",
+            &["rumdl", "check", "--config", ".rumdl.toml", &rel],
+            Some(&root),
+            false,
+        )
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    /// chezmoi テンプレートを展開して一時ファイルに書き出す。
+    fn render_template(&self, rel_path: &str, ext: &str) -> Option<PathBuf> {
+        let source_dir = self.repo_root.join("home");
+        let src = self.repo_root.join(rel_path);
+        let out_name = format!("rendered_{}{}", rel_path.replace(['/', '.'], "_"), ext);
+        let out = self.tmp_dir.join(out_name);
+
+        let output = Command::new("chezmoi")
+            .arg("-S")
+            .arg(&source_dir)
+            .arg("execute-template")
+            .arg("-f")
+            .arg(&src)
+            .output();
+
+        match output {
+            Ok(o) if o.status.success() => {
+                if std::fs::write(&out, &o.stdout).is_err() {
+                    return None;
+                }
+                Some(out)
+            }
+            Ok(o) => {
+                eprintln!("lint: chezmoi execute-template failed: {rel_path}");
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                if !stderr.trim().is_empty() {
+                    eprintln!("{}", stderr.trim_end());
+                }
+                None
+            }
+            Err(_) => {
+                eprintln!("lint: chezmoi execute-template failed: {rel_path}");
+                None
+            }
+        }
+    }
+
+    /// ルールのコマンドを実行し、非ゼロなら失敗を記録する。
+    fn run_rule_cmd(
+        &mut self,
+        f: &FileContext,
+        rule: &str,
+        phase: &str,
+        cmd: &[&str],
+        cwd: Option<&Path>,
+        shellcheck_hint: bool,
+    ) -> i32 {
+        if self.verbose {
+            let where_ = cwd
+                .map(|c| format!(" (cwd={})", c.display()))
+                .unwrap_or_default();
+            println!(
+                "[{phase}:{rule}] {}: {}{where_}",
+                f.rel_path,
+                format_cmd(cmd)
+            );
+        }
+
+        let mut command = Command::new(cmd[0]);
+        command.args(&cmd[1..]);
+        if let Some(c) = cwd {
+            command.current_dir(c);
+        }
+        let code = match command.status() {
+            Ok(status) => status.code().unwrap_or(1),
+            Err(_) => 1,
+        };
+
+        if code != 0 {
+            if shellcheck_hint {
+                eprintln!(
+                    "lint: shellcheck failed on expanded template (source: {})",
+                    f.rel_path
+                );
+            }
+            self.record(f, rule, phase, cmd, code);
+        }
+        code
+    }
+
+    fn record(&mut self, f: &FileContext, rule: &str, phase: &str, cmd: &[&str], code: i32) {
+        self.failures.push(Failure {
+            file: f.rel_path.clone(),
+            rule: rule.to_string(),
+            phase: phase.to_string(),
+            command: format_cmd(cmd),
+            exit_code: code,
+        });
+    }
+
+    pub fn print_summary(&self) {
+        println!("lint: failures={}", self.failures.len());
+        for r in &self.failures {
+            println!(
+                "- {}:{} {} -> ({}) {}",
+                r.phase, r.rule, r.file, r.exit_code, r.command
+            );
+        }
+    }
+
+    pub fn print_json(&self, failed: bool) {
+        let mut items = Vec::with_capacity(self.failures.len());
+        for r in &self.failures {
+            items.push(format!(
+                "{{\"file\":{},\"rule\":{},\"phase\":{},\"command\":{},\"exitCode\":{}}}",
+                json_str(&r.file),
+                json_str(&r.rule),
+                json_str(&r.phase),
+                json_str(&r.command),
+                r.exit_code,
+            ));
+        }
+        println!(
+            "{{\"failed\":{},\"failureCount\":{},\"failures\":[{}]}}",
+            i32::from(failed),
+            self.failures.len(),
+            items.join(",")
+        );
+    }
+}
+
+/// FileContext の絶対パスを String にする。
+fn abs(f: &FileContext) -> String {
+    f.abs_path.to_string_lossy().into_owned()
+}
+
+/// コマンドを表示用にシェルクオートして連結する。
+fn format_cmd(cmd: &[&str]) -> String {
+    cmd.iter()
+        .map(|part| shell_quote(part))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | '=' | ':'))
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// コマンドを実行し (exit code, stdout, stderr) を返す。
+fn capture(cmd: &[&str], cwd: Option<&Path>) -> Option<(i32, String, String)> {
+    let mut command = Command::new(cmd[0]);
+    command.args(&cmd[1..]);
+    if let Some(c) = cwd {
+        command.current_dir(c);
+    }
+    let output = command.output().ok()?;
+    Some((
+        output.status.code().unwrap_or(1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_leaves_simple_words() {
+        assert_eq!(shell_quote("shfmt"), "shfmt");
+        assert_eq!(shell_quote("-i"), "-i");
+        assert_eq!(shell_quote("/a/b.sh"), "/a/b.sh");
+    }
+
+    #[test]
+    fn shell_quote_wraps_spaces() {
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn format_cmd_joins() {
+        assert_eq!(format_cmd(&["shfmt", "-w", "x y"]), "shfmt -w 'x y'");
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("a\"b\\c"), "\"a\\\"b\\\\c\"");
+    }
+}

--- a/src/lint/classify.rs
+++ b/src/lint/classify.rs
@@ -1,0 +1,126 @@
+//! ファイルの分類判定。旧 `nix/lint/classify.py` の移植。
+//!
+//! 拡張子・パスベースの判定はファイル名（リポジトリ相対）に対して行い、
+//! 内容ベースの判定（chezmoi マーカー・shebang）は実ファイルを読む。
+
+use std::path::Path;
+
+/// ファイルの先頭行を返す（読めなければ空文字）。
+fn first_line(path: &Path) -> String {
+    std::fs::read(path)
+        .ok()
+        .map(|bytes| {
+            let text = String::from_utf8_lossy(&bytes);
+            text.lines().next().unwrap_or("").to_string()
+        })
+        .unwrap_or_default()
+}
+
+pub fn is_markdown(f: &str) -> bool {
+    f.ends_with(".md")
+}
+
+pub fn is_lua(f: &str) -> bool {
+    f.ends_with(".lua")
+}
+
+pub fn is_toml(f: &str) -> bool {
+    f.ends_with(".toml")
+}
+
+pub fn is_python(f: &str) -> bool {
+    f.ends_with(".py")
+}
+
+pub fn is_fish(f: &str) -> bool {
+    f.ends_with(".fish") || f.ends_with(".fish.tmpl")
+}
+
+pub fn is_shell_ext(f: &str) -> bool {
+    f.ends_with(".sh") || f.ends_with(".sh.tmpl")
+}
+
+pub fn is_shell_path(f: &str) -> bool {
+    f.starts_with("bin/") || f.starts_with("bash/")
+}
+
+/// ファイルに chezmoi テンプレートマーカー `{{` を含むか。
+pub fn has_chezmoi_markers(path: &Path) -> bool {
+    std::fs::read(path)
+        .map(|bytes| String::from_utf8_lossy(&bytes).contains("{{"))
+        .unwrap_or(false)
+}
+
+pub fn is_home_chezmoi_shell_template(f: &str, repo_root: &Path) -> bool {
+    f.starts_with("home/") && f.ends_with(".sh.tmpl") && has_chezmoi_markers(&repo_root.join(f))
+}
+
+pub fn is_home_chezmoi_fish_template(f: &str, repo_root: &Path) -> bool {
+    f.starts_with("home/") && f.ends_with(".fish.tmpl") && has_chezmoi_markers(&repo_root.join(f))
+}
+
+pub fn is_home_chezmoi_fish_completion_template(f: &str, repo_root: &Path) -> bool {
+    is_home_chezmoi_fish_template(f, repo_root) && f.contains("dot_config/fish/completions/")
+}
+
+/// 先頭行が python の shebang か。
+pub fn has_python_shebang(path: &Path) -> bool {
+    let first = first_line(path);
+    first.starts_with("#!") && first.contains("python")
+}
+
+/// shebang から shell 種別を判定する（"bash" / "sh" / ""）。
+pub fn shell_flavor(path: &Path) -> String {
+    let first = first_line(path);
+    if first.contains("bash") {
+        "bash".to_string()
+    } else if first.starts_with("#!") && first.ends_with("sh") {
+        "sh".to_string()
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_predicates() {
+        assert!(is_markdown("README.md"));
+        assert!(is_lua("a.lua"));
+        assert!(is_toml("Cargo.toml"));
+        assert!(is_python("x.py"));
+        assert!(is_fish("f.fish"));
+        assert!(is_fish("f.fish.tmpl"));
+        assert!(is_shell_ext("s.sh"));
+        assert!(is_shell_ext("s.sh.tmpl"));
+        assert!(!is_toml("starship.toml.tmpl"));
+    }
+
+    #[test]
+    fn shell_path_predicate() {
+        assert!(is_shell_path("bin/foo"));
+        assert!(is_shell_path("bash/bar"));
+        assert!(!is_shell_path("home/bin/foo"));
+    }
+
+    #[test]
+    fn content_predicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmpl = dir.path().join("x.sh.tmpl");
+        std::fs::write(&tmpl, "#!/bin/bash\necho {{ .chezmoi.os }}\n").unwrap();
+        assert!(has_chezmoi_markers(&tmpl));
+        assert_eq!(shell_flavor(&tmpl), "bash");
+
+        let py = dir.path().join("p");
+        std::fs::write(&py, "#!/usr/bin/env python3\nprint(1)\n").unwrap();
+        assert!(has_python_shebang(&py));
+        assert_eq!(shell_flavor(&py), String::new());
+
+        let sh = dir.path().join("s");
+        std::fs::write(&sh, "#!/bin/sh\necho hi\n").unwrap();
+        assert_eq!(shell_flavor(&sh), "sh");
+        assert!(!has_python_shebang(&sh));
+    }
+}

--- a/src/lint/collect.rs
+++ b/src/lint/collect.rs
@@ -1,0 +1,114 @@
+//! リポジトリのファイル収集。旧 `nix/lint/collect.py` の移植。
+//!
+//! `.gitignore` を尊重し、`.git` / `.cursor` を除外する。収集は `ignore`
+//! クレート（ripgrep と同じ実装）に任せる。
+
+use std::path::{Path, PathBuf};
+
+use ignore::WalkBuilder;
+
+use super::FileContext;
+
+/// `Cargo.toml` を上方向に探してリポジトリルートを決める。
+///
+/// 旧実装は `flake.nix` を目印にしていたが、Nix 撤去後も安定する
+/// `Cargo.toml`（version の単一 SoT）に変更した。
+pub fn find_repo_root(start: &Path) -> PathBuf {
+    let canonical = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
+    let mut cur = canonical.as_path();
+    loop {
+        if cur.join("Cargo.toml").is_file() {
+            return cur.to_path_buf();
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => return canonical.clone(),
+        }
+    }
+}
+
+/// リポジトリ配下のファイルを `.gitignore` 準拠で収集する。
+pub fn collect_files(repo_root: &Path) -> Vec<FileContext> {
+    let mut out = Vec::new();
+    let walker = WalkBuilder::new(repo_root)
+        .hidden(false) // .github/ や .markdownlint 系の dotfile も対象
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(false)
+        .parents(false)
+        .filter_entry(|entry| {
+            let name = entry.file_name();
+            name != ".git" && name != ".cursor"
+        })
+        .build();
+
+    for result in walker {
+        let entry = match result {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        if !entry.file_type().is_some_and(|t| t.is_file()) {
+            continue;
+        }
+        let abs = entry.path();
+        let rel = match abs.strip_prefix(repo_root) {
+            Ok(rel) => rel.to_string_lossy().replace('\\', "/"),
+            Err(_) => continue,
+        };
+        out.push(FileContext {
+            rel_path: rel,
+            abs_path: abs.to_path_buf(),
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    #[test]
+    fn collect_respects_gitignore_and_skips_special_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // .gitignore は git リポジトリ内でのみ効くため init する。
+        Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .current_dir(root)
+            .status()
+            .unwrap();
+
+        fs::write(root.join(".gitignore"), "build/\n*.log\n").unwrap();
+        fs::write(root.join("a.md"), "# a\n").unwrap();
+        fs::write(root.join("y.log"), "noise\n").unwrap();
+        fs::create_dir_all(root.join("build")).unwrap();
+        fs::write(root.join("build/x.toml"), "k = 1\n").unwrap();
+        fs::create_dir_all(root.join("sub")).unwrap();
+        fs::write(root.join("sub/b.fish"), "echo hi\n").unwrap();
+        fs::create_dir_all(root.join(".cursor")).unwrap();
+        fs::write(root.join(".cursor/z.md"), "# z\n").unwrap();
+
+        let mut got: Vec<String> = collect_files(root)
+            .into_iter()
+            .map(|f| f.rel_path)
+            .collect();
+        got.sort();
+
+        assert!(got.contains(&"a.md".to_string()));
+        assert!(got.contains(&"sub/b.fish".to_string()));
+        assert!(got.contains(&".gitignore".to_string()));
+        assert!(
+            !got.iter().any(|p| p.starts_with("build/")),
+            "build/ ignored"
+        );
+        assert!(!got.contains(&"y.log".to_string()), "*.log ignored");
+        assert!(
+            !got.iter().any(|p| p.starts_with(".cursor")),
+            ".cursor skipped"
+        );
+        assert!(!got.iter().any(|p| p.starts_with(".git/")), ".git skipped");
+    }
+}


### PR DESCRIPTION
## 概要

エピック #388 の **フェーズ 3 / 7**（最大フェーズ）。lint を **cargo + mise + rumdl** ベースへ移行する。マージ先は Epic 統合ブランチ。

本 PR は **新旧 lint が共存する追加構成**。Nix/Python の lint 一式・`markdownlint-cli2`・taplo schema vendoring の撤去は後続 **PR5（Nix 撤去）** に分離した（`taplo.toml` の `@starshipSchemaPath@` は Nix の `replaceVars` と結合しており、変更すると Nix lint が壊れるため、vendoring は Nix 撤去と不可分）。よって CI は新（cargo-lint）・旧（Nix flake check）の両方が green のまま。

## 変更内容

- **`src/bin/dotfiles-lint` + `src/lint{,/classify,/collect}`**: 旧 `nix/lint`（Python）のオーケストレータを Rust 移植。
  - `ignore` クレートで `.gitignore` 準拠の収集（`.git`/`.cursor` 除外）。
  - 拡張子・パス・内容（chezmoi `{{` マーカー / shebang）で分類。
  - chezmoi `*.sh.tmpl` / `*.fish.tmpl` は `chezmoi execute-template` で展開してから検査（現挙動を踏襲）。
  - `fix` / `check` モード、`--summary` / `--json` / `--verbose`。
- **markdown を `markdownlint-cli2` → `rumdl`**（`.rumdl.toml`）。旧設定（MD013/033/041 無効）に加え **MD025 も無効化**して README の意図的な複数 H1 を保持、CHANGELOG は除外。
- **`mise.toml [tools]` に linter 群を版ピンで供給**（chezmoi 2.70.5 / ruff 0.15.17 / rumdl 0.2.16 / shellcheck 0.11.0 / shfmt 3.13.1 / stylua 2.5.2 / taplo 0.10.0）。`fish` は brew 既存、`ruff` は Rust 製で Python ランタイム不要。
- **`mise` の `lint`/`check` タスクを `cargo run --bin dotfiles-lint` へ**。
- **`.github/workflows/lint.yml` に `cargo-lint` ジョブ追加**（mise でツール供給 + fish を apt 導入 → `dotfiles-lint check`）。

## 検証（ローカル）

- `cargo fmt --check` / `clippy -D warnings` / `cargo test`（**12 tests**: classify / collect(gitignore 準拠) / helpers）。
- **ピン版ツールでの初回一括整形 `dotfiles-lint fix` は既存 dotfiles に変更ゼロ**（移行 churn なし＝ピン版の整形が既存コミットと一致）。
- `dotfiles-lint check --summary` → **EXIT=0 / failures=0**。
- rumdl 移行は全 `.md` で content 変更なし、taplo の vendored schema 検証（PoC-B）も別途確認済み（PR5 で導入）。

## PR5 へ繰り越し

`flake.nix`/`flake.lock`/`nix/`・`tests/lint`・`pyproject.toml`・`.markdownlint-cli2.yaml`・`bin/sync-starship-config-schema` の削除、Nix CI ジョブ撤去、taplo starship schema の vendoring（`schemas/` + `taplo.toml` 相対パス化 + `mise run update-starship-schema`）。

Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)