### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.69.1] - 2026-06-16
+### Features
+- _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))
+- _fzf_worktree_remove を Rust 化（B群 Rust化 PR2/3） ([#414](https://github.com/toshiki670/dotfiles/pull/414)) ([`0884b97`](https://github.com/toshiki670/dotfiles/commit/0884b973f5e5f4d4ea0e5b47c0ac8ad929bfae9c))
+- Cdabbr を Rust 化（B群 Rust化 PR3/3・完了） ([#415](https://github.com/toshiki670/dotfiles/pull/415)) ([`ef312d0`](https://github.com/toshiki670/dotfiles/commit/ef312d08243cfdc7ee23888f4669e39378847043))
+- メモリ棚卸し Skill memory-tidy を追加 ([#420](https://github.com/toshiki670/dotfiles/pull/420)) ([`4d8ce5c`](https://github.com/toshiki670/dotfiles/commit/4d8ce5ccb7b36f8aff53efcf8ff863e99e827520))
+- Cleanup-env・upgrade-env を Rust 化 ([#390](https://github.com/toshiki670/dotfiles/pull/390)) ([#421](https://github.com/toshiki670/dotfiles/pull/421)) ([`876dacd`](https://github.com/toshiki670/dotfiles/commit/876dacd14aff91ca396dd12a1c5441a15f007c85))
+### Fixes
+- Per-package CHANGELOG.md も markdown lint から除外 ([#411](https://github.com/toshiki670/dotfiles/pull/411)) ([`336fe09`](https://github.com/toshiki670/dotfiles/commit/336fe0996ec01f0d71283c9426651ed2d167ba16))
+
+
 ## [0.69.0] - 2026-06-16
 
 Rust / Cargo workspace 化のブートストラップリリース（epic #388）。シェル関数群を Rust バイナリへ移行し、release-plz による per-package バージョニングを確立した。以降のフォーマットは release-plz（git-cliff）に統一される。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license     = { workspace = true }
 name        = "dotfiles"
 publish     = false
 repository  = { workspace = true }
-version     = "0.69.0"
+version     = "0.69.1"
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/color/CHANGELOG.md
+++ b/crates/color/CHANGELOG.md
@@ -3,3 +3,4 @@
 All notable changes to this project will be documented in this file.
 
 
+

--- a/crates/copy-obj/CHANGELOG.md
+++ b/crates/copy-obj/CHANGELOG.md
@@ -3,3 +3,4 @@
 All notable changes to this project will be documented in this file.
 
 
+

--- a/crates/env-tools/CHANGELOG.md
+++ b/crates/env-tools/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+### Features
+- Cleanup-env・upgrade-env を Rust 化 ([#390](https://github.com/toshiki670/dotfiles/pull/390)) ([#421](https://github.com/toshiki670/dotfiles/pull/421)) ([`876dacd`](https://github.com/toshiki670/dotfiles/commit/876dacd14aff91ca396dd12a1c5441a15f007c85))
+

--- a/crates/fzf-picker/CHANGELOG.md
+++ b/crates/fzf-picker/CHANGELOG.md
@@ -1,3 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+### Features
+- _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))
+- _fzf_worktree_remove を Rust 化（B群 Rust化 PR2/3） ([#414](https://github.com/toshiki670/dotfiles/pull/414)) ([`0884b97`](https://github.com/toshiki670/dotfiles/commit/0884b973f5e5f4d4ea0e5b47c0ac8ad929bfae9c))
+- Cdabbr を Rust 化（B群 Rust化 PR3/3・完了） ([#415](https://github.com/toshiki670/dotfiles/pull/415)) ([`ef312d0`](https://github.com/toshiki670/dotfiles/commit/ef312d08243cfdc7ee23888f4669e39378847043))
+
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/crates/gcm/CHANGELOG.md
+++ b/crates/gcm/CHANGELOG.md
@@ -3,3 +3,4 @@
 All notable changes to this project will be documented in this file.
 
 
+

--- a/crates/git-upstream/CHANGELOG.md
+++ b/crates/git-upstream/CHANGELOG.md
@@ -3,3 +3,4 @@
 All notable changes to this project will be documented in this file.
 
 
+


### PR DESCRIPTION



## 🤖 New release

* `color`: 0.1.0
* `copy-obj`: 0.1.0
* `dotfiles-workers`: 0.1.0
* `env-tools`: 0.1.0
* `fzf-picker`: 0.1.0
* `gcm`: 0.1.0
* `gh-clone`: 0.1.0
* `git-upstream`: 0.1.0
* `v-sync`: 0.1.0
* `dotfiles`: 0.69.0 -> 0.69.1

<details><summary><i><b>Changelog</b></i></summary><p>



## `dotfiles-workers`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>

## `env-tools`

<blockquote>

## [0.1.0] - 2026-06-16

### Features
- Cleanup-env・upgrade-env を Rust 化 ([#390](https://github.com/toshiki670/dotfiles/pull/390)) ([#421](https://github.com/toshiki670/dotfiles/pull/421)) ([`876dacd`](https://github.com/toshiki670/dotfiles/commit/876dacd14aff91ca396dd12a1c5441a15f007c85))
</blockquote>

## `fzf-picker`

<blockquote>

## [0.1.0] - 2026-06-16

### Features
- _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))
- _fzf_worktree_remove を Rust 化（B群 Rust化 PR2/3） ([#414](https://github.com/toshiki670/dotfiles/pull/414)) ([`0884b97`](https://github.com/toshiki670/dotfiles/commit/0884b973f5e5f4d4ea0e5b47c0ac8ad929bfae9c))
- Cdabbr を Rust 化（B群 Rust化 PR3/3・完了） ([#415](https://github.com/toshiki670/dotfiles/pull/415)) ([`ef312d0`](https://github.com/toshiki670/dotfiles/commit/ef312d08243cfdc7ee23888f4669e39378847043))
</blockquote>


## `gh-clone`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>


## `v-sync`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>

## `dotfiles`

<blockquote>

## [0.69.1] - 2026-06-16

### Features
- _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))
- _fzf_worktree_remove を Rust 化（B群 Rust化 PR2/3） ([#414](https://github.com/toshiki670/dotfiles/pull/414)) ([`0884b97`](https://github.com/toshiki670/dotfiles/commit/0884b973f5e5f4d4ea0e5b47c0ac8ad929bfae9c))
- Cdabbr を Rust 化（B群 Rust化 PR3/3・完了） ([#415](https://github.com/toshiki670/dotfiles/pull/415)) ([`ef312d0`](https://github.com/toshiki670/dotfiles/commit/ef312d08243cfdc7ee23888f4669e39378847043))
- メモリ棚卸し Skill memory-tidy を追加 ([#420](https://github.com/toshiki670/dotfiles/pull/420)) ([`4d8ce5c`](https://github.com/toshiki670/dotfiles/commit/4d8ce5ccb7b36f8aff53efcf8ff863e99e827520))
- Cleanup-env・upgrade-env を Rust 化 ([#390](https://github.com/toshiki670/dotfiles/pull/390)) ([#421](https://github.com/toshiki670/dotfiles/pull/421)) ([`876dacd`](https://github.com/toshiki670/dotfiles/commit/876dacd14aff91ca396dd12a1c5441a15f007c85))
### Fixes
- Per-package CHANGELOG.md も markdown lint から除外 ([#411](https://github.com/toshiki670/dotfiles/pull/411)) ([`336fe09`](https://github.com/toshiki670/dotfiles/commit/336fe0996ec01f0d71283c9426651ed2d167ba16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).