### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/color/CHANGELOG.md
+++ b/crates/color/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/crates/copy-obj/CHANGELOG.md
+++ b/crates/copy-obj/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/crates/dotfiles-workers/CHANGELOG.md
+++ b/crates/dotfiles-workers/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+### Fixes
+- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
+

--- a/crates/gcm/CHANGELOG.md
+++ b/crates/gcm/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/crates/gh-clone/CHANGELOG.md
+++ b/crates/gh-clone/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+### Fixes
+- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
+

--- a/crates/git-upstream/CHANGELOG.md
+++ b/crates/git-upstream/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/crates/v-sync/CHANGELOG.md
+++ b/crates/v-sync/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+### Fixes
+- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
+


### PR DESCRIPTION



## 🤖 New release

* `color`: 0.1.0
* `copy-obj`: 0.1.0
* `dotfiles-workers`: 0.1.0
* `gcm`: 0.1.0
* `gh-clone`: 0.1.0
* `git-upstream`: 0.1.0
* `v-sync`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>



## `dotfiles-workers`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>


## `gh-clone`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>


## `v-sync`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).