### PR TITLE
fix(release): root dotfiles を publishable にしてタグ生成を検証（カナリア）

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 # root package = `dotfiles` コマンド（= dotfiles 本体 / core）。
 # いまは chezmoi と各コマンドに委譲しているが、将来それらを取り込む器。
 # version は SoT（タグ `v{version}`）。当面は clap で `dotfiles --version` が取れれば十分。
+# publish はあえて false にしない: release-plz は Cargo.toml が publish=false の package を
+# release 対象から除外しタグを作らない（再追加すると release が "nothing to release" になる）。
+# crates.io への publish 抑止は release-plz config の publish=false + git_only に一本化。
 [package]
 description = "toshiki670/dotfiles 本体（core）コマンド"
 edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
-publish     = false
 repository  = { workspace = true }
 version     = "0.69.1"
 


### PR DESCRIPTION
## 目的（カナリア検証）

過去の失敗から、`publish` の真理値表で残る唯一の現実解 **「Cargo.toml=true × release-plz config=false」** が本当に効くかを、まず **root `dotfiles` 1 パッケージだけ**で検証する。

| Cargo.toml | config | 結果 | 実測 |
|---|---|---|---|
| false | true | ❌ validation error | #422, #424 |
| false | false | ❌ nothing to release | #427 |
| **true** | **false** | ✅ タグ作成（の想定） | ← **本PRで検証** |

## 変更

- root `Cargo.toml` から `publish = false` を削除（release-plz の release 対象に含める）
- 再発防止コメントを追加（publish=false を再追加すると release が "nothing to release" になる旨）
- crates.io publish 抑止は release-plz config の `[workspace] publish = false` + `git_only`（既設）に一本化
- 配布 9 クレート・dotfiles-lint は **据え置き**（カナリアなので変更しない）

## 期待結果

マージ → release-prepare → release PR マージ → release-publish で、**`v0.69.1` タグ + GitHub Release だけが作られる**（クレートは publish=false のままなので未生成）。これが確認できれば真理値表の未検証マスが確定し、続けて 9 クレートも外して残りタグを生成する。

`mise run check` パス・`cargo metadata` で dotfiles の publish が解除されたことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)