### PR TITLE
feat(release): release PR タイトルにルート dotfiles 版を付与

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -27,3 +27,32 @@ jobs:
         env:
           # PAT で PR を作成し、Release PR 上で CI を発火させる（GITHUB_TOKEN では発火しない）。
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      # release PR の title にルート dotfiles 版を付ける。release-plz の pr_name は
+      # 版が異なる多パッケージ時に version を埋められず（pr_name は特定パッケージ版を
+      # 参照不可）generic な "chore: release" になるため、ここで上書きする。bump 後の
+      # Cargo.toml は release ブランチ側にあり、main は未 bump な点に注意。
+      - name: Set Release PR title to root version
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          release_prs=$(gh pr list --repo "${{ github.repository }}" --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-"))]')
+          pr_number=$(jq -r '.[0].number // empty' <<<"$release_prs")
+          head_branch=$(jq -r '.[0].headRefName // empty' <<<"$release_prs")
+          if [ -z "$pr_number" ] || [ -z "$head_branch" ]; then
+            echo "release PR が見つからないため title 変更をスキップ"
+            exit 0
+          fi
+          git fetch --quiet origin "$head_branch"
+          root_version=$(git show "FETCH_HEAD:Cargo.toml" \
+            | sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -n1)
+          if [ -z "$root_version" ]; then
+            echo "::warning::ルート版を取得できず title 変更をスキップ"
+            exit 0
+          fi
+          new_title="chore: release v${root_version}"
+          echo "PR #${pr_number} の title を「${new_title}」に設定"
+          gh pr edit "$pr_number" --repo "${{ github.repository }}" --title "$new_title"


### PR DESCRIPTION
## 背景

release PR（[例 #424](https://github.com/toshiki670/dotfiles/pull/424)）の title が `chore: release` で、ルート `dotfiles` の bump 版（例 `v0.69.2`）が出ないのを改善したい。

## なぜ pr_name では無理か

release-plz の `pr_name` テンプレートで使える変数は `package` と `version` のみで、`version` は**「単一パッケージ」または「全パッケージ同一版」のときだけ**埋まる（一次ソースで確認）。本リポジトリは `dotfiles` 0.69.x と各クレート 0.1.0 が**版違いで混在**するため version が空になり、generic な `chore: release` になる。per-package 版を参照する手段（`releases` 配列）は `pr_body` 専用で `pr_name` にはない。

## 修正

`release-prepare.yml` の release-plz step の後に後処理 step を追加:
1. open な `release-*` PR を `gh pr list` で特定
2. その release ブランチ側の **bump 後 Cargo.toml**（main は未 bump）からルート `dotfiles` 版を読む
3. `gh pr edit` で title を `chore: release v{version}` に上書き

版が混在する回でも必ずルート版が出る。非クリティカル経路（取得失敗時は warning で skip、PR 自体は残る）。毎回 release-plz の後に走るので、PR 更新時も title を維持。

## 検証

- YAML パース OK（ruby/psych）
- 埋め込み run スクリプトを shellcheck（指摘なし）

マージ後、リカバリの release PR でタイトルが `chore: release v0.69.1` になることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)