### PR TITLE
fix(release-plz): 依存更新だけの空 patch bump を release_commits で抑止

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -24,6 +24,12 @@ publish            = false
 # member の既定タグ。複数パッケージ workspace の既定値を明示しておく。
 git_tag_name     = "{{ package }}-v{{ version }}"
 pr_branch_prefix = "release-"
+# リリース対象とするコミットを限定する。これに「マッチするコミットが 1 つも無い」
+# パッケージは bump しない。狙いは Cargo.lock の transitive 依存更新（例: clip 追加で
+# syn が 2.0.117→2.0.118）だけで、ソース無変更のクレートまで一斉に patch bump される
+# 事故（#441）の抑止。正規表現は cliff.toml の commit_parsers（feat/fix/perf/refactor/
+# revert を採用、他は skip）と揃える。
+release_commits = "^(feat|fix|perf|refactor|revert)"
 
 # root package = `dotfiles` 本体（core）。タグは従来どおり `v{version}` を維持する
 # （0.68.0 からの連続。`git_tag_name` を root だけ上書き）。


### PR DESCRIPTION
## 背景

リリース PR #441 で、ソースを変更していない 7 クレート（color / gcm / gh-clone /
git-upstream / v-sync / dotfiles-workers / env-tools）まで `0.1.0 → 0.1.1` に bump され、
空の CHANGELOG エントリが生成されていた。

## 原因

release-plz は「crate にパッケージされるファイルのいずれかが変わると bump する。
これには **Cargo.lock の依存更新** も含む」仕様（公式 FAQ）。#435（clip 統合）の
マージで `Cargo.lock` が再解決され、transitive dependency の `syn` が
`2.0.117 → 2.0.118` に上がり `clap_complete 4.6.5` が追加された。配布 9 クレートは
全て `clap` を使う（= `syn` を間接依存）ため、ソース無変更のクレートまで一斉に
patch bump された（空 CHANGELOG はこの「依存更新のみ bump」のシグネチャ）。

## 対応

`release-plz.toml` の `[workspace]` に以下を追加。マッチするコミットが 1 つも無い
パッケージは bump しない。正規表現は `cliff.toml` の `commit_parsers`（feat / fix /
perf / refactor / revert を採用、他は skip）と揃えた。

```toml
release_commits = "^(feat|fix|perf|refactor|revert)"
```

## 検証

ローカルで `release-plz update`（v0.3.159）を実行し、bump 対象が以下の 3 つに
限定されることを確認した:

- `clip`: 0.1.0（新規）
- `fzf-picker`: 0.1.1
- `dotfiles`: 0.69.3

`color` など 7 クレートの `Cargo.toml` / `CHANGELOG` は無変更。

## マージ後の手順

main にマージ後、`release-prepare` workflow（workflow_dispatch）を再実行すると
#441（新しい Release PR）が `release_commits` を反映した内容で再生成される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
