### PR TITLE
docs(changelog): root に v0.69.0（Cargo workspace 化）エントリを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.69.0] - 2026-06-16
+
+Rust / Cargo workspace 化のブートストラップリリース（epic #388）。シェル関数群を Rust バイナリへ移行し、release-plz による per-package バージョニングを確立した。以降のフォーマットは release-plz（git-cliff）に統一される。
+
+### Features
+
+- 各コマンドを Rust バイナリ化し、`cargo install` × chezmoi で配布（color / copy-obj / v-sync / gh-clone / gcm / git-upstream、背景 worker の daily-check / git-background-fetch）
+- lint/format オーケストレータを Rust 化（rumdl / mise でツール供給）
+- Rust edition を 2024 に更新
+
+### Refactor
+
+- 単一利用モジュールを lib から各 bin 配下へ移動
+
+### Build
+
+- リリースを release-please から release-plz（git_only・per-package タグ）へ移行
+- Nix を撤去し lint を cargo + mise に一本化
+
 ## [0.68.0](https://github.com/toshiki670/dotfiles/compare/v0.67.0...v0.68.0) (2026-06-10)
 
 


### PR DESCRIPTION
## 概要

root `CHANGELOG.md` が **v0.69.0 のエントリを欠いていた**（0.68.0 止まり）ので追記する。

## 原因

v0.69.0 は release-plz の baseline 成立用に **手動でタグ + GitHub Release** を作成した（[bootstrap](https://github.com/toshiki670/dotfiles/releases/tag/v0.69.0)）。release-plz の changelog 生成フローを経由しなかったため、root CHANGELOG.md に反映されなかった。

## 内容

epic #388（Rust / Cargo workspace 化）の v0.68.0..v0.69.0 をキュレート要約。リリースツール試行錯誤（Knope / PSR 移行とその revert）のノイズは除外。フォーマットは以降 release-plz（git-cliff）が使う `## [0.69.0] - 2026-06-16` 形式に合わせた（0.68.0 以下は release-please 時代の旧形式のまま。ここが移行境界）。

## 補足（今後）

root に releasable なコミットが入れば、以降は release-plz が `changelog_update = true` で root CHANGELOG.md を自動更新する。今回の欠落は手動ブートストラップ限りの一回性。root CHANGELOG.md は #411 で lint 対象外（自動生成物扱い）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)