### PR TITLE
test(refactor): #416 の残件対応（実挙動E2E整備 + lint/gcm の役割分割）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "clap",
  "predicates",
  "rstest",
+ "tempfile",
 ]
 
 [[package]]
@@ -233,6 +234,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "predicates",
+ "tempfile",
 ]
 
 [[package]]
@@ -335,6 +337,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -358,6 +361,7 @@ dependencies = [
  "clap",
  "predicates",
  "rstest",
+ "tempfile",
 ]
 
 [[package]]
@@ -369,6 +373,7 @@ dependencies = [
  "libc",
  "predicates",
  "rstest",
+ "tempfile",
 ]
 
 [[package]]
@@ -835,6 +840,7 @@ dependencies = [
  "clap",
  "predicates",
  "rstest",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/copy-obj/Cargo.toml
+++ b/crates/copy-obj/Cargo.toml
@@ -15,6 +15,7 @@ clap = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/crates/copy-obj/tests/e2e/mod.rs
+++ b/crates/copy-obj/tests/e2e/mod.rs
@@ -3,6 +3,8 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
+use std::fs;
+use tempfile::TempDir;
 
 fn copy_obj() -> Command {
     Command::cargo_bin("copy-obj").unwrap()
@@ -34,4 +36,56 @@ fn missing_required_file_arg_fails_with_usage() {
         .failure()
         .code(2)
         .stderr(predicate::str::contains("required").or(predicate::str::contains("FILE")));
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn exits_with_macos_only_on_non_macos() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("x.txt");
+    fs::write(&file, "x\n").unwrap();
+
+    copy_obj()
+        .arg(&file)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("macOS only"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_invokes_osascript_for_existing_file() {
+    let fx = TempDir::new().unwrap();
+    let file = fx.path().join("sample.txt");
+    let bin = fx.path().join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    fs::write(&file, "sample\n").unwrap();
+
+    let args_out = fx.path().join("osascript.args");
+    let stub = bin.join("osascript");
+    fs::write(
+        &stub,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >\"{}\"\n",
+            args_out.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let path =
+        std::env::join_paths(std::iter::once(bin.clone()).chain(std::env::split_paths(&existing)))
+            .unwrap();
+
+    copy_obj().arg(&file).env("PATH", path).assert().success();
+
+    let args = fs::read_to_string(args_out).unwrap();
+    assert!(args.contains("-e"));
+    assert!(args.contains("set the clipboard to POSIX file"));
+    assert!(args.contains(&file.canonicalize().unwrap().display().to_string()));
 }

--- a/crates/copy-obj/tests/e2e/mod.rs
+++ b/crates/copy-obj/tests/e2e/mod.rs
@@ -4,6 +4,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
 use std::fs;
+#[cfg(target_os = "macos")]
 use tempfile::TempDir;
 
 fn copy_obj() -> Command {

--- a/crates/dotfiles-workers/Cargo.toml
+++ b/crates/dotfiles-workers/Cargo.toml
@@ -12,6 +12,7 @@ version     = "0.1.0"
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/crates/dotfiles-workers/tests/e2e/mod.rs
+++ b/crates/dotfiles-workers/tests/e2e/mod.rs
@@ -1,10 +1,45 @@
 //! `dotfiles-workers`（daily-check-worker / git-background-fetch-worker）の
-//! 最小 E2E。worker は引数を取らず env 駆動のバックグラウンドプロセスのため、必要な外部
-//! コマンド（date / brew / mise / git）が不在でも無害に成功終了することを確認する。
+//! E2E。worker は引数を取らず env 駆動のため、スタブや実 git repo を用いて
+//! 副作用（結果ファイル / スタンプファイル作成）を検証する。
 
 use assert_cmd::Command;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::process::Command as ProcessCommand;
+use tempfile::TempDir;
 
 const EMPTY_PATH: &str = "/nonexistent-dotfiles-e2e";
+const DATE_STUB: &str = "#!/bin/sh\nprintf '2026-06-16\\n'\n";
+const BREW_STUB: &str = "#!/bin/sh\nprintf 'pkg-a\\n'\n";
+const MISE_STUB: &str = "#!/bin/sh\nprintf 'node@22\\n'\n";
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn path_with(prefix: &Path) -> OsString {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![prefix.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::env::join_paths(paths).unwrap()
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
 
 #[test]
 fn daily_check_worker_exits_success_without_tools() {
@@ -16,10 +51,75 @@ fn daily_check_worker_exits_success_without_tools() {
 }
 
 #[test]
-fn git_background_fetch_worker_exits_success_outside_repo() {
-    Command::cargo_bin("git-background-fetch-worker")
+fn daily_check_worker_writes_result_when_outdated_exists() {
+    let bin = tempfile::tempdir().unwrap();
+    let env = tempfile::tempdir().unwrap();
+    let ts = env.path().join("daily.ts");
+    let cache = env.path().join("cache");
+    let result = env.path().join("daily.result");
+
+    write_exec(bin.path(), "date", DATE_STUB);
+    write_exec(bin.path(), "brew", BREW_STUB);
+    write_exec(bin.path(), "mise", MISE_STUB);
+
+    Command::cargo_bin("daily-check-worker")
         .unwrap()
-        .env("PATH", EMPTY_PATH)
+        .env("PATH", path_with(bin.path()))
+        .env("DAILY_CHECK_TS", &ts)
+        .env("DAILY_CHECK_CACHE", &cache)
+        .env("DAILY_CHECK_RESULT", &result)
         .assert()
         .success();
+
+    assert_eq!(fs::read_to_string(&ts).unwrap(), "2026-06-16");
+    let output = fs::read_to_string(&result).unwrap();
+    assert!(output.contains("=== Homebrew Outdated Packages ==="));
+    assert!(output.contains("pkg-a"));
+    assert!(output.contains("=== Mise Outdated Tools ==="));
+    assert!(output.contains("node@22"));
+}
+
+#[test]
+fn git_background_fetch_worker_creates_throttle_stamp_in_repo() {
+    let repo = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    git(repo.path(), &["init"]);
+
+    Command::cargo_bin("git-background-fetch-worker")
+        .unwrap()
+        .current_dir(repo.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("GIT_FETCH_THROTTLE_SEC", "9999")
+        .assert()
+        .success();
+
+    let top = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(repo.path())
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .unwrap();
+    assert!(top.status.success());
+    let top = String::from_utf8_lossy(&top.stdout).trim().to_string();
+
+    let hash = ProcessCommand::new("git")
+        .arg("hash-object")
+        .arg("--stdin")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(top.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    let id = String::from_utf8_lossy(&hash.stdout)
+        .trim()
+        .chars()
+        .take(12)
+        .collect::<String>();
+    let stamp = cache.path().join("fish/git-fetch-last").join(id);
+    assert!(stamp.is_file());
 }

--- a/crates/dotfiles-workers/tests/e2e/mod.rs
+++ b/crates/dotfiles-workers/tests/e2e/mod.rs
@@ -7,7 +7,6 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
 use std::process::Command as ProcessCommand;
-use tempfile::TempDir;
 
 const EMPTY_PATH: &str = "/nonexistent-dotfiles-e2e";
 const DATE_STUB: &str = "#!/bin/sh\nprintf '2026-06-16\\n'\n";

--- a/crates/gcm/Cargo.toml
+++ b/crates/gcm/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/crates/gcm/src/claude.rs
+++ b/crates/gcm/src/claude.rs
@@ -1,0 +1,63 @@
+//! `claude -p` 呼び出し。
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use crate::proposals::{Commit, parse_proposals};
+
+const SYSTEM_PROMPT: &str = "You are a git commit message generator using Conventional Commits.
+
+Analyze the staged diff and split into the minimum number of semantically independent commits.
+- Single concern -> one entry
+- Multiple independent concerns (e.g. feat + fix, or unrelated files) -> multiple entries
+
+Output a JSON array of commit objects:
+
+[{\"message\": \"<type>[scope]: <description>\", \"files\": [\"path/to/file\"]}, ...]
+
+Rules:
+- type: feat, fix, docs, style, refactor, test, chore, perf, ci, build
+- description: English, imperative mood (add, fix, update, remove, ...)
+- Every staged file must appear in exactly one entry's files array";
+
+/// claude を呼び出して commit 提案を得る。
+pub(crate) fn call_claude(conversation: &str, model: &str) -> Option<Vec<Commit>> {
+    let mut child = match Command::new("claude")
+        .args(["-p", "--model", model, "--system-prompt", SYSTEM_PROMPT])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => {
+            eprintln!("生成に失敗しました。claude コマンドが利用可能か確認してください。");
+            return None;
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(conversation.as_bytes());
+        // stdin はここで drop され閉じる。
+    }
+
+    let output = child.wait_with_output().ok()?;
+    let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+    if raw.trim().is_empty() {
+        eprintln!("生成に失敗しました。claude コマンドが利用可能か確認してください。");
+        return None;
+    }
+
+    match parse_proposals(&raw) {
+        Ok(proposals) if !proposals.is_empty() => Some(proposals),
+        Ok(_) => {
+            eprintln!("コミット提案が空です。");
+            None
+        }
+        Err(_) => {
+            eprintln!("不正なJSON出力を受け取りました:");
+            eprintln!("{raw}");
+            None
+        }
+    }
+}

--- a/crates/gcm/src/execute.rs
+++ b/crates/gcm/src/execute.rs
@@ -1,0 +1,27 @@
+//! 提案コミットの実行。
+
+use std::process::ExitCode;
+
+use crate::git::{git_status, run_status};
+use crate::proposals::Commit;
+
+/// 提案コミットを実行する。
+pub(crate) fn execute(proposals: &[Commit]) -> ExitCode {
+    if proposals.len() == 1 {
+        return run_status(&["commit", "-m", &proposals[0].message]);
+    }
+
+    // 複数コミット: 全 unstage してからエントリごとに stage + commit。
+    let _ = git_status(&["restore", "--staged", "."]);
+    for (idx, commit) in proposals.iter().enumerate() {
+        let mut add_args = vec!["add"];
+        add_args.extend(commit.files.iter().map(String::as_str));
+        let _ = git_status(&add_args);
+
+        if !git_status(&["commit", "-m", &commit.message]) {
+            eprintln!("コミット {idx} 失敗。残りのファイルはステージされたままです。");
+            return ExitCode::FAILURE;
+        }
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/gcm/src/git.rs
+++ b/crates/gcm/src/git.rs
@@ -1,0 +1,38 @@
+//! git コマンド実行ラッパー。
+
+use std::process::{Command, ExitCode};
+
+/// `git diff --cached --name-only` のステージ済みファイル一覧。
+pub(crate) fn staged_files() -> Vec<String> {
+    git_capture(&["diff", "--cached", "--name-only"])
+        .map(|out| {
+            out.lines()
+                .filter(|line| !line.is_empty())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// `git <args>` の stdout を取得する。
+pub(crate) fn git_capture(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// `git <args>` を stdio 継承で実行し、終了コードを `ExitCode` で返す。
+pub(crate) fn run_status(args: &[&str]) -> ExitCode {
+    match Command::new("git").args(args).status() {
+        Ok(status) => ExitCode::from(status.code().unwrap_or(1) as u8),
+        Err(_) => ExitCode::FAILURE,
+    }
+}
+
+/// `git <args>` を stdio 継承で実行し、成功したかを返す。
+pub(crate) fn git_status(args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}

--- a/crates/gcm/src/main.rs
+++ b/crates/gcm/src/main.rs
@@ -4,13 +4,21 @@
 //! 生成し、対話的に承認/修正して 1 つ以上のコミットを実行する。JSON 解析は
 //! （fish 版の jq の代わりに）serde_json で行うため jq 依存は不要。
 
+mod claude;
+mod execute;
+mod git;
 mod proposals;
+mod ui;
 
 use std::io::{self, Write};
-use std::process::{Command, ExitCode, Stdio};
+use std::process::ExitCode;
 
 use clap::Parser;
-use proposals::{Commit, parse_proposals};
+use claude::call_claude;
+use execute::execute;
+use git::{git_capture, staged_files};
+use proposals::Commit;
+use ui::display;
 
 /// AI-powered git commit with Conventional Commits（claude -p）。
 #[derive(Parser)]
@@ -20,21 +28,6 @@ use proposals::{Commit, parse_proposals};
     about = "AI-powered git commit with Conventional Commits (claude -p)"
 )]
 struct Cli {}
-
-const SYSTEM_PROMPT: &str = "You are a git commit message generator using Conventional Commits.
-
-Analyze the staged diff and split into the minimum number of semantically independent commits.
-- Single concern → one entry
-- Multiple independent concerns (e.g. feat + fix, or unrelated files) → multiple entries
-
-Output a JSON array of commit objects:
-
-[{\"message\": \"<type>[scope]: <description>\", \"files\": [\"path/to/file\"]}, ...]
-
-Rules:
-- type: feat, fix, docs, style, refactor, test, chore, perf, ci, build
-- description: English, imperative mood (add, fix, update, remove, ...)
-- Every staged file must appear in exactly one entry's files array";
 
 fn main() -> ExitCode {
     // 引数は取らないが、clap で --help / --version を提供する。
@@ -96,122 +89,4 @@ fn main() -> ExitCode {
             None => return ExitCode::FAILURE,
         };
     }
-}
-
-/// `git diff --cached --name-only` のステージ済みファイル一覧。
-fn staged_files() -> Vec<String> {
-    git_capture(&["diff", "--cached", "--name-only"])
-        .map(|out| {
-            out.lines()
-                .filter(|l| !l.is_empty())
-                .map(String::from)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-/// `git <args>` の stdout を取得する。
-fn git_capture(args: &[&str]) -> Option<String> {
-    let out = Command::new("git").args(args).output().ok()?;
-    Some(String::from_utf8_lossy(&out.stdout).into_owned())
-}
-
-/// claude を呼び出して commit 提案を得る。
-fn call_claude(conversation: &str, model: &str) -> Option<Vec<Commit>> {
-    let mut child = match Command::new("claude")
-        .args(["-p", "--model", model, "--system-prompt", SYSTEM_PROMPT])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => {
-            eprintln!("生成に失敗しました。claude コマンドが利用可能か確認してください。");
-            return None;
-        }
-    };
-
-    if let Some(mut stdin) = child.stdin.take() {
-        let _ = stdin.write_all(conversation.as_bytes());
-        // stdin はここで drop され閉じる。
-    }
-
-    let output = child.wait_with_output().ok()?;
-    let raw = String::from_utf8_lossy(&output.stdout).into_owned();
-    if raw.trim().is_empty() {
-        eprintln!("生成に失敗しました。claude コマンドが利用可能か確認してください。");
-        return None;
-    }
-
-    match parse_proposals(&raw) {
-        Ok(proposals) if !proposals.is_empty() => Some(proposals),
-        Ok(_) => {
-            eprintln!("コミット提案が空です。");
-            None
-        }
-        Err(_) => {
-            eprintln!("不正なJSON出力を受け取りました:");
-            eprintln!("{raw}");
-            None
-        }
-    }
-}
-
-/// 提案コミットを表示する。
-fn display(proposals: &[Commit]) {
-    let count = proposals.len();
-    println!();
-    if count == 1 {
-        println!("提案されたコミット:");
-    } else {
-        println!("提案されたコミット ({count} 件):");
-    }
-    for (i, commit) in proposals.iter().enumerate() {
-        println!();
-        // bold cyan
-        println!("\x1b[1;36m  {}. {}\x1b[0m", i + 1, commit.message);
-        for f in &commit.files {
-            println!("     {f}");
-        }
-    }
-    println!();
-}
-
-/// 提案コミットを実行する。
-fn execute(proposals: &[Commit]) -> ExitCode {
-    if proposals.len() == 1 {
-        return run_status(&["commit", "-m", &proposals[0].message]);
-    }
-
-    // 複数コミット: 全 unstage してからエントリごとに stage + commit。
-    let _ = git_status(&["restore", "--staged", "."]);
-    for (i, commit) in proposals.iter().enumerate() {
-        let mut add_args = vec!["add"];
-        add_args.extend(commit.files.iter().map(String::as_str));
-        let _ = git_status(&add_args);
-
-        if !git_status(&["commit", "-m", &commit.message]) {
-            eprintln!("コミット {i} 失敗。残りのファイルはステージされたままです。");
-            return ExitCode::FAILURE;
-        }
-    }
-    ExitCode::SUCCESS
-}
-
-/// `git <args>` を stdio 継承で実行し、終了コードを ExitCode で返す。
-fn run_status(args: &[&str]) -> ExitCode {
-    match Command::new("git").args(args).status() {
-        Ok(status) => ExitCode::from(status.code().unwrap_or(1) as u8),
-        Err(_) => ExitCode::FAILURE,
-    }
-}
-
-/// `git <args>` を stdio 継承で実行し、成功したかを返す。
-fn git_status(args: &[&str]) -> bool {
-    Command::new("git")
-        .args(args)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }

--- a/crates/gcm/src/main.rs
+++ b/crates/gcm/src/main.rs
@@ -17,7 +17,6 @@ use clap::Parser;
 use claude::call_claude;
 use execute::execute;
 use git::{git_capture, staged_files};
-use proposals::Commit;
 use ui::display;
 
 /// AI-powered git commit with Conventional Commits（claude -p）。

--- a/crates/gcm/src/ui.rs
+++ b/crates/gcm/src/ui.rs
@@ -1,0 +1,23 @@
+//! 表示処理。
+
+use crate::proposals::Commit;
+
+/// 提案コミットを表示する。
+pub(crate) fn display(proposals: &[Commit]) {
+    let count = proposals.len();
+    println!();
+    if count == 1 {
+        println!("提案されたコミット:");
+    } else {
+        println!("提案されたコミット ({count} 件):");
+    }
+    for (idx, commit) in proposals.iter().enumerate() {
+        println!();
+        // bold cyan
+        println!("\x1b[1;36m  {}. {}\x1b[0m", idx + 1, commit.message);
+        for file in &commit.files {
+            println!("     {file}");
+        }
+    }
+    println!();
+}

--- a/crates/gcm/tests/e2e/mod.rs
+++ b/crates/gcm/tests/e2e/mod.rs
@@ -1,16 +1,91 @@
 //! `gcm` の E2E テスト（assert_cmd + predicates + rstest）。
 //!
-//! git 不在（PATH 差し替え）ではステージ済みファイルが空とみなされ、
-//! 「ステージされた変更がありません」で失敗する経路を決定的に検証する。
+//! 外部コマンド `claude` は PATH 先頭に置くスタブで差し替え、`git` は実物を使う
+//! （PATH に実 PATH を残す）。一時リポジトリを `git init` してステージ済み差分から
+//! 実際に commit されることを検証する。
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use tempfile::TempDir;
 
 const EMPTY_PATH: &str = "/nonexistent-dotfiles-e2e";
+const CLAUDE_STUB: &str = "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' \"$CLAUDE_JSON\"\n";
 
 fn gcm() -> Command {
     Command::cargo_bin("gcm").unwrap()
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn path_with(prefix: &Path) -> OsString {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![prefix.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::env::join_paths(paths).unwrap()
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn git_capture(dir: &Path, args: &[&str]) -> String {
+    let out = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "git {args:?} failed");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+struct Fixture {
+    repo: TempDir,
+    bin: TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let repo = tempfile::tempdir().unwrap();
+        let bin = tempfile::tempdir().unwrap();
+        git(repo.path(), &["init"]);
+        git(repo.path(), &["config", "user.name", "E2E"]);
+        git(repo.path(), &["config", "user.email", "e2e@example.com"]);
+        git(
+            repo.path(),
+            &["commit", "--allow-empty", "-m", "chore: init"],
+        );
+        write_exec(bin.path(), "claude", CLAUDE_STUB);
+
+        Self { repo, bin }
+    }
+
+    fn repo_path(&self) -> &Path {
+        self.repo.path()
+    }
+
+    fn stub_path(&self) -> PathBuf {
+        self.bin.path().to_path_buf()
+    }
 }
 
 #[rstest]
@@ -39,4 +114,82 @@ fn no_staged_changes_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("ステージされた変更がありません"));
+}
+
+#[test]
+fn commits_single_proposal_with_real_git_repo() {
+    let fx = Fixture::new();
+    let file = fx.repo_path().join("a.txt");
+    fs::write(&file, "hello\n").unwrap();
+    git(fx.repo_path(), &["add", "a.txt"]);
+
+    gcm()
+        .current_dir(fx.repo_path())
+        .env("PATH", path_with(&fx.stub_path()))
+        .env(
+            "CLAUDE_JSON",
+            "[{\"message\":\"feat: add alpha\",\"files\":[\"a.txt\"]}]",
+        )
+        .write_stdin("\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("feat: add alpha"));
+
+    assert_eq!(
+        git_capture(fx.repo_path(), &["log", "-1", "--pretty=%s"]),
+        "feat: add alpha"
+    );
+    assert!(
+        git_capture(
+            fx.repo_path(),
+            &["show", "--name-only", "--pretty=format:", "HEAD"]
+        )
+        .lines()
+        .any(|line| line == "a.txt")
+    );
+}
+
+#[test]
+fn commits_multiple_proposals_as_split_commits() {
+    let fx = Fixture::new();
+    fs::write(fx.repo_path().join("a.txt"), "alpha\n").unwrap();
+    fs::write(fx.repo_path().join("b.txt"), "beta\n").unwrap();
+    git(fx.repo_path(), &["add", "a.txt", "b.txt"]);
+
+    gcm()
+        .current_dir(fx.repo_path())
+        .env("PATH", path_with(&fx.stub_path()))
+        .env(
+            "CLAUDE_JSON",
+            r#"[{"message":"feat: add alpha","files":["a.txt"]},{"message":"fix: add beta","files":["b.txt"]}]"#,
+        )
+        .write_stdin("\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("提案されたコミット (2 件)"));
+
+    assert_eq!(
+        git_capture(fx.repo_path(), &["log", "-1", "--pretty=%s"]),
+        "fix: add beta"
+    );
+    assert_eq!(
+        git_capture(fx.repo_path(), &["log", "-2", "--pretty=%s"]),
+        "fix: add beta\nfeat: add alpha"
+    );
+    assert!(
+        git_capture(
+            fx.repo_path(),
+            &["show", "--name-only", "--pretty=format:", "HEAD"]
+        )
+        .lines()
+        .any(|line| line == "b.txt")
+    );
+    assert!(
+        git_capture(
+            fx.repo_path(),
+            &["show", "--name-only", "--pretty=format:", "HEAD~1"]
+        )
+        .lines()
+        .any(|line| line == "a.txt")
+    );
 }

--- a/crates/gh-clone/Cargo.toml
+++ b/crates/gh-clone/Cargo.toml
@@ -15,6 +15,7 @@ clap = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/crates/gh-clone/tests/e2e/mod.rs
+++ b/crates/gh-clone/tests/e2e/mod.rs
@@ -1,15 +1,72 @@
 //! `gh-clone` の E2E テスト（assert_cmd + predicates + rstest）。
 //!
-//! gh / ghq 不在は PATH を実在しないディレクトリに差し替えて再現する。
+//! 外部コマンド `gh` / `ghq` は PATH 先頭に置くスタブで差し替え、clone -> migrate ->
+//! 移設先パス出力（stdout）を実バイナリで検証する。
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 const EMPTY_PATH: &str = "/nonexistent-dotfiles-e2e";
+const GH_STUB: &str = "#!/bin/sh\nprintf '%s\\n' \"$@\" >\"$GH_ARGS_FILE\"\nrepo=\"${3##*/}\"\nmkdir -p \"$repo\"\nprintf 'cloned %s\\n' \"$3\"\n";
+const GHQ_STUB: &str = "#!/bin/sh\nprintf '%s\\n' \"$@\" >\"$GHQ_ARGS_FILE\"\nrepo=\"$3\"\ndst=\"$GHQ_MIGRATED_ROOT/$repo\"\nmkdir -p \"$dst\"\nprintf '%s\\n' \"$dst\"\n";
 
 fn gh_clone() -> Command {
     Command::cargo_bin("gh-clone").unwrap()
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn path_with(prefix: &Path) -> OsString {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![prefix.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::env::join_paths(paths).unwrap()
+}
+
+struct Fixture {
+    work: TempDir,
+    bin: TempDir,
+    migrated_root: TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let work = tempfile::tempdir().unwrap();
+        let bin = tempfile::tempdir().unwrap();
+        let migrated_root = tempfile::tempdir().unwrap();
+        write_exec(bin.path(), "gh", GH_STUB);
+        write_exec(bin.path(), "ghq", GHQ_STUB);
+        Self {
+            work,
+            bin,
+            migrated_root,
+        }
+    }
+
+    fn path(&self) -> OsString {
+        path_with(self.bin.path())
+    }
+
+    fn gh_args_file(&self) -> PathBuf {
+        self.work.path().join("gh.args")
+    }
+
+    fn ghq_args_file(&self) -> PathBuf {
+        self.work.path().join("ghq.args")
+    }
 }
 
 #[rstest]
@@ -49,4 +106,32 @@ fn missing_gh_exits_127() {
         .failure()
         .code(127)
         .stderr(predicate::str::contains("gh command not found"));
+}
+
+#[test]
+fn clones_then_migrates_and_prints_migrated_path() {
+    let fx = Fixture::new();
+    let expected = fx.migrated_root.path().join("repo");
+
+    gh_clone()
+        .current_dir(fx.work.path())
+        .arg("owner/repo")
+        .env("PATH", fx.path())
+        .env("GH_ARGS_FILE", fx.gh_args_file())
+        .env("GHQ_ARGS_FILE", fx.ghq_args_file())
+        .env("GHQ_MIGRATED_ROOT", fx.migrated_root.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected.display().to_string()))
+        .stderr(predicate::str::contains("cloned owner/repo"));
+
+    assert_eq!(
+        fs::read_to_string(fx.gh_args_file()).unwrap(),
+        "repo\nclone\nowner/repo\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.ghq_args_file()).unwrap(),
+        "migrate\n-y\nrepo\n"
+    );
+    assert!(expected.is_dir());
 }

--- a/crates/git-upstream/Cargo.toml
+++ b/crates/git-upstream/Cargo.toml
@@ -16,6 +16,7 @@ libc = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/crates/git-upstream/tests/e2e/mod.rs
+++ b/crates/git-upstream/tests/e2e/mod.rs
@@ -1,16 +1,114 @@
 //! `git-upstream` の E2E テスト（assert_cmd + predicates + rstest）。
 //!
-//! git 不在（PATH 差し替え）では「Git command not found → exit 8」の経路を
-//! 決定的に検証する。CI / 開発機は非 root 前提（root の場合は先に exit 4）。
+//! 実 git リポジトリを使って initialize / merge の挙動を検証する。
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use std::process::Command as ProcessCommand;
+use tempfile::TempDir;
 
 const EMPTY_PATH: &str = "/nonexistent-dotfiles-e2e";
 
 fn git_upstream() -> Command {
     Command::cargo_bin("git-upstream").unwrap()
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
+fn git_capture(dir: &Path, args: &[&str]) -> String {
+    let out = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed in {}",
+        dir.display()
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+struct Fixture {
+    _tmp: TempDir,
+    seed: std::path::PathBuf,
+    upstream_bare: std::path::PathBuf,
+    local: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let seed = root.join("seed");
+        let upstream_bare = root.join("upstream.git");
+        let local = root.join("local");
+
+        let _ = ProcessCommand::new("git")
+            .args(["init", "-b", "master"])
+            .arg(&seed)
+            .status();
+        git(&seed, &["config", "user.name", "E2E"]);
+        git(&seed, &["config", "user.email", "e2e@example.com"]);
+        fs::write(seed.join("README.md"), "seed\n").unwrap();
+        git(&seed, &["add", "README.md"]);
+        git(&seed, &["commit", "-m", "chore: seed"]);
+
+        let status = ProcessCommand::new("git")
+            .arg("clone")
+            .arg("--bare")
+            .arg(&seed)
+            .arg(&upstream_bare)
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let status = ProcessCommand::new("git")
+            .arg("clone")
+            .arg(&seed)
+            .arg(&local)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        git(&local, &["config", "user.name", "E2E"]);
+        git(&local, &["config", "user.email", "e2e@example.com"]);
+
+        Self {
+            _tmp: tmp,
+            seed,
+            upstream_bare,
+            local,
+        }
+    }
+
+    fn push_new_upstream_commit(&self) {
+        let work = self.seed.parent().unwrap().join("upstream-work");
+        let status = ProcessCommand::new("git")
+            .arg("clone")
+            .arg(&self.upstream_bare)
+            .arg(&work)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        git(&work, &["config", "user.name", "E2E"]);
+        git(&work, &["config", "user.email", "e2e@example.com"]);
+        fs::write(work.join("upstream.txt"), "upstream change\n").unwrap();
+        git(&work, &["add", "upstream.txt"]);
+        git(&work, &["commit", "-m", "feat: upstream"]);
+        git(&work, &["push", "origin", "master"]);
+    }
 }
 
 #[rstest]
@@ -40,4 +138,40 @@ fn missing_git_exits_8() {
         .failure()
         .code(8)
         .stderr(predicate::str::contains("Git command not found"));
+}
+
+#[test]
+fn initialize_adds_upstream_remote_and_fetches() {
+    let fx = Fixture::new();
+    git_upstream()
+        .current_dir(&fx.local)
+        .arg("-i")
+        .arg(&fx.upstream_bare)
+        .assert()
+        .success();
+
+    let remotes = git_capture(&fx.local, &["remote"]);
+    assert!(remotes.lines().any(|line| line.trim() == "upstream"));
+}
+
+#[test]
+fn merge_fetches_upstream_master_into_local() {
+    let fx = Fixture::new();
+    git(
+        &fx.local,
+        &[
+            "remote",
+            "add",
+            "upstream",
+            &fx.upstream_bare.to_string_lossy(),
+        ],
+    );
+    fx.push_new_upstream_commit();
+    let before = git_capture(&fx.local, &["rev-parse", "HEAD"]);
+
+    git_upstream().current_dir(&fx.local).assert().success();
+
+    let after = git_capture(&fx.local, &["rev-parse", "HEAD"]);
+    assert_ne!(before, after);
+    assert!(fx.local.join("upstream.txt").is_file());
 }

--- a/crates/v-sync/Cargo.toml
+++ b/crates/v-sync/Cargo.toml
@@ -15,6 +15,7 @@ clap = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/crates/v-sync/tests/e2e/mod.rs
+++ b/crates/v-sync/tests/e2e/mod.rs
@@ -1,17 +1,70 @@
 //! `v-sync` の E2E テスト（assert_cmd + predicates + rstest）。
 //!
-//! nvim / chezmoi 不在を再現するため、PATH を実在しないディレクトリに差し替えて
-//! 「コマンド未検出 → exit 127」の経路を決定的に検証する。
+//! 外部コマンド `nvim` / `chezmoi` は PATH 先頭に置くスタブで差し替え、同期手順
+//! （nvim headless 実行 -> chezmoi re-add）を実バイナリで検証する。
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 /// PATH 上に何も存在しない状態を作るための実在しないディレクトリ。
 const EMPTY_PATH: &str = "/nonexistent-dotfiles-e2e";
+const NVIM_STUB: &str =
+    "#!/bin/sh\nprintf '%s\\n' \"$@\" >\"$NVIM_ARGS_FILE\"\nexit \"${NVIM_EXIT:-0}\"\n";
+const CHEZMOI_STUB: &str = "#!/bin/sh\nprintf '%s\\n' \"$@\" >\"$CHEZMOI_ARGS_FILE\"\n";
 
 fn v_sync() -> Command {
     Command::cargo_bin("v-sync").unwrap()
+}
+
+fn write_exec(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn path_with(prefix: &Path) -> OsString {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![prefix.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::env::join_paths(paths).unwrap()
+}
+
+struct Fixture {
+    home: TempDir,
+    bin: TempDir,
+    out: TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let home = tempfile::tempdir().unwrap();
+        let bin = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        write_exec(bin.path(), "nvim", NVIM_STUB);
+        write_exec(bin.path(), "chezmoi", CHEZMOI_STUB);
+        Self { home, bin, out }
+    }
+
+    fn path(&self) -> OsString {
+        path_with(self.bin.path())
+    }
+
+    fn nvim_args_file(&self) -> PathBuf {
+        self.out.path().join("nvim.args")
+    }
+
+    fn chezmoi_args_file(&self) -> PathBuf {
+        self.out.path().join("chezmoi.args")
+    }
 }
 
 #[rstest]
@@ -41,4 +94,31 @@ fn missing_nvim_exits_127() {
         .failure()
         .code(127)
         .stderr(predicate::str::contains("nvim command not found"));
+}
+
+#[test]
+fn runs_nvim_sync_then_readd_lockfile() {
+    let fx = Fixture::new();
+    let home_lock = fx.home.path().join(".config/nvim/lazy-lock.json");
+    fs::create_dir_all(home_lock.parent().unwrap()).unwrap();
+    fs::write(&home_lock, "{}\n").unwrap();
+
+    v_sync()
+        .env("PATH", fx.path())
+        .env("HOME", fx.home.path())
+        .env("NVIM_ARGS_FILE", fx.nvim_args_file())
+        .env("CHEZMOI_ARGS_FILE", fx.chezmoi_args_file())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("v-sync: syncing nvim plugins"))
+        .stdout(predicate::str::contains("v-sync: re-adding lazy-lock.json"));
+
+    assert_eq!(
+        fs::read_to_string(fx.nvim_args_file()).unwrap(),
+        "--headless\n+Lazy! sync\n+qa\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.chezmoi_args_file()).unwrap(),
+        format!("re-add\n{}\n", home_lock.display())
+    );
 }

--- a/tools/dotfiles-lint/src/lint.rs
+++ b/tools/dotfiles-lint/src/lint.rs
@@ -7,11 +7,14 @@
 
 mod classify;
 mod collect;
+mod exec;
+mod report;
+mod rules;
+mod template;
 
 pub use collect::{collect_files, find_repo_root};
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 
 /// 実行モード。
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -79,7 +82,7 @@ impl Orchestrator {
 
     fn fix_file(&mut self, f: &FileContext) -> bool {
         let mut failed = false;
-        if self.match_shell(f) && self.fix_shell(f) != 0 {
+        if rules::match_shell(f) && self.fix_shell(f) != 0 {
             failed = true;
         }
         if classify::is_fish(&f.rel_path) && self.fix_fish(f) != 0 {
@@ -88,13 +91,13 @@ impl Orchestrator {
         if classify::is_lua(&f.rel_path) && self.fix_lua(f) != 0 {
             failed = true;
         }
-        if self.match_python(f) && self.fix_python(f) != 0 {
+        if rules::match_python(f) && self.fix_python(f) != 0 {
             failed = true;
         }
         if classify::is_toml(&f.rel_path) && self.fix_toml(f) != 0 {
             failed = true;
         }
-        if self.match_markdown(f) && self.fix_markdown(f) != 0 {
+        if rules::match_markdown(f) && self.fix_markdown(f) != 0 {
             failed = true;
         }
         failed
@@ -102,7 +105,7 @@ impl Orchestrator {
 
     fn check_file(&mut self, f: &FileContext) -> bool {
         let mut failed = false;
-        if self.match_shell(f) && self.check_shell(f) != 0 {
+        if rules::match_shell(f) && self.check_shell(f) != 0 {
             failed = true;
         }
         if classify::is_fish(&f.rel_path) && self.check_fish(f) != 0 {
@@ -111,462 +114,15 @@ impl Orchestrator {
         if classify::is_lua(&f.rel_path) && self.check_lua(f) != 0 {
             failed = true;
         }
-        if self.match_python(f) && self.check_python(f) != 0 {
+        if rules::match_python(f) && self.check_python(f) != 0 {
             failed = true;
         }
         if classify::is_toml(&f.rel_path) && self.check_toml(f) != 0 {
             failed = true;
         }
-        if self.match_markdown(f) && self.check_markdown(f) != 0 {
+        if rules::match_markdown(f) && self.check_markdown(f) != 0 {
             failed = true;
         }
         failed
-    }
-
-    // --- shell -------------------------------------------------------------
-
-    fn match_shell(&self, f: &FileContext) -> bool {
-        if !(classify::is_shell_ext(&f.rel_path) || classify::is_shell_path(&f.rel_path)) {
-            return false;
-        }
-        if classify::has_python_shebang(&f.abs_path) {
-            return false;
-        }
-        matches!(
-            classify::shell_flavor(&f.abs_path).as_str(),
-            "bash" | "sh" | ""
-        )
-    }
-
-    fn fix_shell(&mut self, f: &FileContext) -> i32 {
-        if classify::is_home_chezmoi_shell_template(&f.rel_path, &self.repo_root) {
-            return 0;
-        }
-        let abs = abs(f);
-        self.run_rule_cmd(
-            f,
-            "shell",
-            "fix",
-            &["shfmt", "-w", "-i", "2", "-ci", &abs],
-            None,
-            false,
-        )
-    }
-
-    fn check_shell(&mut self, f: &FileContext) -> i32 {
-        if classify::is_home_chezmoi_shell_template(&f.rel_path, &self.repo_root) {
-            let rendered = match self.render_template(&f.rel_path, ".sh") {
-                Some(p) => p.to_string_lossy().into_owned(),
-                None => return 1,
-            };
-            let mut failed = 0;
-            if self.run_rule_cmd(
-                f,
-                "shell",
-                "check",
-                &["shfmt", "-d", "-i", "2", "-ci", &rendered],
-                None,
-                false,
-            ) != 0
-            {
-                failed = 1;
-            }
-            if self.run_rule_cmd(f, "shell", "check", &["shellcheck", &rendered], None, true) != 0 {
-                failed = 1;
-            }
-            return failed;
-        }
-
-        let abs = abs(f);
-        let mut failed = 0;
-        if self.run_rule_cmd(
-            f,
-            "shell",
-            "check",
-            &["shfmt", "-d", "-i", "2", "-ci", &abs],
-            None,
-            false,
-        ) != 0
-        {
-            failed = 1;
-        }
-        if self.run_rule_cmd(f, "shell", "check", &["shellcheck", &abs], None, false) != 0 {
-            failed = 1;
-        }
-        failed
-    }
-
-    // --- fish --------------------------------------------------------------
-
-    fn fix_fish(&mut self, f: &FileContext) -> i32 {
-        if classify::is_home_chezmoi_fish_template(&f.rel_path, &self.repo_root) {
-            return 0;
-        }
-        let abs = abs(f);
-        let cmd = ["fish_indent", abs.as_str()];
-        if self.verbose {
-            println!("[fix:fish] {}: {}", f.rel_path, format_cmd(&cmd));
-        }
-        match capture(&cmd, None) {
-            Some((0, formatted, _)) => {
-                let current = std::fs::read(&f.abs_path)
-                    .map(|b| String::from_utf8_lossy(&b).into_owned())
-                    .unwrap_or_default();
-                if formatted != current {
-                    let _ = std::fs::write(&f.abs_path, formatted.as_bytes());
-                }
-                0
-            }
-            Some((code, _, _)) => {
-                self.record(f, "fish", "fix", &cmd, code);
-                1
-            }
-            None => {
-                self.record(f, "fish", "fix", &cmd, 1);
-                1
-            }
-        }
-    }
-
-    fn check_fish(&mut self, f: &FileContext) -> i32 {
-        let is_tmpl = classify::is_home_chezmoi_fish_template(&f.rel_path, &self.repo_root);
-        let target = if is_tmpl {
-            match self.render_template(&f.rel_path, ".fish") {
-                Some(p) => p.to_string_lossy().into_owned(),
-                None => return 1,
-            }
-        } else {
-            abs(f)
-        };
-
-        let mut failed = 0;
-        if !is_tmpl
-            && !classify::is_home_chezmoi_fish_completion_template(&f.rel_path, &self.repo_root)
-            && self.run_rule_cmd(
-                f,
-                "fish",
-                "check",
-                &["fish_indent", "--check", &target],
-                None,
-                false,
-            ) != 0
-        {
-            failed = 1;
-        }
-        if self.run_rule_cmd(
-            f,
-            "fish",
-            "check",
-            &["fish", "--no-execute", &target],
-            None,
-            false,
-        ) != 0
-        {
-            failed = 1;
-        }
-        failed
-    }
-
-    // --- lua ---------------------------------------------------------------
-
-    fn fix_lua(&mut self, f: &FileContext) -> i32 {
-        let abs = abs(f);
-        self.run_rule_cmd(f, "lua", "fix", &["stylua", &abs], None, false)
-    }
-
-    fn check_lua(&mut self, f: &FileContext) -> i32 {
-        let abs = abs(f);
-        self.run_rule_cmd(f, "lua", "check", &["stylua", "--check", &abs], None, false)
-    }
-
-    // --- python (ruff: Rust 製、Python ランタイム不要) ----------------------
-
-    fn match_python(&self, f: &FileContext) -> bool {
-        classify::is_python(&f.rel_path) || classify::has_python_shebang(&f.abs_path)
-    }
-
-    fn fix_python(&mut self, f: &FileContext) -> i32 {
-        let abs = abs(f);
-        self.run_rule_cmd(f, "python", "fix", &["ruff", "format", &abs], None, false)
-    }
-
-    fn check_python(&mut self, f: &FileContext) -> i32 {
-        let abs = abs(f);
-        self.run_rule_cmd(
-            f,
-            "python",
-            "check",
-            &["ruff", "format", "--check", &abs],
-            None,
-            false,
-        )
-    }
-
-    // --- toml --------------------------------------------------------------
-
-    fn fix_toml(&mut self, f: &FileContext) -> i32 {
-        let abs = abs(f);
-        self.run_rule_cmd(f, "toml", "fix", &["taplo", "fmt", &abs], None, false)
-    }
-
-    fn check_toml(&mut self, f: &FileContext) -> i32 {
-        let abs = abs(f);
-        let mut failed = 0;
-        if self.run_rule_cmd(
-            f,
-            "toml",
-            "check",
-            &["taplo", "fmt", "--check", &abs],
-            None,
-            false,
-        ) != 0
-        {
-            failed = 1;
-        }
-        if self.run_rule_cmd(f, "toml", "check", &["taplo", "lint", &abs], None, false) != 0 {
-            failed = 1;
-        }
-        failed
-    }
-
-    // --- markdown (rumdl) --------------------------------------------------
-
-    /// CHANGELOG.md は自動生成のため除外する（root・各クレート直下の per-package
-    /// とも。.rumdl.toml の exclude と一致）。
-    fn match_markdown(&self, f: &FileContext) -> bool {
-        classify::is_markdown(&f.rel_path) && !classify::is_changelog(&f.rel_path)
-    }
-
-    fn fix_markdown(&mut self, f: &FileContext) -> i32 {
-        let root = self.repo_root.clone();
-        let rel = f.rel_path.clone();
-        self.run_rule_cmd(
-            f,
-            "markdown",
-            "fix",
-            &["rumdl", "check", "--fix", "--config", ".rumdl.toml", &rel],
-            Some(&root),
-            false,
-        )
-    }
-
-    fn check_markdown(&mut self, f: &FileContext) -> i32 {
-        let root = self.repo_root.clone();
-        let rel = f.rel_path.clone();
-        self.run_rule_cmd(
-            f,
-            "markdown",
-            "check",
-            &["rumdl", "check", "--config", ".rumdl.toml", &rel],
-            Some(&root),
-            false,
-        )
-    }
-
-    // --- helpers -----------------------------------------------------------
-
-    /// chezmoi テンプレートを展開して一時ファイルに書き出す。
-    fn render_template(&self, rel_path: &str, ext: &str) -> Option<PathBuf> {
-        let source_dir = self.repo_root.join("home");
-        let src = self.repo_root.join(rel_path);
-        let out_name = format!("rendered_{}{}", rel_path.replace(['/', '.'], "_"), ext);
-        let out = self.tmp_dir.join(out_name);
-
-        let output = Command::new("chezmoi")
-            .arg("-S")
-            .arg(&source_dir)
-            .arg("execute-template")
-            .arg("-f")
-            .arg(&src)
-            .output();
-
-        match output {
-            Ok(o) if o.status.success() => {
-                if std::fs::write(&out, &o.stdout).is_err() {
-                    return None;
-                }
-                Some(out)
-            }
-            Ok(o) => {
-                eprintln!("lint: chezmoi execute-template failed: {rel_path}");
-                let stderr = String::from_utf8_lossy(&o.stderr);
-                if !stderr.trim().is_empty() {
-                    eprintln!("{}", stderr.trim_end());
-                }
-                None
-            }
-            Err(_) => {
-                eprintln!("lint: chezmoi execute-template failed: {rel_path}");
-                None
-            }
-        }
-    }
-
-    /// ルールのコマンドを実行し、非ゼロなら失敗を記録する。
-    fn run_rule_cmd(
-        &mut self,
-        f: &FileContext,
-        rule: &str,
-        phase: &str,
-        cmd: &[&str],
-        cwd: Option<&Path>,
-        shellcheck_hint: bool,
-    ) -> i32 {
-        if self.verbose {
-            let where_ = cwd
-                .map(|c| format!(" (cwd={})", c.display()))
-                .unwrap_or_default();
-            println!(
-                "[{phase}:{rule}] {}: {}{where_}",
-                f.rel_path,
-                format_cmd(cmd)
-            );
-        }
-
-        let mut command = Command::new(cmd[0]);
-        command.args(&cmd[1..]);
-        if let Some(c) = cwd {
-            command.current_dir(c);
-        }
-        let code = match command.status() {
-            Ok(status) => status.code().unwrap_or(1),
-            Err(_) => 1,
-        };
-
-        if code != 0 {
-            if shellcheck_hint {
-                eprintln!(
-                    "lint: shellcheck failed on expanded template (source: {})",
-                    f.rel_path
-                );
-            }
-            self.record(f, rule, phase, cmd, code);
-        }
-        code
-    }
-
-    fn record(&mut self, f: &FileContext, rule: &str, phase: &str, cmd: &[&str], code: i32) {
-        self.failures.push(Failure {
-            file: f.rel_path.clone(),
-            rule: rule.to_string(),
-            phase: phase.to_string(),
-            command: format_cmd(cmd),
-            exit_code: code,
-        });
-    }
-
-    pub fn print_summary(&self) {
-        println!("lint: failures={}", self.failures.len());
-        for r in &self.failures {
-            println!(
-                "- {}:{} {} -> ({}) {}",
-                r.phase, r.rule, r.file, r.exit_code, r.command
-            );
-        }
-    }
-
-    pub fn print_json(&self, failed: bool) {
-        let mut items = Vec::with_capacity(self.failures.len());
-        for r in &self.failures {
-            items.push(format!(
-                "{{\"file\":{},\"rule\":{},\"phase\":{},\"command\":{},\"exitCode\":{}}}",
-                json_str(&r.file),
-                json_str(&r.rule),
-                json_str(&r.phase),
-                json_str(&r.command),
-                r.exit_code,
-            ));
-        }
-        println!(
-            "{{\"failed\":{},\"failureCount\":{},\"failures\":[{}]}}",
-            i32::from(failed),
-            self.failures.len(),
-            items.join(",")
-        );
-    }
-}
-
-/// FileContext の絶対パスを String にする。
-fn abs(f: &FileContext) -> String {
-    f.abs_path.to_string_lossy().into_owned()
-}
-
-/// コマンドを表示用にシェルクオートして連結する。
-fn format_cmd(cmd: &[&str]) -> String {
-    cmd.iter()
-        .map(|part| shell_quote(part))
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn shell_quote(s: &str) -> String {
-    if !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | '=' | ':'))
-    {
-        s.to_string()
-    } else {
-        format!("'{}'", s.replace('\'', "'\\''"))
-    }
-}
-
-fn json_str(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
-}
-
-/// コマンドを実行し (exit code, stdout, stderr) を返す。
-fn capture(cmd: &[&str], cwd: Option<&Path>) -> Option<(i32, String, String)> {
-    let mut command = Command::new(cmd[0]);
-    command.args(&cmd[1..]);
-    if let Some(c) = cwd {
-        command.current_dir(c);
-    }
-    let output = command.output().ok()?;
-    Some((
-        output.status.code().unwrap_or(1),
-        String::from_utf8_lossy(&output.stdout).into_owned(),
-        String::from_utf8_lossy(&output.stderr).into_owned(),
-    ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn shell_quote_leaves_simple_words() {
-        assert_eq!(shell_quote("shfmt"), "shfmt");
-        assert_eq!(shell_quote("-i"), "-i");
-        assert_eq!(shell_quote("/a/b.sh"), "/a/b.sh");
-    }
-
-    #[test]
-    fn shell_quote_wraps_spaces() {
-        assert_eq!(shell_quote("a b"), "'a b'");
-        assert_eq!(shell_quote(""), "''");
-    }
-
-    #[test]
-    fn format_cmd_joins() {
-        assert_eq!(format_cmd(&["shfmt", "-w", "x y"]), "shfmt -w 'x y'");
-    }
-
-    #[test]
-    fn json_str_escapes() {
-        assert_eq!(json_str("a\"b\\c"), "\"a\\\"b\\\\c\"");
     }
 }

--- a/tools/dotfiles-lint/src/lint/exec.rs
+++ b/tools/dotfiles-lint/src/lint/exec.rs
@@ -1,0 +1,130 @@
+//! コマンド実行と失敗記録。
+
+use std::path::Path;
+use std::process::Command;
+
+use super::{Failure, FileContext, Orchestrator};
+
+impl Orchestrator {
+    /// ルールのコマンドを実行し、非ゼロなら失敗を記録する。
+    pub(super) fn run_rule_cmd(
+        &mut self,
+        f: &FileContext,
+        rule: &str,
+        phase: &str,
+        cmd: &[&str],
+        cwd: Option<&Path>,
+        shellcheck_hint: bool,
+    ) -> i32 {
+        if self.verbose {
+            let where_ = cwd
+                .map(|c| format!(" (cwd={})", c.display()))
+                .unwrap_or_default();
+            println!(
+                "[{phase}:{rule}] {}: {}{where_}",
+                f.rel_path,
+                format_cmd(cmd)
+            );
+        }
+
+        let mut command = Command::new(cmd[0]);
+        command.args(&cmd[1..]);
+        if let Some(c) = cwd {
+            command.current_dir(c);
+        }
+        let code = match command.status() {
+            Ok(status) => status.code().unwrap_or(1),
+            Err(_) => 1,
+        };
+
+        if code != 0 {
+            if shellcheck_hint {
+                eprintln!(
+                    "lint: shellcheck failed on expanded template (source: {})",
+                    f.rel_path
+                );
+            }
+            self.record(f, rule, phase, cmd, code);
+        }
+        code
+    }
+
+    pub(super) fn record(
+        &mut self,
+        f: &FileContext,
+        rule: &str,
+        phase: &str,
+        cmd: &[&str],
+        code: i32,
+    ) {
+        self.failures.push(Failure {
+            file: f.rel_path.clone(),
+            rule: rule.to_string(),
+            phase: phase.to_string(),
+            command: format_cmd(cmd),
+            exit_code: code,
+        });
+    }
+}
+
+/// FileContext の絶対パスを String にする。
+pub(super) fn abs(f: &FileContext) -> String {
+    f.abs_path.to_string_lossy().into_owned()
+}
+
+/// コマンドを表示用にシェルクオートして連結する。
+pub(super) fn format_cmd(cmd: &[&str]) -> String {
+    cmd.iter()
+        .map(|part| shell_quote(part))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | '=' | ':'))
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+/// コマンドを実行し (exit code, stdout, stderr) を返す。
+pub(super) fn capture(cmd: &[&str], cwd: Option<&Path>) -> Option<(i32, String, String)> {
+    let mut command = Command::new(cmd[0]);
+    command.args(&cmd[1..]);
+    if let Some(c) = cwd {
+        command.current_dir(c);
+    }
+    let output = command.output().ok()?;
+    Some((
+        output.status.code().unwrap_or(1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_leaves_simple_words() {
+        assert_eq!(shell_quote("shfmt"), "shfmt");
+        assert_eq!(shell_quote("-i"), "-i");
+        assert_eq!(shell_quote("/a/b.sh"), "/a/b.sh");
+    }
+
+    #[test]
+    fn shell_quote_wraps_spaces() {
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn format_cmd_joins() {
+        assert_eq!(format_cmd(&["shfmt", "-w", "x y"]), "shfmt -w 'x y'");
+    }
+}

--- a/tools/dotfiles-lint/src/lint/report.rs
+++ b/tools/dotfiles-lint/src/lint/report.rs
@@ -1,0 +1,63 @@
+//! サマリ/JSON 出力。
+
+use super::Orchestrator;
+
+impl Orchestrator {
+    pub fn print_summary(&self) {
+        println!("lint: failures={}", self.failures.len());
+        for r in &self.failures {
+            println!(
+                "- {}:{} {} -> ({}) {}",
+                r.phase, r.rule, r.file, r.exit_code, r.command
+            );
+        }
+    }
+
+    pub fn print_json(&self, failed: bool) {
+        let mut items = Vec::with_capacity(self.failures.len());
+        for r in &self.failures {
+            items.push(format!(
+                "{{\"file\":{},\"rule\":{},\"phase\":{},\"command\":{},\"exitCode\":{}}}",
+                json_str(&r.file),
+                json_str(&r.rule),
+                json_str(&r.phase),
+                json_str(&r.command),
+                r.exit_code,
+            ));
+        }
+        println!(
+            "{{\"failed\":{},\"failureCount\":{},\"failures\":[{}]}}",
+            i32::from(failed),
+            self.failures.len(),
+            items.join(",")
+        );
+    }
+}
+
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::json_str;
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("a\"b\\c"), "\"a\\\"b\\\\c\"");
+    }
+}

--- a/tools/dotfiles-lint/src/lint/rules/fish.rs
+++ b/tools/dotfiles-lint/src/lint/rules/fish.rs
@@ -1,0 +1,73 @@
+use super::super::{FileContext, Orchestrator, classify};
+use crate::lint::exec::{abs, capture, format_cmd};
+
+impl Orchestrator {
+    pub(crate) fn fix_fish(&mut self, f: &FileContext) -> i32 {
+        if classify::is_home_chezmoi_fish_template(&f.rel_path, &self.repo_root) {
+            return 0;
+        }
+        let abs = abs(f);
+        let cmd = ["fish_indent", abs.as_str()];
+        if self.verbose {
+            println!("[fix:fish] {}: {}", f.rel_path, format_cmd(&cmd));
+        }
+        match capture(&cmd, None) {
+            Some((0, formatted, _)) => {
+                let current = std::fs::read(&f.abs_path)
+                    .map(|b| String::from_utf8_lossy(&b).into_owned())
+                    .unwrap_or_default();
+                if formatted != current {
+                    let _ = std::fs::write(&f.abs_path, formatted.as_bytes());
+                }
+                0
+            }
+            Some((code, _, _)) => {
+                self.record(f, "fish", "fix", &cmd, code);
+                1
+            }
+            None => {
+                self.record(f, "fish", "fix", &cmd, 1);
+                1
+            }
+        }
+    }
+
+    pub(crate) fn check_fish(&mut self, f: &FileContext) -> i32 {
+        let is_tmpl = classify::is_home_chezmoi_fish_template(&f.rel_path, &self.repo_root);
+        let target = if is_tmpl {
+            match self.render_template(&f.rel_path, ".fish") {
+                Some(p) => p.to_string_lossy().into_owned(),
+                None => return 1,
+            }
+        } else {
+            abs(f)
+        };
+
+        let mut failed = 0;
+        if !is_tmpl
+            && !classify::is_home_chezmoi_fish_completion_template(&f.rel_path, &self.repo_root)
+            && self.run_rule_cmd(
+                f,
+                "fish",
+                "check",
+                &["fish_indent", "--check", &target],
+                None,
+                false,
+            ) != 0
+        {
+            failed = 1;
+        }
+        if self.run_rule_cmd(
+            f,
+            "fish",
+            "check",
+            &["fish", "--no-execute", &target],
+            None,
+            false,
+        ) != 0
+        {
+            failed = 1;
+        }
+        failed
+    }
+}

--- a/tools/dotfiles-lint/src/lint/rules/lua.rs
+++ b/tools/dotfiles-lint/src/lint/rules/lua.rs
@@ -1,0 +1,14 @@
+use super::super::{FileContext, Orchestrator};
+use crate::lint::exec::abs;
+
+impl Orchestrator {
+    pub(crate) fn fix_lua(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "lua", "fix", &["stylua", &abs], None, false)
+    }
+
+    pub(crate) fn check_lua(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "lua", "check", &["stylua", "--check", &abs], None, false)
+    }
+}

--- a/tools/dotfiles-lint/src/lint/rules/markdown.rs
+++ b/tools/dotfiles-lint/src/lint/rules/markdown.rs
@@ -1,0 +1,29 @@
+use super::super::{FileContext, Orchestrator};
+
+impl Orchestrator {
+    pub(crate) fn fix_markdown(&mut self, f: &FileContext) -> i32 {
+        let root = self.repo_root.clone();
+        let rel = f.rel_path.clone();
+        self.run_rule_cmd(
+            f,
+            "markdown",
+            "fix",
+            &["rumdl", "check", "--fix", "--config", ".rumdl.toml", &rel],
+            Some(&root),
+            false,
+        )
+    }
+
+    pub(crate) fn check_markdown(&mut self, f: &FileContext) -> i32 {
+        let root = self.repo_root.clone();
+        let rel = f.rel_path.clone();
+        self.run_rule_cmd(
+            f,
+            "markdown",
+            "check",
+            &["rumdl", "check", "--config", ".rumdl.toml", &rel],
+            Some(&root),
+            false,
+        )
+    }
+}

--- a/tools/dotfiles-lint/src/lint/rules/mod.rs
+++ b/tools/dotfiles-lint/src/lint/rules/mod.rs
@@ -1,0 +1,32 @@
+//! 言語別ルール。
+
+mod fish;
+mod lua;
+mod markdown;
+mod python;
+mod shell;
+mod toml;
+
+use super::{FileContext, classify};
+
+pub(super) fn match_shell(f: &FileContext) -> bool {
+    if !(classify::is_shell_ext(&f.rel_path) || classify::is_shell_path(&f.rel_path)) {
+        return false;
+    }
+    if classify::has_python_shebang(&f.abs_path) {
+        return false;
+    }
+    matches!(
+        classify::shell_flavor(&f.abs_path).as_str(),
+        "bash" | "sh" | ""
+    )
+}
+
+pub(super) fn match_python(f: &FileContext) -> bool {
+    classify::is_python(&f.rel_path) || classify::has_python_shebang(&f.abs_path)
+}
+
+/// CHANGELOG.md は自動生成のため除外する（root・各クレート直下の per-package とも）。
+pub(super) fn match_markdown(f: &FileContext) -> bool {
+    classify::is_markdown(&f.rel_path) && !classify::is_changelog(&f.rel_path)
+}

--- a/tools/dotfiles-lint/src/lint/rules/python.rs
+++ b/tools/dotfiles-lint/src/lint/rules/python.rs
@@ -1,0 +1,21 @@
+use super::super::{FileContext, Orchestrator};
+use crate::lint::exec::abs;
+
+impl Orchestrator {
+    pub(crate) fn fix_python(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "python", "fix", &["ruff", "format", &abs], None, false)
+    }
+
+    pub(crate) fn check_python(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(
+            f,
+            "python",
+            "check",
+            &["ruff", "format", "--check", &abs],
+            None,
+            false,
+        )
+    }
+}

--- a/tools/dotfiles-lint/src/lint/rules/shell.rs
+++ b/tools/dotfiles-lint/src/lint/rules/shell.rs
@@ -1,0 +1,62 @@
+use super::super::{FileContext, Orchestrator, classify};
+use crate::lint::exec::abs;
+
+impl Orchestrator {
+    pub(crate) fn fix_shell(&mut self, f: &FileContext) -> i32 {
+        if classify::is_home_chezmoi_shell_template(&f.rel_path, &self.repo_root) {
+            return 0;
+        }
+        let abs = abs(f);
+        self.run_rule_cmd(
+            f,
+            "shell",
+            "fix",
+            &["shfmt", "-w", "-i", "2", "-ci", &abs],
+            None,
+            false,
+        )
+    }
+
+    pub(crate) fn check_shell(&mut self, f: &FileContext) -> i32 {
+        if classify::is_home_chezmoi_shell_template(&f.rel_path, &self.repo_root) {
+            let rendered = match self.render_template(&f.rel_path, ".sh") {
+                Some(p) => p.to_string_lossy().into_owned(),
+                None => return 1,
+            };
+            let mut failed = 0;
+            if self.run_rule_cmd(
+                f,
+                "shell",
+                "check",
+                &["shfmt", "-d", "-i", "2", "-ci", &rendered],
+                None,
+                false,
+            ) != 0
+            {
+                failed = 1;
+            }
+            if self.run_rule_cmd(f, "shell", "check", &["shellcheck", &rendered], None, true) != 0 {
+                failed = 1;
+            }
+            return failed;
+        }
+
+        let abs = abs(f);
+        let mut failed = 0;
+        if self.run_rule_cmd(
+            f,
+            "shell",
+            "check",
+            &["shfmt", "-d", "-i", "2", "-ci", &abs],
+            None,
+            false,
+        ) != 0
+        {
+            failed = 1;
+        }
+        if self.run_rule_cmd(f, "shell", "check", &["shellcheck", &abs], None, false) != 0 {
+            failed = 1;
+        }
+        failed
+    }
+}

--- a/tools/dotfiles-lint/src/lint/rules/toml.rs
+++ b/tools/dotfiles-lint/src/lint/rules/toml.rs
@@ -1,0 +1,29 @@
+use super::super::{FileContext, Orchestrator};
+use crate::lint::exec::abs;
+
+impl Orchestrator {
+    pub(crate) fn fix_toml(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        self.run_rule_cmd(f, "toml", "fix", &["taplo", "fmt", &abs], None, false)
+    }
+
+    pub(crate) fn check_toml(&mut self, f: &FileContext) -> i32 {
+        let abs = abs(f);
+        let mut failed = 0;
+        if self.run_rule_cmd(
+            f,
+            "toml",
+            "check",
+            &["taplo", "fmt", "--check", &abs],
+            None,
+            false,
+        ) != 0
+        {
+            failed = 1;
+        }
+        if self.run_rule_cmd(f, "toml", "check", &["taplo", "lint", &abs], None, false) != 0 {
+            failed = 1;
+        }
+        failed
+    }
+}

--- a/tools/dotfiles-lint/src/lint/template.rs
+++ b/tools/dotfiles-lint/src/lint/template.rs
@@ -1,0 +1,45 @@
+//! chezmoi テンプレート展開。
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use super::Orchestrator;
+
+impl Orchestrator {
+    /// chezmoi テンプレートを展開して一時ファイルに書き出す。
+    pub(super) fn render_template(&self, rel_path: &str, ext: &str) -> Option<PathBuf> {
+        let source_dir = self.repo_root.join("home");
+        let src = self.repo_root.join(rel_path);
+        let out_name = format!("rendered_{}{}", rel_path.replace(['/', '.'], "_"), ext);
+        let out = self.tmp_dir.join(out_name);
+
+        let output = Command::new("chezmoi")
+            .arg("-S")
+            .arg(&source_dir)
+            .arg("execute-template")
+            .arg("-f")
+            .arg(&src)
+            .output();
+
+        match output {
+            Ok(o) if o.status.success() => {
+                if std::fs::write(&out, &o.stdout).is_err() {
+                    return None;
+                }
+                Some(out)
+            }
+            Ok(o) => {
+                eprintln!("lint: chezmoi execute-template failed: {rel_path}");
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                if !stderr.trim().is_empty() {
+                    eprintln!("{}", stderr.trim_end());
+                }
+                None
+            }
+            Err(_) => {
+                eprintln!("lint: chezmoi execute-template failed: {rel_path}");
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #416 の残件対応。

E2E を smoke（`--help`/`--version` 中心）から実挙動検証へ引き上げ、あわせて `gcm` / `dotfiles-lint` の闇鍋状態を役割別に分解した。

## 変更
- **E2E を実挙動ベースへ更新**
  - `gh-clone`: `gh` / `ghq` スタブで `clone -> migrate -> 移設先パス出力` を検証
  - `git-upstream`: 実 git repo + upstream remote で `-i` 初期化と `merge` 挙動を検証
  - `gcm`: 実 git repo + `claude` スタブで単一/複数提案コミットの実行を検証
  - `v-sync`: `nvim` / `chezmoi` スタブで呼び出し順と引数を検証
  - `dotfiles-workers`: スタブ/実 repo で結果ファイル作成・fetch スタンプ作成を検証
  - `copy-obj`: non-macOS 経路と macOS 経路（`osascript` 呼び出し）を分離して検証
- **`gcm` の役割分割**
  - `main.rs` から `git` / `claude` / `ui` / `execute` を分離
- **`dotfiles-lint` の役割分割**
  - `lint.rs` から `rules/*` / `exec.rs` / `template.rs` / `report.rs` へ分離
  - 既存 CLI 挙動は維持
- **CI 修正**
  - Linux `clippy -D warnings` での未使用 import を解消（`gcm` / `copy-obj` / `dotfiles-workers`）

## テスト
- `cargo fmt --all`
- `cargo test -p dotfiles-lint`
- `cargo test -p gh-clone -p v-sync -p git-upstream -p dotfiles-workers -p copy-obj -p gcm`

Closes #416

Made with [Cursor](https://cursor.com)