### PR TITLE
fix(release): dotfiles-lint に publish=false を明示し release-plz の整合性エラーを解消

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -27,6 +27,10 @@ name         = "dotfiles"
 
 # dotfiles-lint は repo 内部の開発専用ツール（xtask 定石）。版を振らず、リリース
 # もしない。`release = false` で release-plz の処理対象から完全に除外する。
+# `publish = false` も明示する: package ブロックを持つと workspace の git_only による
+# publish=false が継承されず default(true) に解決され、Cargo.toml の publish=false と
+# 矛盾して release-plz の整合性チェックでエラーになるため（Cargo.toml と一致させる）。
 [[package]]
 name    = "dotfiles-lint"
+publish = false
 release = false


### PR DESCRIPTION
## 背景

[release-publish run #27635706623](https://github.com/toshiki670/dotfiles/actions/runs/27635706623)（PR #422「chore: release」マージ後）が `release-plz release` で exit 1。

```
ERROR Package `dotfiles-lint` has `publish = false` or `publish = []` in the Cargo.toml,
      but it has `publish = true` in the release-plz configuration.
```

## 原因

`dotfiles-lint` の `[[package]]` ブロック（`release = false`）は #407 (c80ed92) で追加された。これが入った後の最初の実リリース実行が #422 で、ここで初めて publish 整合性チェックに到達した。

配布クレートは workspace の `git_only = true` により config 上 `publish=false` に解決され Cargo.toml と一致するが、`dotfiles-lint` だけは `release = false` を指定したことで `publish` が default(true) に解決され、Cargo.toml の `publish=false` と矛盾していた。

## 修正

`release-plz.toml` の `dotfiles-lint` ブロックに `publish = false` を明示し、Cargo.toml と一致させる。意図（版を振らず install も publish もしない開発専用ツール）どおりで副作用なし。`mise run check` パス済み。

## 影響

#422 が bump したバージョンに対応する git タグ／Release はバリデーション停止により未作成。本 PR を main に入れれば次の release 実行で未作成タグが復旧する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)