### PR TITLE
fix(memory-tidy): トリガーを /memory-tidy のみに限定

### DIFF
--- a/home/dot_claude/skills/memory-tidy/SKILL.md
+++ b/home/dot_claude/skills/memory-tidy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-tidy
-description: プロジェクトの Auto memory（~/.claude/projects/<project>/memory/ の MEMORY.md ＋ fact ファイル群）を棚卸しする。陳腐化したメモリの検出・更新、重複の統合、不要メモリの削除、索引の同期を行う。ユーザーが「メモリを棚卸し/整理/最適化して」「古いメモリある?」等と言ったとき、または /memory-tidy で起動する。
+description: "/memory-tidy で明示的に起動したときのみ使用する。プロジェクトの Auto memory（~/.claude/projects/<project>/memory/ の MEMORY.md ＋ fact ファイル群）を棚卸しする（陳腐化したメモリの検出・更新、重複の統合、不要メモリの削除、索引の同期）。ユーザーの自然言語の依頼では自動起動しない。"
 ---
 
 # memory-tidy — Auto memory の棚卸し


### PR DESCRIPTION
## 概要

`memory-tidy` スキルの起動トリガーを `/memory-tidy` の明示起動のみに限定する。

## 背景・変更内容

`SKILL.md` の `description` に「メモリを棚卸し/整理/最適化して」「古いメモリある?」といった自然言語フレーズが含まれており、ユーザーがこれらに近い発話をすると自動起動し得た。これを避けるため `description` を書き換えた:

- 冒頭に「`/memory-tidy` で明示的に起動したときのみ使用する」を明記
- 末尾に「ユーザーの自然言語の依頼では自動起動しない」を追加
- 自動起動を誘う自然言語トリガー例を削除

スキルの自動起動判定は `description` を見て行われるため、これで実質 `/memory-tidy` 経由に限定される。

## 反映

chezmoi のソース（`home/dot_claude/...`）のため、実環境への反映には `chezmoi apply` が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)