### PR TITLE
feat: gh-clone を Rust バイナリ + 薄い fish shim へ（B 群定石） (#388)

### DIFF
--- a/home/dot_config/fish/functions/gh-clone.fish
+++ b/home/dot_config/fish/functions/gh-clone.fish
@@ -1,31 +1,8 @@
+# gh-clone のロジックは Rust バイナリ（src/bin/gh-clone, ~/.cargo/bin）に移した。
+# 別プロセスでは親シェルの cd を変えられないため、ここはバイナリが出力した
+# 移設先パスへ cd するだけの薄い shim（zoxide / starship と同じ定石）。
 function gh-clone --description 'Clone repository via gh and migrate with ghq'
-    if not command -q gh
-        echo "gh-clone: gh command not found." >&2
-        return 127
-    end
-
-    if not command -q ghq
-        echo "gh-clone: ghq command not found." >&2
-        return 127
-    end
-
-    if test (count $argv) -lt 1
-        echo "Usage: gh-clone <owner/repo>" >&2
-        return 1
-    end
-
-    set -l repo_spec "$argv[1]"
-
-    command gh repo clone "$repo_spec"
-    if test $status -ne 0
-        return $status
-    end
-
-    set -l repo_dir (path basename -- "$repo_spec")
-    set -l migrated_path (command ghq migrate -y "$repo_dir")
-    if test $status -ne 0
-        return $status
-    end
-
-    cd "$migrated_path"
+    set -l migrated_path (command gh-clone $argv)
+    or return
+    test -n "$migrated_path"; and cd "$migrated_path"
 end

--- a/src/bin/gh-clone/main.rs
+++ b/src/bin/gh-clone/main.rs
@@ -1,0 +1,73 @@
+//! `gh repo clone` してから `ghq migrate` でリポジトリを移設し、移設先パスを
+//! stdout に出力する。旧 `gh-clone.fish` のロジック部分。
+//!
+//! 親シェルの cd は別プロセスから行えないため、移設先パスを stdout に出し、
+//! 薄い fish shim（gh-clone.fish）が `cd` する（shim 定石）。stdout はパスのみ、
+//! それ以外（gh/ghq の進捗）は stderr に出す。
+
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::{Command, ExitCode, Stdio};
+
+use dotfiles::command_exists;
+
+fn main() -> ExitCode {
+    if !command_exists("gh") {
+        eprintln!("gh-clone: gh command not found.");
+        return ExitCode::from(127);
+    }
+    if !command_exists("ghq") {
+        eprintln!("gh-clone: ghq command not found.");
+        return ExitCode::from(127);
+    }
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("Usage: gh-clone <owner/repo>");
+        return ExitCode::FAILURE;
+    }
+    let repo_spec = &args[0];
+
+    // gh repo clone: 進捗は stderr 継承。gh の stdout は捕捉して stderr に流し、
+    // 本プロセスの stdout（= 移設先パス）を汚さない。
+    let clone = match Command::new("gh")
+        .args(["repo", "clone", repo_spec])
+        .stderr(Stdio::inherit())
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => {
+            eprintln!("gh-clone: failed to run gh");
+            return ExitCode::FAILURE;
+        }
+    };
+    let _ = io::stderr().write_all(&clone.stdout);
+    if !clone.status.success() {
+        return ExitCode::from(clone.status.code().unwrap_or(1) as u8);
+    }
+
+    // path basename 相当。
+    let repo_dir = Path::new(repo_spec)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| repo_spec.clone());
+
+    let migrate = match Command::new("ghq")
+        .args(["migrate", "-y", &repo_dir])
+        .stderr(Stdio::inherit())
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => {
+            eprintln!("gh-clone: failed to run ghq");
+            return ExitCode::FAILURE;
+        }
+    };
+    if !migrate.status.success() {
+        return ExitCode::from(migrate.status.code().unwrap_or(1) as u8);
+    }
+
+    let migrated_path = String::from_utf8_lossy(&migrate.stdout).trim().to_string();
+    println!("{migrated_path}");
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
## 概要

エピック #388 の fish 移行（**B 群**）。別プロセスの Rust バイナリは親シェルの `cd` を変えられないため、B 群は **「ロジックは Rust バイナリ、`cd` の一行だけ fish shim に残す」定石**（zoxide / starship と同じ）で移行する。その**最初の例**として `gh-clone` を実装し、shim 定石を確立する。マージ先は Epic 統合ブランチ。

## 変更内容

- **`src/bin/gh-clone`**: `gh repo clone` → `ghq migrate` を実行し、**移設先パスを stdout に出力**（gh/ghq の進捗など他の出力は stderr へ）。gh/ghq 不在時 127・`Usage`・終了コードを踏襲。
- **`gh-clone.fish` を薄い shim に書き換え**（fish 関数は残す）:
  ```fish
  set -l migrated_path (command gh-clone $argv)
  or return
  test -n "$migrated_path"; and cd "$migrated_path"
  ```
  `command gh-clone` で同名 Rust バイナリ（`~/.cargo/bin`）を呼び、出力パスへ `cd` する。

## 検証（ローカル）

- `cargo fmt --check` / `clippy -D warnings` / `cargo test`（19）。
- `gh-clone` 引数無し → `Usage` + exit 1。
- 書き換えた `gh-clone.fish` は **fish lint（`fish_indent` / `fish --no-execute`）通過**、`dotfiles-lint check` → EXIT=0。

## B 群の残り（後続、同じ定石）

`__fzf_worktree_list` の lib 化（`git worktree list --porcelain` パーサ）+ `_fzf_ghq_cd` / `_fzf_worktree_remove` / `cdabbr`。`_fzf_file` は小さく fish 据え置き可。C 群（`ps-grep` / `_fzf_history`）は fish 据え置き。

Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)