### PR TITLE
feat(starship): java/kotlin のプロンプトから via を非表示化

### DIFF
--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -116,12 +116,14 @@ symbol = " "
 ssh_symbol = " "
 
 [java]
+format = '[${symbol}(${version} )]($style)'
 symbol = " "
 
 [julia]
 symbol = " "
 
 [kotlin]
+format = '[$symbol($version )]($style)'
 symbol = " "
 
 [lua]


### PR DESCRIPTION
## 概要

starship のプロンプトで java / kotlin の `via` 表示を消す。`via ` プレフィックスのみを公式デフォルト `format` から取り除き、シンボルとバージョンは従来どおり表示する。

## 変更内容

`home/dot_config/starship.toml.tmpl` の `[java]` / `[kotlin]` に `format` を追加。

| モジュール | 設定値 | 備考 |
|---|---|---|
| java | `'[${symbol}(${version} )]($style)'` | 公式デフォルト `'via [${symbol}(${version} )]($style)'` から `via ` を除去 |
| kotlin | `'[$symbol($version )]($style)'` | 公式デフォルト `'via [$symbol($version )]($style)'` から `via ` を除去 |

いずれも公式デフォルトのブレース表記に揃えている。

## 反映方法

`chezmoi apply` で `~/.config/starship.toml` へデプロイ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)