### PR TITLE
chore: release v0.69.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.69.3] - 2026-06-18
+### Features
+- Copy-obj / c-file / c-path を clip コマンドへ統合 ([#435](https://github.com/toshiki670/dotfiles/pull/435)) ([`d9d247e`](https://github.com/toshiki670/dotfiles/commit/d9d247eb30bf6235a00594e0b10c84c79d917da0))
+- Java/kotlin のプロンプトから via を非表示化 ([#440](https://github.com/toshiki670/dotfiles/pull/440)) ([`31f0f84`](https://github.com/toshiki670/dotfiles/commit/31f0f84b79c6ef39445f4cbe0ce799e668e6111b))
+### Fixes
+- トリガーを /memory-tidy のみに限定 ([#433](https://github.com/toshiki670/dotfiles/pull/433)) ([`355f16d`](https://github.com/toshiki670/dotfiles/commit/355f16df411ca65ed90b8531d7b45e6eec612310))
+- Cargo-install フックを run_before 化し補完の初回取りこぼしを修正 ([#438](https://github.com/toshiki670/dotfiles/pull/438)) ([`9307bc7`](https://github.com/toshiki670/dotfiles/commit/9307bc7827e154f8e72a6485fd75015d30d3a837))
+- 依存更新だけの空 patch bump を release_commits で抑止 ([#443](https://github.com/toshiki670/dotfiles/pull/443)) ([`4a5dcad`](https://github.com/toshiki670/dotfiles/commit/4a5dcad46bca85025c911f4639858f529c0a308a))
+
+
 ## [0.69.2] - 2026-06-17
 ### Fixes
 - Root の Release 名から dotfiles- 接頭辞を外す ([#431](https://github.com/toshiki670/dotfiles/pull/431)) ([`72c6cf6`](https://github.com/toshiki670/dotfiles/commit/72c6cf6b43d2890191713be43ca337aa857112d0))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.69.2"
+version = "0.69.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "fzf-picker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.69.2"
+version     = "0.69.3"
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/clip/CHANGELOG.md
+++ b/crates/clip/CHANGELOG.md
@@ -1,3 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-18
+### Features
+- Copy-obj / c-file / c-path を clip コマンドへ統合 ([#435](https://github.com/toshiki670/dotfiles/pull/435)) ([`d9d247e`](https://github.com/toshiki670/dotfiles/commit/d9d247eb30bf6235a00594e0b10c84c79d917da0))
+
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/crates/fzf-picker/CHANGELOG.md
+++ b/crates/fzf-picker/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-06-18
+### Refactor
+- 引数なしピッカーから clap を外す ([#434](https://github.com/toshiki670/dotfiles/pull/434)) ([`e6cd53e`](https://github.com/toshiki670/dotfiles/commit/e6cd53e2e479d5878ddc04d40efaed2dc5495b71))
+
+
 ## [0.1.0] - 2026-06-16
 ### Features
 - _fzf_ghq_cd を Rust 化（B群 Rust化 PR1/3） ([#413](https://github.com/toshiki670/dotfiles/pull/413)) ([`a041941`](https://github.com/toshiki670/dotfiles/commit/a041941bdc23a195a816dd496376d504c289646a))

--- a/crates/fzf-picker/Cargo.toml
+++ b/crates/fzf-picker/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "fzf-picker"
 repository  = { workspace = true }
-version     = "0.1.0"
+version     = "0.1.1"
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `clip`: 0.1.0
* `fzf-picker`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `dotfiles`: 0.69.2 -> 0.69.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `clip`

<blockquote>

## [0.1.0] - 2026-06-18

### Features
- Copy-obj / c-file / c-path を clip コマンドへ統合 ([#435](https://github.com/toshiki670/dotfiles/pull/435)) ([`d9d247e`](https://github.com/toshiki670/dotfiles/commit/d9d247eb30bf6235a00594e0b10c84c79d917da0))
</blockquote>

## `fzf-picker`

<blockquote>

## [0.1.1] - 2026-06-18

### Refactor
- 引数なしピッカーから clap を外す ([#434](https://github.com/toshiki670/dotfiles/pull/434)) ([`e6cd53e`](https://github.com/toshiki670/dotfiles/commit/e6cd53e2e479d5878ddc04d40efaed2dc5495b71))
</blockquote>

## `dotfiles`

<blockquote>

## [0.69.3] - 2026-06-18

### Features
- Copy-obj / c-file / c-path を clip コマンドへ統合 ([#435](https://github.com/toshiki670/dotfiles/pull/435)) ([`d9d247e`](https://github.com/toshiki670/dotfiles/commit/d9d247eb30bf6235a00594e0b10c84c79d917da0))
- Java/kotlin のプロンプトから via を非表示化 ([#440](https://github.com/toshiki670/dotfiles/pull/440)) ([`31f0f84`](https://github.com/toshiki670/dotfiles/commit/31f0f84b79c6ef39445f4cbe0ce799e668e6111b))
### Fixes
- トリガーを /memory-tidy のみに限定 ([#433](https://github.com/toshiki670/dotfiles/pull/433)) ([`355f16d`](https://github.com/toshiki670/dotfiles/commit/355f16df411ca65ed90b8531d7b45e6eec612310))
- Cargo-install フックを run_before 化し補完の初回取りこぼしを修正 ([#438](https://github.com/toshiki670/dotfiles/pull/438)) ([`9307bc7`](https://github.com/toshiki670/dotfiles/commit/9307bc7827e154f8e72a6485fd75015d30d3a837))
- 依存更新だけの空 patch bump を release_commits で抑止 ([#443](https://github.com/toshiki670/dotfiles/pull/443)) ([`4a5dcad`](https://github.com/toshiki670/dotfiles/commit/4a5dcad46bca85025c911f4639858f529c0a308a))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).