### PR TITLE
chore: update telescope lock and refresh Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,9 +777,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/home/dot_config/nvim/lazy-lock.json
+++ b/home/dot_config/nvim/lazy-lock.json
@@ -24,7 +24,7 @@
   "onehalf": { "branch": "master", "commit": "75eb2e97acd74660779fed8380989ee7891eec56" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40" },
-  "telescope.nvim": { "branch": "master", "commit": "7d324792b7943e4aa16ad007212e6acc6f9fe335" },
+  "telescope.nvim": { "branch": "master", "commit": "9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc" },
   "trouble.nvim": { "branch": "main", "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a" },
   "vim-cheatsheet": { "branch": "master", "commit": "35a8d57e53abc210b1baa9377965ffe360b84334" },
   "vim-fugitive": { "branch": "master", "commit": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0" },


### PR DESCRIPTION
## Summary
- Update the pinned `telescope.nvim` revision in `home/dot_config/nvim/lazy-lock.json`
- Include the related `Cargo.lock` refresh (`syn` 2.0.117 -> 2.0.118)
- Keep lockfiles aligned on a dedicated maintenance branch

## Test plan
- [x] Confirmed branch diff only updates lockfiles
- [x] Verified working tree is clean after commits
- [ ] Run any project-specific checks if needed

Made with [Cursor](https://cursor.com)