### PR TITLE
chore: release v0.69.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.69.2] - 2026-06-17
+### Fixes
+- Root の Release 名から dotfiles- 接頭辞を外す ([#431](https://github.com/toshiki670/dotfiles/pull/431)) ([`72c6cf6`](https://github.com/toshiki670/dotfiles/commit/72c6cf6b43d2890191713be43ca337aa857112d0))
+
+
 ## [0.69.1] - 2026-06-16
 ### Features
 - _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.69.1"
+version = "0.69.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.69.1"
+version     = "0.69.2"
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/color/CHANGELOG.md
+++ b/crates/color/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.0] - 2026-06-17
+### Fixes
+- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
+
 
 
 

--- a/crates/copy-obj/CHANGELOG.md
+++ b/crates/copy-obj/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.0] - 2026-06-17
+### Fixes
+- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
+
 
 
 

--- a/crates/gcm/CHANGELOG.md
+++ b/crates/gcm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.0] - 2026-06-17
+### Fixes
+- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
+
 
 
 

--- a/crates/git-upstream/CHANGELOG.md
+++ b/crates/git-upstream/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.0] - 2026-06-17
+### Fixes
+- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
+
 
 
 


### PR DESCRIPTION



## 🤖 New release

* `color`: 0.1.0
* `copy-obj`: 0.1.0
* `dotfiles-workers`: 0.1.0
* `env-tools`: 0.1.0
* `fzf-picker`: 0.1.0
* `gcm`: 0.1.0
* `gh-clone`: 0.1.0
* `git-upstream`: 0.1.0
* `v-sync`: 0.1.0
* `dotfiles`: 0.69.1 -> 0.69.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `color`

<blockquote>

## [0.1.0] - 2026-06-17

### Fixes
- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
</blockquote>

## `copy-obj`

<blockquote>

## [0.1.0] - 2026-06-17

### Fixes
- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
</blockquote>

## `dotfiles-workers`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>

## `env-tools`

<blockquote>

## [0.1.0] - 2026-06-16

### Features
- Cleanup-env・upgrade-env を Rust 化 ([#390](https://github.com/toshiki670/dotfiles/pull/390)) ([#421](https://github.com/toshiki670/dotfiles/pull/421)) ([`876dacd`](https://github.com/toshiki670/dotfiles/commit/876dacd14aff91ca396dd12a1c5441a15f007c85))
</blockquote>

## `fzf-picker`

<blockquote>

## [0.1.0] - 2026-06-16

### Features
- _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))
- _fzf_worktree_remove を Rust 化（B群 Rust化 PR2/3） ([#414](https://github.com/toshiki670/dotfiles/pull/414)) ([`0884b97`](https://github.com/toshiki670/dotfiles/commit/0884b973f5e5f4d4ea0e5b47c0ac8ad929bfae9c))
- Cdabbr を Rust 化（B群 Rust化 PR3/3・完了） ([#415](https://github.com/toshiki670/dotfiles/pull/415)) ([`ef312d0`](https://github.com/toshiki670/dotfiles/commit/ef312d08243cfdc7ee23888f4669e39378847043))
</blockquote>

## `gcm`

<blockquote>

## [0.1.0] - 2026-06-17

### Fixes
- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
</blockquote>

## `gh-clone`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>

## `git-upstream`

<blockquote>

## [0.1.0] - 2026-06-17

### Fixes
- 配布9クレートを publishable にし per-package タグを生成可能に ([#430](https://github.com/toshiki670/dotfiles/pull/430)) ([`6a03872`](https://github.com/toshiki670/dotfiles/commit/6a0387280fb5ebd5f2f79592f816defd2679d9b5))
</blockquote>

## `v-sync`

<blockquote>

## [0.1.0] - 2026-06-16

### Fixes
- 内部依存を解消し cargo package を通す + root を v0.69.0 にブートストラップ ([#409](https://github.com/toshiki670/dotfiles/pull/409)) ([`f2f94f6`](https://github.com/toshiki670/dotfiles/commit/f2f94f6b64f4592c02c48c591d2627604c20572a))
</blockquote>

## `dotfiles`

<blockquote>

## [0.69.2] - 2026-06-17

### Fixes
- Root の Release 名から dotfiles- 接頭辞を外す ([#431](https://github.com/toshiki670/dotfiles/pull/431)) ([`72c6cf6`](https://github.com/toshiki670/dotfiles/commit/72c6cf6b43d2890191713be43ca337aa857112d0))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).