### PR TITLE
fix(release): root の Release 名から dotfiles- 接頭辞を外す

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -27,11 +27,14 @@ pr_branch_prefix = "release-"
 
 # root package = `dotfiles` 本体（core）。タグは従来どおり `v{version}` を維持する
 # （0.68.0 からの連続。`git_tag_name` を root だけ上書き）。
+# `git_release_name` も上書き: 既定は多パッケージ workspace で `{{ package }}-v{{ version }}`
+# となり Release 名が `dotfiles-v0.69.1` になる。タグ（v0.69.1）と揃えて `v{version}` にする。
 # `publish = false` を明示（workspace 値の継承に依存せず整合性チェックを確実に通す）。
 [[package]]
-git_tag_name = "v{{ version }}"
-name         = "dotfiles"
-publish      = false
+git_release_name = "v{{ version }}"
+git_tag_name     = "v{{ version }}"
+name             = "dotfiles"
+publish          = false
 
 # dotfiles-lint は repo 内部の開発専用ツール（xtask 定石）。版を振らず、リリース
 # もしない。`release = false` で release-plz の処理対象から完全に除外する。


### PR DESCRIPTION
## 背景

root の GitHub Release 名が **`dotfiles-v0.69.1`** になっている（タグ自体は `v0.69.1`）。`git_release_name` の既定が多パッケージ workspace で `{{ package }}-v{{ version }}` のため。

## 変更

root `dotfiles` ブロックに `git_release_name = "v{{ version }}"` を追加し、Release 名をタグと揃えて **`v0.69.1`** にする。配布クレートは `color-v0.1.0` 等の接頭辞付きが適切なので root だけ上書き（`git_tag_name` を root だけ上書きしているのと同じ方針）。

`mise run check` パス済み。

## 注意（既存 Release）

本変更は**今後の release** に適用される。既に作成済みの `dotfiles-v0.69.1` Release は自動では改名されないため、必要なら別途 `gh release edit v0.69.1 --title "v0.69.1"` でリネームする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)