### PR TITLE
docs: README / CLAUDE.md を Rust クレート構成へ更新 (#388)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## リポジトリ構造
 
-chezmoi で管理。`home/` がソースで `chezmoi apply` でホームディレクトリへデプロイされる（`home/dot_config/` → `~/.config/`）。`home/.chezmoiscripts/` に apply 前後のフック（パッケージアップグレード、シンボリックリンク作成、ヘルスチェック）がある。
+chezmoi で管理。`home/` がソースで `chezmoi apply` でホームディレクトリへデプロイされる（`home/dot_config/` → `~/.config/`）。`home/.chezmoiscripts/` に apply 前後のフック（パッケージアップグレード、シンボリックリンク作成、ヘルスチェック、cargo install）がある。
 
-- セットアップ・ツール一覧 → [README.md](README.md)
+CLI コマンドの一部はリポジトリルートの **Rust クレート**（`Cargo.toml` / `src/bin/<name>/` / 共有は `src/lib.rs`、version SoT）。`chezmoi apply` のフックが `cargo install` で `~/.cargo/bin` へ配布する。lint/format は Rust 製オーケストレータ `dotfiles-lint`（`mise run lint` / `check`）が mise 供給のツール（shfmt / shellcheck / taplo / stylua / rumdl / ruff / chezmoi）を呼ぶ。リリースは release-plz（git タグ + GitHub Release、crates.io へは publish しない）。
+
+- セットアップ・ツール一覧・Rust コマンド → [README.md](README.md)
 - lint/check・テスト・リリース手順 → [CONTRIBUTING.md](CONTRIBUTING.md)
 - バージョニングルール → [CONTRIBUTING.md](CONTRIBUTING.md#リリースプロセス)
 - カラーテーマ設定の一覧・変更手順 → [COLOR.md](COLOR.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Simplification of environment construction
 - Unification of environment across multiple platforms
 
-This repository is managed with [chezmoi](https://www.chezmoi.io/). **Fish** is the shell (`~/.config/fish/conf.d/`), with **[Starship](https://starship.rs/)** as the interactive prompt. Also included: **Neovim**, **Git** (split config + delta), **mise**, optional **Ghostty** / **Zellij** configs, and scripts under `bin/`.
+This repository is managed with [chezmoi](https://www.chezmoi.io/). **Fish** is the shell (`~/.config/fish/conf.d/`), with **[Starship](https://starship.rs/)** as the interactive prompt. Also included: **Neovim**, **Git** (split config + delta), **mise**, optional **Ghostty** / **Zellij** configs, a few scripts under `bin/`, and small **Rust** CLI commands (`color`, `git-upstream`, `gcm`, `copy-obj`, `v-sync`, …) built from the repository-root crate and installed via `cargo install` into `~/.cargo/bin` (see [Rust commands](#rust-commands)).
 
 # Prerequisites
 
@@ -131,9 +131,24 @@ On macOS, `chezmoi apply` runs a hook that symlinks Ghostty’s expected config 
 ### macOS
 
 - Homebrew configurations will be applied automatically
-- Custom binaries in `bin/` will be added to PATH
+- Scripts under `bin/` (`$DOTFILES/bin`) and Rust commands (`~/.cargo/bin`) are added to PATH
 - Ghostty config symlink is set up as described above
+
+# Rust commands
+
+Several CLI commands are written in Rust and live in the repository-root crate (`Cargo.toml`, `src/bin/<name>/`). On `chezmoi apply`, a hook (`run_onchange_after_cargo-install`) runs `cargo install --path . --locked` to build them into `~/.cargo/bin`. The Rust toolchain and the lint tools are supplied by **mise** (`mise.toml`), so a fresh machine bootstraps as: `mise install` (rust) → `chezmoi apply` (cargo install).
+
+| Command | Description |
+| --- | --- |
+| `color` | Print an ANSI color table (16 + 256 colors) |
+| `git-upstream` | Merge `upstream/master` / initialize the upstream remote |
+| `gcm` | AI-powered git commit with Conventional Commits (`claude -p`) |
+| `copy-obj` | Copy a file as a Finder-pasteable file object (macOS) |
+| `v-sync` | Sync Neovim plugins and re-add `lazy-lock.json` into chezmoi |
+| `dotfiles-lint` | Lint/format orchestrator (run via `mise run lint` / `mise run check`) |
+
+`gcm` / `gh-clone` keep a thin Fish shim for the parts that must change the parent shell (`cd`), with the logic in the Rust binary.
 
 # Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for lint, test, and release instructions. To trigger a release directly: [Run Release Workflow](https://github.com/toshiki670/dotfiles/actions/workflows/release.yml).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for lint, test, and release instructions. To trigger a release directly: [Run Release Prepare Workflow](https://github.com/toshiki670/dotfiles/actions/workflows/release-prepare.yml).


### PR DESCRIPTION
## 概要

エピック #388 の **フェーズ 7 / 7（ドキュメント）**。新しい構成（Rust クレート・cargo install 配布・mise・release-plz）を反映する。マージ先は Epic 統合ブランチ。これで Epic→main マージ前のドキュメントが揃う。

## 変更内容

- **README.md**:
  - 概要に Rust 製 CLI コマンドを追記し、**「Rust commands」節**を新設（`color` / `git-upstream` / `gcm` / `copy-obj` / `v-sync` / `dotfiles-lint` の表、cargo install × chezmoi フックでの配布、mise でのツール供給、`gcm` / `gh-clone` の薄い shim を説明）。
  - **存在しない `release.yml` へのリンクを `release-prepare.yml` へ修正**。
  - PATH の説明（`$DOTFILES/bin` + `~/.cargo/bin`）を更新。
- **CLAUDE.md**: リポジトリ構造に**ルート Rust クレート**・cargo install 配布・`dotfiles-lint`（mise 供給ツール）・release-plz を追記。

`CONTRIBUTING.md` は PR3 / PR5 / PR6 で更新済み。`bug_report.md` は汎用で陳腐化なし。

## 検証

- `dotfiles-lint check` → **EXIT=0 / failures=0**（README / CLAUDE.md が rumdl 通過）。
- 陳腐化参照（`release-please` / `nix` / `flake` / `markdownlint` / `release.yml` / `.#lint`）が全ドキュメントから消えていることを確認。

Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)