### PR TITLE
fix(chezmoi): cargo-install フックを run_before 化し補完の初回取りこぼしを修正

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_cargo-install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_cargo-install.sh.tmpl
@@ -14,6 +14,15 @@
 # Each crate is installed in turn into ~/.cargo/bin, but they share a single
 # --target-dir so workspace dependencies are compiled once and reused.
 #
+# This is a run_*before* hook (not after) on purpose: fish completion templates
+# such as dot_config/fish/completions/clip.fish.tmpl gate generation on
+# `{{ "{{ if lookPath \"clip\" }}" }}`. chezmoi runs all run_before scripts, *then*
+# renders/applies file targets, so building the self-owned binaries here ensures
+# they are on $PATH by the time those templates evaluate lookPath — otherwise the
+# first apply that introduces a new self-owned command would write an empty
+# completion file and only recover on a second apply. External tools (bat/docker/
+# gh) are unaffected: their completions depend on separately-installed binaries.
+#
 # rust/cargo is supplied on-demand by mise (`mise exec rust@latest`), so this
 # works on a fresh machine before `mise install` has run and regardless of the
 # create-once global mise config (~/.config/mise/config.toml) state.


### PR DESCRIPTION
## 背景 / 症状

`clip` / `merge-ready` など**自前ツール**の fish 補完テンプレート（例: `home/dot_config/fish/completions/clip.fish.tmpl`）は、`{{ if lookPath "<bin>" }}` でバイナリの存在を gate して `output "<bin>" "completions" "fish"` を生成している。

しかしバイナリをビルド・インストールする `cargo-install` フックが **`run_after`** だったため、適用順序の鶏卵問題が発生していた:

1. 補完テンプレートはメインパスで先にレンダリングされる
2. その時点で自前バイナリはまだビルドされていない（ビルドは後段の `run_after` フック）
3. → `lookPath` が偽 → **空の補完ファイル**が書かれる
4. その後 cargo-install がビルド
5. → **2 回目の apply まで補完が空のまま**

`clip` を新規導入した #435 で実発生。

## 修正

`run_onchange_after_cargo-install.sh.tmpl` → `run_onchange_before_cargo-install.sh.tmpl` にリネーム。

chezmoi の実行順序は「全 `run_before` → ファイル適用 → 全 `run_after`」なので、フックを `run_before` 化することで、補完テンプレートが `lookPath` を評価する時点で自前バイナリが `$PATH` 上に存在することを保証する。テンプレートも chezmoi 管理もそのまま、リネーム + 根拠コメント追記のみ。

## 検証

- **chezmoi の評価順序**: 使い捨て環境で実証 → `run_before` で作ったバイナリが同じ apply 内のファイルテンプレートの `lookPath` で `FOUND` になる（chezmoi v2.70.5）。
- **テンプレート健全性**: dry-run でエラーなし。コメント内のエスケープ `{{ if lookPath "clip" }}` も正しくリテラル化。
- **退行なし**: `chezmoi diff ~/.config/fish/completions/clip.fish` は空。
- 依存的に安全: cargo-install は `mise`(外部) と sourceDir にしか依存せず、適用される home ファイルに依存しない。外部ツール(bat/docker/gh)の補完は別途インストールされるバイナリに依存するため影響なし。
- `merge-ready` や将来追加する自前ツール補完も同じ仕組みで自動的に救済される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)