### PR TITLE
feat(starship): gradle のプロンプトから via を非表示化

### DIFF
--- a/home/dot_config/starship.toml.tmpl
+++ b/home/dot_config/starship.toml.tmpl
@@ -98,6 +98,7 @@ format = '[$symbol($version )]($style)'
 symbol = " "
 
 [gradle]
+format = '[$symbol($version )]($style)'
 symbol = " "
 
 [guix_shell]


### PR DESCRIPTION
## 概要

Closes #442

Starship の gradle プロンプトから `via` プレフィックスを非表示にする。

## 変更内容

`home/dot_config/starship.toml.tmpl` の `[gradle]` セクションに `format` 行を追加。

```toml
[gradle]
format = '[$symbol($version )]($style)'
symbol = " "
```

公式デフォルトの format `'via [$symbol($version )]($style)'` から先頭の `via ` だけを削除したもので、それ以外は公式と同一。#440 で java/kotlin に対して行った対応と同じパターン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)