### PR TITLE
fix(lint): per-package CHANGELOG.md も markdown lint から除外

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -4,7 +4,7 @@
 #   バッジ/HTML・長行を許容するため無効。
 #   MD025(複数 H1) は README が `# Prerequisites` 等のセクション見出しに
 #   トップレベル見出しを意図的に使うため無効。
-# CHANGELOG.md は自動生成のため除外。
+# CHANGELOG.md は自動生成のため除外（root・各クレート直下の per-package とも）。
 [global]
 disable = [ "MD013", "MD025", "MD033", "MD041" ]
-exclude = [ "CHANGELOG.md" ]
+exclude = [ "CHANGELOG.md", "**/CHANGELOG.md" ]

--- a/tools/dotfiles-lint/src/lint.rs
+++ b/tools/dotfiles-lint/src/lint.rs
@@ -331,9 +331,10 @@ impl Orchestrator {
 
     // --- markdown (rumdl) --------------------------------------------------
 
-    /// CHANGELOG.md は自動生成のため除外する（.rumdl.toml の exclude と一致）。
+    /// CHANGELOG.md は自動生成のため除外する（root・各クレート直下の per-package
+    /// とも。.rumdl.toml の exclude と一致）。
     fn match_markdown(&self, f: &FileContext) -> bool {
-        classify::is_markdown(&f.rel_path) && f.rel_path != "CHANGELOG.md"
+        classify::is_markdown(&f.rel_path) && !classify::is_changelog(&f.rel_path)
     }
 
     fn fix_markdown(&mut self, f: &FileContext) -> i32 {

--- a/tools/dotfiles-lint/src/lint/classify.rs
+++ b/tools/dotfiles-lint/src/lint/classify.rs
@@ -20,6 +20,11 @@ pub fn is_markdown(f: &str) -> bool {
     f.ends_with(".md")
 }
 
+/// 自動生成の CHANGELOG.md か（root・各クレート直下の per-package とも対象）。
+pub fn is_changelog(f: &str) -> bool {
+    f == "CHANGELOG.md" || f.ends_with("/CHANGELOG.md")
+}
+
 pub fn is_lua(f: &str) -> bool {
     f.ends_with(".lua")
 }
@@ -88,6 +93,10 @@ mod tests {
     #[test]
     fn extension_predicates() {
         assert!(is_markdown("README.md"));
+        assert!(is_changelog("CHANGELOG.md"));
+        assert!(is_changelog("crates/gh-clone/CHANGELOG.md"));
+        assert!(!is_changelog("README.md"));
+        assert!(!is_changelog("docs/CHANGELOG.md.bak"));
         assert!(is_lua("a.lua"));
         assert!(is_toml("Cargo.toml"));
         assert!(is_python("x.py"));


### PR DESCRIPTION
## 概要

release-plz が生成する `crates/*/CHANGELOG.md` が markdown lint（rumdl）で落ち、Release PR #410 の `cargo lint (dotfiles-lint)` ジョブが失敗していた。

失敗ログ（[run](https://github.com/toshiki670/dotfiles/actions/runs/27586892275/job/81559128609)）:

```
crates/gh-clone/CHANGELOG.md:5:1: [MD022] Expected 1 blank line below heading
crates/gh-clone/CHANGELOG.md:7:1: [MD032] List should be preceded by blank line
...
lint: failures=7   (color / copy-obj / gcm / gh-clone / git-upstream / v-sync / dotfiles-workers の CHANGELOG)
```

## 原因

lint オーケストレータの除外判定が**完全一致**だった:

```rust
fn match_markdown(&self, f: &FileContext) -> bool {
    classify::is_markdown(&f.rel_path) && f.rel_path != "CHANGELOG.md"  // root しか除外できない
}
```

これだと root の `CHANGELOG.md` しか除外されず、各クレート直下の per-package CHANGELOG（`crates/*/CHANGELOG.md`）が lint 対象に入っていた。per-package CHANGELOG（Cargo workspace 化）導入時の見落とし。自動生成物なので lint 対象外が正しい挙動。

## 修正

- `classify` に `is_changelog`（`== "CHANGELOG.md" || ends_with("/CHANGELOG.md")`、root・ネスト両対応）を追加し、`match_markdown` で使用。
- `.rumdl.toml` の `exclude` に `**/CHANGELOG.md` を追加（rumdl を直接実行する場合との整合）。

## 検証

- `classify::is_changelog` の単体テスト追加（root / ネスト / 非 CHANGELOG）
- 違反する `crates/gh-clone/CHANGELOG.md` を置いて `mise run check` → **exit 0（除外）**
- `cargo fmt --check` / `cargo clippy -p dotfiles-lint -- -D warnings` / `cargo test -p dotfiles-lint` すべて pass

## マージ後

これを main に入れた後、Release PR #410 の CI を再実行すれば `cargo lint` は pass する（pull_request CI は base=main にマージした状態で走るため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)