### PR TITLE
feat(git): コミット時に gitleaks 検査するグローバル hook を全ホストに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository is managed with [chezmoi](https://www.chezmoi.io/). **Fish** is 
 These cover the Fish-first workflow and shared tooling (Git, editor, mise, CLI utilities).
 
 ```bash
-brew install git gh fish nvim mise eza bat fd ripgrep starship zoxide fzf git-delta
+brew install git gh fish nvim mise eza bat fd ripgrep starship zoxide fzf git-delta gitleaks
 ```
 
 ### Required Homebrew tool descriptions
@@ -34,6 +34,7 @@ brew install git gh fish nvim mise eza bat fd ripgrep starship zoxide fzf git-de
 - `zoxide` - Smarter cd command that learns your habits
 - `fzf` - Command-line fuzzy finder (used with zoxide and Fish key bindings)
 - `git-delta` - Syntax-highlighting pager for git, diff, and grep output
+- `gitleaks` - Scans staged changes for secrets; used by the global `pre-commit` hook (see [Configuration](#configuration)). Skipped with a warning if not installed.
 
 ## Optional Tools
 
@@ -125,6 +126,17 @@ exec $SHELL -l
 ## Ghostty (macOS)
 
 On macOS, `chezmoi apply` runs a hook that symlinks Ghostty’s expected config path to `~/.config/ghostty/config`. If you use Ghostty, install it separately (see [Optional Tools](#optional-tools)). Ghostty works well as the terminal for a Fish-centric setup.
+
+## Git hooks (gitleaks)
+
+Git is configured with a global `core.hooksPath = ~/.config/git/hooks`, so the managed hooks run for **every** repository on the host. A single dispatcher script (`dispatch`) is symlinked under every client-side hook name (`pre-commit`, `commit-msg`, `prepare-commit-msg`, `pre-push`, `post-checkout`, `post-merge`, `post-commit`, `pre-rebase`, `pre-merge-commit`, `post-rewrite`, `applypatch-msg`, `pre-applypatch`, `post-applypatch`) and dispatches on `basename "$0"` (`dispatch` itself is not a hook name, so Git never runs it directly). It does two things:
+
+1. **Secret scan (pre-commit only)** — runs `gitleaks git --staged` on the staged diff. If a likely secret is found, the commit is **blocked**; secret values are redacted in the output. False positives can be silenced with a `.gitleaks.toml` allowlist or an inline `gitleaks:allow` comment. If `gitleaks` is not installed, the scan is **skipped with a warning** (the commit is not blocked).
+2. **Chaining (all hook types)** — because a global `core.hooksPath` makes Git stop looking at each repo's `.git/hooks`, the dispatcher explicitly invokes the repository-local `.git/hooks/<hook>` afterwards (if present and executable), forwarding arguments and stdin, so per-project hooks keep working.
+
+Bypass everything for a single commit with `git commit --no-verify`.
+
+**Note:** Repositories managed by husky / lefthook set their own `core.hooksPath` locally, which overrides the global one — in those repos these hooks (and the gitleaks scan) do not run.
 
 ## Platform-Specific Notes
 

--- a/home/dot_config/git/configs/core
+++ b/home/dot_config/git/configs/core
@@ -2,3 +2,4 @@
 
 [core]
   editor = nvim
+  hooksPath = ~/.config/git/hooks

--- a/home/dot_config/git/hooks/executable_dispatch
+++ b/home/dot_config/git/hooks/executable_dispatch
@@ -35,9 +35,14 @@ if [ "$hook_name" = "pre-commit" ]; then
 fi
 
 # --- 2. リポジトリ固有 hook へのチェイン（全 hook 種別） ----------------------
-# core.hooksPath 設定下では `git rev-parse --git-path hooks` はグローバル dir を
-# 返してしまうため使わない。実体の .git/hooks を --absolute-git-dir から組み立てる。
-local_hook="$(git rev-parse --absolute-git-dir)/hooks/$hook_name"
+# repo ローカル hook の場所を解決する。
+#   - `git rev-parse --git-path hooks` は core.hooksPath 設定下でグローバル dir
+#     （＝自分自身）を返すため使えない。
+#   - `--absolute-git-dir` は linked worktree で .git/worktrees/<name> を指し、共通
+#     の repo-local hooks (.git/hooks) を取りこぼす。
+# 共通 git dir を絶対パスで取得し、clone / worktree の双方で共通 hooks を参照する。
+common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+local_hook="$common_dir/hooks/$hook_name"
 
 if [ -x "$local_hook" ]; then
   # 自分自身（このディスパッチャ）を指していたら無限再帰になるので除外する。

--- a/home/dot_config/git/hooks/executable_dispatch
+++ b/home/dot_config/git/hooks/executable_dispatch
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Global Git hooks dispatcher deployed by chezmoi.
+#
+# 実体はこの `dispatch` 1 本。git config の core.hooksPath を ~/.config/git/hooks
+# に向けているため git は全リポジトリ・全 hook 種別をこのディレクトリだけで探す。
+# 各 hook 名（pre-commit / commit-msg / pre-push ...）はこの `dispatch` への
+# シンボリックリンクとして配置し、起動名 basename "$0" で分岐する。`dispatch`
+# 自体は hook 名ではないので git から直接起動されることはない。
+#
+# 役割:
+#   1. pre-commit のときだけ、ステージ済み差分を gitleaks で検査する。
+#   2. すべての hook 種別で、リポジトリ固有の .git/hooks/<hook名> があれば引数と
+#      stdin をそのまま渡してチェイン実行する（グローバル hooksPath で握り潰され
+#      る repo ローカル hook を実質復活させる）。
+set -euo pipefail
+
+hook_name="$(basename "$0")"
+
+# --- 1. gitleaks による機密情報スキャン（pre-commit のみ） --------------------
+# gitleaks は必須ではない。未導入のホストでは警告のみ出してスキップし、commit は
+# 止めない（作業を妨げない安全側）。導入済みなら検出時に commit をブロックする。
+if [ "$hook_name" = "pre-commit" ]; then
+  if command -v gitleaks >/dev/null 2>&1; then
+    if ! gitleaks git --staged --redact --no-banner -v; then
+      {
+        echo "✖ gitleaks: 機密情報の可能性がある内容を検出しました。コミットを中止します。"
+        echo "  誤検知の場合は .gitleaks.toml の allowlist か、該当行末コメント 'gitleaks:allow' を利用してください。"
+        echo "  どうしても回避する場合は: git commit --no-verify"
+      } >&2
+      exit 1
+    fi
+  else
+    echo "⚠ gitleaks 未検出のため機密情報スキャンをスキップしました（brew install gitleaks 推奨）。" >&2
+  fi
+fi
+
+# --- 2. リポジトリ固有 hook へのチェイン（全 hook 種別） ----------------------
+# core.hooksPath 設定下では `git rev-parse --git-path hooks` はグローバル dir を
+# 返してしまうため使わない。実体の .git/hooks を --absolute-git-dir から組み立てる。
+local_hook="$(git rev-parse --absolute-git-dir)/hooks/$hook_name"
+
+if [ -x "$local_hook" ]; then
+  # 自分自身（このディスパッチャ）を指していたら無限再帰になるので除外する。
+  self="$(realpath "${BASH_SOURCE[0]}")"
+  if [ "$(realpath "$local_hook")" != "$self" ]; then
+    exec "$local_hook" "$@"
+  fi
+fi

--- a/home/dot_config/git/hooks/symlink_applypatch-msg
+++ b/home/dot_config/git/hooks/symlink_applypatch-msg
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_commit-msg
+++ b/home/dot_config/git/hooks/symlink_commit-msg
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_post-applypatch
+++ b/home/dot_config/git/hooks/symlink_post-applypatch
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_post-checkout
+++ b/home/dot_config/git/hooks/symlink_post-checkout
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_post-commit
+++ b/home/dot_config/git/hooks/symlink_post-commit
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_post-merge
+++ b/home/dot_config/git/hooks/symlink_post-merge
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_post-rewrite
+++ b/home/dot_config/git/hooks/symlink_post-rewrite
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_pre-applypatch
+++ b/home/dot_config/git/hooks/symlink_pre-applypatch
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_pre-commit
+++ b/home/dot_config/git/hooks/symlink_pre-commit
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_pre-merge-commit
+++ b/home/dot_config/git/hooks/symlink_pre-merge-commit
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_pre-push
+++ b/home/dot_config/git/hooks/symlink_pre-push
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_pre-rebase
+++ b/home/dot_config/git/hooks/symlink_pre-rebase
@@ -1,0 +1,1 @@
+dispatch

--- a/home/dot_config/git/hooks/symlink_prepare-commit-msg
+++ b/home/dot_config/git/hooks/symlink_prepare-commit-msg
@@ -1,0 +1,1 @@
+dispatch


### PR DESCRIPTION
## 概要

全ホストで「コミット時にステージ差分を gitleaks で検査し機密混入を防ぐ」グローバル Git hook を chezmoi 管理で追加する。

## 仕組み

- `home/dot_config/git/configs/core` に `core.hooksPath = ~/.config/git/hooks` を追加（`~/.config/git/config` に取り込まれ全リポジトリに適用）。
- 実体は `executable_dispatch` 1 本。`pre-commit` を含む全 client-side hook 名を `dispatch` への symlink として配置し、`basename "$0"` で分岐する（`dispatch` は hook 名でないため git から直接起動されない）。
- ディスパッチャの役割:
  1. **gitleaks スキャン（pre-commit のみ）**: `gitleaks git --staged --redact` を実行。検出時は commit を**ブロック**（値はマスク）。未導入なら**警告のみでスキップ**し commit は止めない。
  2. **チェイン（全 hook 種別）**: グローバル `core.hooksPath` で握り潰される repo ローカル `.git/hooks/<hook>` を、引数・stdin 転送付きで実行し直す。
- `README.md`: Required Tools に `gitleaks` を追加、「Git hooks (gitleaks)」小節で挙動を記載。

## 挙動の要点

- 回避: `git commit --no-verify`。
- husky / lefthook 利用 repo はローカル `core.hooksPath` が優先され、これらの hook は走らない（仕様）。
- gitleaks は `pre-commit` 時のみ実行（クリーンな auto-merge で走る `pre-merge-commit` 経路はスキャン対象外）。

## 検証

- `pre-commit`（symlink→dispatch）直接起動 → gitleaks 発火・ブロック・`REDACTED` マスク。
- `commit-msg`（symlink→dispatch）直接起動 → ステージに leak があっても gitleaks 不実行・exit 0（`basename` 分岐）。
- `commit-msg` → repo ローカル `.git/hooks/commit-msg` を引数 `$1` 付きでチェイン。
- gitleaks 未導入（PATH 除外）→ 警告して commit 通過。
- `git commit --no-verify` → hook スキップで通過。
- 本 PR のコミット自体が pre-commit hook を実走し `no leaks found`。
- `mise run check` ＝ 問題なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)