### PR TITLE
fix(release): release-plz を git_only モードにして空 Release PR を解消

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,16 +1,23 @@
 # release-plz: https://release-plz.dev/
 # Cargo workspace モード。配布物（root dotfiles + 各コマンド + workers）と support lib は
 # 独立版を振り、per-package で git タグ + GitHub Release + CHANGELOG を生成する。
-# crates.io へは publish しない（`publish = false`）。
+# crates.io へは publish しない。
+#
+# `git_only = true`: 最新リリース版の判定を「git タグ」から行う（crates.io を参照しない）。
+# これが本リポジトリの設計（per-package タグ = 版の SoT）。
+# 注意: 単に `publish = false` だけだと cargo publish は止まるが、release-plz は
+# 「最新リリースの判定」に依然 crates.io を参照する。本クレート群は crates.io に
+# 存在しないため版の基準を確立できず、Release PR が空になる（{"prs":[]}）。
+# `git_only = true` は publish もスキップするので `publish = false` を内包する。
 [workspace]
 changelog_config   = "cliff.toml"
 changelog_update   = true
+git_only           = true
 git_release_draft  = false
 git_release_enable = true
 # member の既定タグ。複数パッケージ workspace の既定値を明示しておく。
 git_tag_name     = "{{ package }}-v{{ version }}"
 pr_branch_prefix = "release-"
-publish          = false
 
 # root package = `dotfiles` 本体（core）。タグは従来どおり `v{version}` を維持する
 # （0.68.0 からの連続。`git_tag_name` を root だけ上書き）。


### PR DESCRIPTION
## 概要

`mise release-prepare`（= `release-plz/action` の `release-pr`）を実行しても **Release PR が作られない** 不具合を修正する。

該当 run: https://github.com/toshiki670/dotfiles/actions/runs/27560701860
ログでは release-plz がエラーなく以下を出力していた:

```
INFO using release-plz config file release-plz.toml
release_pr_output: {"prs":[]}
```

## 原因

`release-plz.toml` が `publish = false` のみで `git_only` 未設定だった。

release-plz 公式ドキュメント（`publish` フィールド）より:

> With this option disabled, release-plz will continue creating git tags. However, note that **release-plz will still use the cargo registry to check what's the latest release**, so you still need to run `cargo publish` by yourself.

つまり `publish = false` は `cargo publish` を止めるだけで、「最新リリース版が何か」の判定には **依然 crates.io を参照** する。本リポジトリのクレート群（`dotfiles` / `color` / `gh-clone` …）は crates.io に存在せず `Cargo.toml` 側も `publish = false` のため、release-plz は版の基準を確立できず全パッケージが「変更なし」扱いとなり、Release PR が空になっていた。

## 修正

`[workspace]` に `git_only = true` を追加（`publish = false` を置き換え）。

- 版判定を **git タグ** から行う ＝ 本リポジトリの設計（per-package タグ = 版の SoT）どおり
- `git_only = true` は `cargo publish` も自動でスキップするため `publish = false` を内包する
- `crates/*/Cargo.toml` 側の `publish = false` は誤 publish 防止として残置
- `dotfiles-lint`（`release = false`）は引き続き処理対象外で影響なし

## 期待される挙動

マージ後に再度 `mise release-prepare` を実行すると:

- root `dotfiles`: タグ `v0.68.0` を基準に次版へ bump
- 新クレート: タグ無しのため `0.1.0` で初回リリース

として Release PR が作成される。

## 検証

ローカルでの release-plz 実行は環境制約（外部バイナリ実行不可）で未実施。本ブランチをマージ後にワークフローを再実行して Release PR 生成を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)