### PR TITLE
fix(release): workspace に publish=false を設定し release の整合性エラーを根絶

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,32 +4,38 @@
 # crates.io へは publish しない。
 #
 # `git_only = true`: 最新リリース版の判定を「git タグ」から行う（crates.io を参照しない）。
-# これが本リポジトリの設計（per-package タグ = 版の SoT）。
-# 注意: 単に `publish = false` だけだと cargo publish は止まるが、release-plz は
-# 「最新リリースの判定」に依然 crates.io を参照する。本クレート群は crates.io に
-# 存在しないため版の基準を確立できず、Release PR が空になる（{"prs":[]}）。
-# `git_only = true` は publish もスキップするので `publish = false` を内包する。
+# これが本リポジトリの設計（per-package タグ = 版の SoT）。単に `publish = false` だけ
+# だと release-plz は最新版判定に依然 crates.io を参照し、未公開クレートでは版の基準を
+# 確立できず Release PR が空になる（{"prs":[]}）ため、git_only が必須。
+#
+# `publish = false`（workspace）: ① cargo publish を止める（crates.io へは出さない）。
+# ② release-plz は member ごとに「config の publish」と「Cargo.toml の publish」を
+# 突き合わせ、不一致だと `release` がエラーで停止する（Package ... has publish = false
+# in the Cargo.toml, but it has publish = true in the release-plz configuration）。全
+# member の Cargo.toml が publish=false なので config 側も false に揃える。git_only は
+# publish を false にしない（独立フィールド）ため、ここで明示する。
 [workspace]
 changelog_config   = "cliff.toml"
 changelog_update   = true
 git_only           = true
 git_release_draft  = false
 git_release_enable = true
+publish            = false
 # member の既定タグ。複数パッケージ workspace の既定値を明示しておく。
 git_tag_name     = "{{ package }}-v{{ version }}"
 pr_branch_prefix = "release-"
 
 # root package = `dotfiles` 本体（core）。タグは従来どおり `v{version}` を維持する
 # （0.68.0 からの連続。`git_tag_name` を root だけ上書き）。
+# `publish = false` を明示（workspace 値の継承に依存せず整合性チェックを確実に通す）。
 [[package]]
 git_tag_name = "v{{ version }}"
 name         = "dotfiles"
+publish      = false
 
 # dotfiles-lint は repo 内部の開発専用ツール（xtask 定石）。版を振らず、リリース
 # もしない。`release = false` で release-plz の処理対象から完全に除外する。
-# `publish = false` も明示する: package ブロックを持つと workspace の git_only による
-# publish=false が継承されず default(true) に解決され、Cargo.toml の publish=false と
-# 矛盾して release-plz の整合性チェックでエラーになるため（Cargo.toml と一致させる）。
+# `publish = false` も明示（workspace 値の継承に依存せず整合性チェックを確実に通す）。
 [[package]]
 name    = "dotfiles-lint"
 publish = false


### PR DESCRIPTION
## 背景

#423 で `dotfiles-lint` に `publish = false` を入れたが、[release-publish #27657821578](https://github.com/toshiki670/dotfiles/actions/runs/27657821578) で今度は **root の `dotfiles`** が同じエラーで停止した。

```
ERROR Package `dotfiles` has `publish = false` in the Cargo.toml,
      but it has `publish = true` in the release-plz configuration.
```

## 原因（#423 の見立ては誤りだった）

release-plz の `release` は member ごとに **「config の publish」 vs 「Cargo.toml の publish」** を突き合わせ、不一致なら停止する。全 member の Cargo.toml は `publish = false` だが、release-plz config 側は default(`true`) のまま。これが**非決定的な検証順で 1 個ずつ**露見していた（run1=dotfiles-lint → #423 で潰す → run2=dotfiles）。

公式ドキュメントで確認したとおり `git_only` は**バージョン判定を git タグから行うだけ**で `publish` を false にはしない（独立フィールド）。「git_only が publish=false を内包する」という従来コメントは誤りだった。そもそもこの `git_only` 構成下で `release-plz release` が成功したことは一度もない（#408 設定 → 初の実 release が #422 で失敗）。

## 修正

- `[workspace] publish = false` を設定 → 全 member の config-publish を false に揃え、Cargo.toml と一致させる（検証順に依存せず一括解消）。
- `dotfiles` / `dotfiles-lint` のブロックにも `publish = false` を明示（workspace 値の継承挙動に依存せず確実に通す）。
- 誤っていたコメントを実態に合わせて修正。

`crates.io` publish は元々不要なので副作用なし。`git_only` は据え置き（バージョン判定は git タグのまま）。`mise run check` パス済み。

## マージ後のリカバリ（別途対応）

main は `dotfiles` 0.69.1 / 各クレート 0.1.0 に bump 済みだが**対応タグが未作成**（過去の release 失敗のため）。本 PR マージ後に release PR を 1 本通せば、修正済み config で `release-plz release` が走り、`v0.69.1` + 各 `*-v0.1.0` タグ/Release が作られて整合する。旧 release-please の残骸ブランチ `release-please--branches--main` も削除予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)