### PR TITLE
feat(fzf-picker): Issue/PR 横断 fzf ピッカー追加 + gh ID 補完バグ修正

### DIFF
--- a/crates/fzf-picker/src/bin/fzf-gh.rs
+++ b/crates/fzf-picker/src/bin/fzf-gh.rs
@@ -1,0 +1,60 @@
+//! `fzf-gh`: Issue/PR を fzf で選び、種別に応じたアクションを選んで
+//! `gh <group> <action> <number>` を stdout に 1 行出力する。fish shim
+//! （`_fzf_gh.fish`）はそれをコマンドラインへ挿入する。
+//!
+//! fzf の UI・エラーメッセージは stderr に出し、stdout は組み立てたコマンド 1 行だけに
+//! 保つ（`run_fzf` が stderr を継承する）。各段のキャンセル（ESC / Ctrl-C）や候補なしは
+//! 何も出さずに正常終了する。
+
+use std::process::ExitCode;
+
+use fzf_picker::gh::{self, build_command, parse_selection};
+use fzf_picker::launch::{command_exists, run_fzf};
+
+// fish shim から引数なしで呼ばれるだけなので clap は持たない。
+
+fn main() -> ExitCode {
+    if !command_exists("gh") {
+        eprintln!("fzf-gh: gh not found on PATH.");
+        return ExitCode::FAILURE;
+    }
+
+    let candidates = match gh::list_candidates() {
+        Ok(lines) => lines,
+        Err(_) => {
+            eprintln!("fzf-gh: failed to list issues/PRs.");
+            return ExitCode::FAILURE;
+        }
+    };
+    // open な Issue/PR が無い、または repo 外。静かに終わる。
+    if candidates.is_empty() {
+        return ExitCode::SUCCESS;
+    }
+
+    // 1 段目: Issue/PR の項目を選ぶ。
+    let selection = match run_fzf(&candidates, &[]) {
+        Ok(Some(selection)) => selection,
+        Ok(None) => return ExitCode::SUCCESS, // キャンセル
+        Err(_) => {
+            eprintln!("fzf-gh: failed to run fzf.");
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some((kind, number)) = parse_selection(&selection) else {
+        return ExitCode::SUCCESS;
+    };
+
+    // 2 段目: 種別に応じたアクションを選ぶ。
+    let actions: Vec<String> = kind.actions().iter().map(|a| (*a).to_string()).collect();
+    let action = match run_fzf(&actions, &[]) {
+        Ok(Some(action)) => action,
+        Ok(None) => return ExitCode::SUCCESS, // キャンセル
+        Err(_) => {
+            eprintln!("fzf-gh: failed to run fzf.");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!("{}", build_command(kind, &action, &number));
+    ExitCode::SUCCESS
+}

--- a/crates/fzf-picker/src/gh.rs
+++ b/crates/fzf-picker/src/gh.rs
@@ -1,0 +1,179 @@
+//! gh ピッカーのドメイン（Issue/PR を fzf で選び、種別に応じたアクションを組み立てる）。
+//!
+//! gh は worktree/ghq とは別ドメインなので、[`crate::format`] / [`crate::parse`]
+//! （worktree 色のモジュール）には混ぜず、この 1 ファイルに凝集させる
+//! （[`crate::worktree`] がドメイン型 + 一覧取得 IO を同居させるのと同じ方針）。
+//!
+//! 純ロジック（選択行パース・アクション集合・コマンド組立）はユニットテストを同居させ、
+//! `gh` を叩く IO（[`list_candidates`]）はバイナリの E2E（`tests/e2e/fzf_gh.rs`）で検証する。
+
+use std::io;
+use std::process::Command;
+
+/// fzf 各行のフィールド区切り（表示=1列目、kind=2列目、番号=3列目）。
+const TAB: char = '\t';
+
+/// 選択対象の種別。`gh <group> <action> <number>` の group を決める。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Issue,
+    Pr,
+}
+
+impl Kind {
+    /// gh のサブコマンド group 名（`gh issue …` / `gh pr …`）。
+    pub fn group(self) -> &'static str {
+        match self {
+            Kind::Issue => "issue",
+            Kind::Pr => "pr",
+        }
+    }
+
+    /// 種別ごとに選べるアクション。先頭を `view` にして「選ぶ→Enter」を最短にする。
+    /// gh.fish.tmpl の Tab 補完と同じ集合に揃える。
+    pub fn actions(self) -> &'static [&'static str] {
+        match self {
+            Kind::Issue => &["view", "edit", "close", "reopen", "comment", "pin"],
+            Kind::Pr => &[
+                "view",
+                "checkout",
+                "review",
+                "diff",
+                "merge",
+                "checks",
+                "update-branch",
+            ],
+        }
+    }
+
+    /// fzf 行の kind 列（`issue` / `pr`）を [`Kind`] に戻す。未知の種別は `None`。
+    pub fn parse(s: &str) -> Option<Kind> {
+        match s {
+            "issue" => Some(Kind::Issue),
+            "pr" => Some(Kind::Pr),
+            _ => None,
+        }
+    }
+}
+
+/// fzf が返した選択行（`表示\tkind\t番号`）から `(Kind, 番号)` を取り出す。
+/// 列が欠ける・種別が未知・番号が空ならいずれも `None`。
+pub fn parse_selection(line: &str) -> Option<(Kind, String)> {
+    let mut cols = line.split(TAB);
+    let _display = cols.next()?;
+    let kind = Kind::parse(cols.next()?)?;
+    let number = cols.next()?.trim();
+    (!number.is_empty()).then(|| (kind, number.to_string()))
+}
+
+/// `gh <group> <action> <number>` を組み立てる（fish へ挿入する 1 行）。
+pub fn build_command(kind: Kind, action: &str, number: &str) -> String {
+    format!("gh {} {} {}", kind.group(), action, number)
+}
+
+/// Issue と PR を `表示\tkind\t番号` の fzf 候補行にして連結して返す。
+///
+/// 表示列は内部タブ無しの 1 列（番号・title・author・assignee を含む）なので、`run_fzf`
+/// の `--with-nth 1` でそれら全てが検索対象になる。表示成形は `gh` の `--jq` に委譲する。
+pub fn list_candidates() -> io::Result<Vec<String>> {
+    let mut lines = list_one(Kind::Issue)?;
+    lines.extend(list_one(Kind::Pr)?);
+    Ok(lines)
+}
+
+/// 片側（Issue または PR）の候補行を取得する。`gh` が repo 外・未認証などで失敗しても、
+/// もう片方は出したいので空 Vec を返す（呼び出し側でまとめてキャンセル扱いにできる）。
+fn list_one(kind: Kind) -> io::Result<Vec<String>> {
+    let jq = jq_for(kind);
+    let output = Command::new("gh")
+        .args([
+            kind.group(),
+            "list",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,author,assignees",
+            "--jq",
+            &jq,
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// `gh … --jq` に渡す式。1 行を `[group] #番号 title @author →assignees\tgroup\t番号` に
+/// 成形する（assignee が無ければ ` →…` 部分を省く）。
+fn jq_for(kind: Kind) -> String {
+    let group = kind.group();
+    format!(
+        r#".[] | "[{group}] #\(.number) \(.title) @\(.author.login)\(if (.assignees | length) > 0 then " →" + ([.assignees[].login] | join(",")) else "" end)\t{group}\t\(.number)""#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_names() {
+        assert_eq!(Kind::Issue.group(), "issue");
+        assert_eq!(Kind::Pr.group(), "pr");
+    }
+
+    #[test]
+    fn parse_kind_roundtrip_and_unknown() {
+        assert_eq!(Kind::parse("issue"), Some(Kind::Issue));
+        assert_eq!(Kind::parse("pr"), Some(Kind::Pr));
+        assert_eq!(Kind::parse("gist"), None);
+    }
+
+    #[test]
+    fn actions_lead_with_view() {
+        assert_eq!(Kind::Issue.actions().first(), Some(&"view"));
+        assert!(Kind::Issue.actions().contains(&"edit"));
+        assert_eq!(Kind::Pr.actions().first(), Some(&"view"));
+        assert!(Kind::Pr.actions().contains(&"checkout"));
+    }
+
+    #[test]
+    fn parse_selection_extracts_issue() {
+        let line = "[issue] #341 demo @me\tissue\t341";
+        assert_eq!(
+            parse_selection(line),
+            Some((Kind::Issue, "341".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_selection_extracts_pr() {
+        let line = "[pr] #7 fix @you\tpr\t7";
+        assert_eq!(parse_selection(line), Some((Kind::Pr, "7".to_string())));
+    }
+
+    #[test]
+    fn parse_selection_rejects_missing_columns_or_unknown_kind() {
+        assert_eq!(parse_selection("only display"), None);
+        assert_eq!(parse_selection("display\tissue"), None);
+        assert_eq!(parse_selection("display\tunknown\t9"), None);
+    }
+
+    #[test]
+    fn parse_selection_rejects_empty_number() {
+        assert_eq!(parse_selection("display\tissue\t"), None);
+    }
+
+    #[test]
+    fn build_command_formats_invocation() {
+        assert_eq!(
+            build_command(Kind::Issue, "edit", "341"),
+            "gh issue edit 341"
+        );
+        assert_eq!(build_command(Kind::Pr, "checkout", "7"), "gh pr checkout 7");
+    }
+}

--- a/crates/fzf-picker/src/gh.rs
+++ b/crates/fzf-picker/src/gh.rs
@@ -57,12 +57,16 @@ impl Kind {
 }
 
 /// fzf が返した選択行（`表示\tkind\t番号`）から `(Kind, 番号)` を取り出す。
-/// 列が欠ける・種別が未知・番号が空ならいずれも `None`。
+///
+/// 末尾 2 列の `kind \t 番号` だけに依存し、**末尾から**読む。表示列（先頭）の title に
+/// 万一タブが紛れて列が増えても、kind/番号 を誤読しない（[`jq_for`] でも title を
+/// サニタイズしているので二重の安全策）。表示列が無い（最低 3 列に満たない）・種別が
+/// 未知・番号が空はいずれも `None`。
 pub fn parse_selection(line: &str) -> Option<(Kind, String)> {
-    let mut cols = line.split(TAB);
-    let _display = cols.next()?;
-    let kind = Kind::parse(cols.next()?)?;
+    let mut cols = line.rsplit(TAB);
     let number = cols.next()?.trim();
+    let kind = Kind::parse(cols.next()?)?;
+    cols.next()?; // 表示列が存在すること（最低 3 列）。
     (!number.is_empty()).then(|| (kind, number.to_string()))
 }
 
@@ -109,10 +113,14 @@ fn list_one(kind: Kind) -> io::Result<Vec<String>> {
 
 /// `gh … --jq` に渡す式。1 行を `[group] #番号 title @author →assignees\tgroup\t番号` に
 /// 成形する（assignee が無ければ ` →…` 部分を省く）。
+///
+/// `title` はタブ・改行を含み得るので空白へ置換しておく。これを怠ると、表示列の中に
+/// タブが入って列がずれたり、改行で 1 候補が 2 行に割れたりする（番号/種別は GitHub の
+/// 性質上タブ・改行を含まないので対象外）。
 fn jq_for(kind: Kind) -> String {
     let group = kind.group();
     format!(
-        r#".[] | "[{group}] #\(.number) \(.title) @\(.author.login)\(if (.assignees | length) > 0 then " →" + ([.assignees[].login] | join(",")) else "" end)\t{group}\t\(.number)""#
+        r#".[] | "[{group}] #\(.number) \(.title | gsub("[\t\n\r]"; " ")) @\(.author.login)\(if (.assignees | length) > 0 then " →" + ([.assignees[].login] | join(",")) else "" end)\t{group}\t\(.number)""#
     )
 }
 
@@ -166,6 +174,16 @@ mod tests {
     #[test]
     fn parse_selection_rejects_empty_number() {
         assert_eq!(parse_selection("display\tissue\t"), None);
+    }
+
+    #[test]
+    fn parse_selection_survives_tab_in_display() {
+        // title 由来のタブで表示列が割れても、末尾から読むので kind/番号 は正しく取れる。
+        let line = "[issue] #341 weird\ttitle\tissue\t341";
+        assert_eq!(
+            parse_selection(line),
+            Some((Kind::Issue, "341".to_string()))
+        );
     }
 
     #[test]

--- a/crates/fzf-picker/src/lib.rs
+++ b/crates/fzf-picker/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - **役割ごとに 1 モジュール**。各ファイルは単一の責務だけを持つ:
 //!   - [`worktree`] — git worktree ドメイン（型と一覧取得 IO）
+//!   - [`gh`] — gh Issue/PR ピッカーのドメイン（型・純ロジック・一覧取得 IO）
 //!   - [`parse`] — テキスト → 構造のパース（純ロジック）
 //!   - [`format`] — 構造 → fzf 候補行の成形（純ロジック）
 //!   - [`launch`] — 外部コマンド（fzf 等）の起動・存在確認（IO）
@@ -15,6 +16,7 @@
 //!   共有はクレート内の bin（`src/bin/*.rs`）からのみ行う。
 
 pub mod format;
+pub mod gh;
 pub mod launch;
 pub mod parse;
 pub mod worktree;

--- a/crates/fzf-picker/tests/e2e/fzf_gh.rs
+++ b/crates/fzf-picker/tests/e2e/fzf_gh.rs
@@ -1,0 +1,123 @@
+//! `fzf-gh` の E2E（実バイナリ + gh/fzf スタブで検証）。
+//!
+//! 検証: gh 不在で失敗、Issue 選択→アクション選択で `gh issue edit 341` 出力、
+//! PR 選択で `gh pr checkout 7` 出力、項目段キャンセルで無出力、アクション段キャンセルで
+//! 無出力。`gh` は第1引数で issue/pr を出し分け、あらかじめ `表示\tkind\t番号` に整形した
+//! canned TSV を返すスタブ（`--jq` はバイパス）。`fzf` は stdin にタブを含むかで
+//! 項目段/アクション段を判別する 2 段対応スタブ。
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+use crate::{EMPTY_PATH, path_with, write_exec};
+
+/// `gh` スタブ: `issue`/`pr` を第1引数で判定し、canned TSV をファイルから返す。
+const GH_STUB: &str = "#!/bin/sh\ncase \"$1\" in\n  issue) cat \"${GH_ISSUE_FILE:-/dev/null}\" ;;\n  pr) cat \"${GH_PR_FILE:-/dev/null}\" ;;\nesac\n";
+
+/// `fzf` スタブ（2段対応）: stdin にタブを含めば項目段
+/// （`$FZF_PICK_ITEM` / `$FZF_EXIT_ITEM`）、含まなければアクション段
+/// （`$FZF_PICK_ACTION` / `$FZF_EXIT_ACTION`）として振る舞う。終了コードが 0 のときだけ
+/// 選択行を出力する（非 0 = fzf キャンセル相当）。
+const FZF_STUB: &str = "#!/bin/sh\ninput=$(cat)\nif printf '%s' \"$input\" | grep -q \"$(printf '\\t')\"; then\n  sel=\"$FZF_PICK_ITEM\"; code=\"${FZF_EXIT_ITEM:-0}\"\nelse\n  sel=\"$FZF_PICK_ACTION\"; code=\"${FZF_EXIT_ACTION:-0}\"\nfi\n[ \"$code\" = \"0\" ] && [ -n \"$sel\" ] && printf '%s\\n' \"$sel\"\nexit \"$code\"\n";
+
+const ISSUE_LINE: &str = "[issue] #341 demo @me\tissue\t341";
+const PR_LINE: &str = "[pr] #7 fix @you\tpr\t7";
+
+fn fzf_gh() -> Command {
+    Command::cargo_bin("fzf-gh").unwrap()
+}
+
+struct GhFixture {
+    _root: TempDir,
+    bin: PathBuf,
+    issue_file: PathBuf,
+    pr_file: PathBuf,
+}
+
+fn fixture() -> GhFixture {
+    let root = TempDir::new().unwrap();
+    let bin = root.path().join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    write_exec(&bin, "gh", GH_STUB);
+    write_exec(&bin, "fzf", FZF_STUB);
+
+    let issue_file = root.path().join("issues.tsv");
+    let pr_file = root.path().join("prs.tsv");
+    fs::write(&issue_file, format!("{ISSUE_LINE}\n")).unwrap();
+    fs::write(&pr_file, format!("{PR_LINE}\n")).unwrap();
+
+    GhFixture {
+        _root: root,
+        bin,
+        issue_file,
+        pr_file,
+    }
+}
+
+#[test]
+fn gh_missing_fails() {
+    fzf_gh()
+        .env("PATH", EMPTY_PATH)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("gh not found"));
+}
+
+#[test]
+fn issue_selection_builds_edit_command() {
+    let fx = fixture();
+    fzf_gh()
+        .env("PATH", path_with(&fx.bin))
+        .env("GH_ISSUE_FILE", &fx.issue_file)
+        .env("GH_PR_FILE", &fx.pr_file)
+        .env("FZF_PICK_ITEM", ISSUE_LINE)
+        .env("FZF_PICK_ACTION", "edit")
+        .assert()
+        .success()
+        .stdout("gh issue edit 341\n");
+}
+
+#[test]
+fn pr_selection_builds_checkout_command() {
+    let fx = fixture();
+    fzf_gh()
+        .env("PATH", path_with(&fx.bin))
+        .env("GH_ISSUE_FILE", &fx.issue_file)
+        .env("GH_PR_FILE", &fx.pr_file)
+        .env("FZF_PICK_ITEM", PR_LINE)
+        .env("FZF_PICK_ACTION", "checkout")
+        .assert()
+        .success()
+        .stdout("gh pr checkout 7\n");
+}
+
+#[test]
+fn cancel_item_stage_no_output() {
+    let fx = fixture();
+    fzf_gh()
+        .env("PATH", path_with(&fx.bin))
+        .env("GH_ISSUE_FILE", &fx.issue_file)
+        .env("GH_PR_FILE", &fx.pr_file)
+        .env("FZF_EXIT_ITEM", "1")
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn cancel_action_stage_no_output() {
+    let fx = fixture();
+    fzf_gh()
+        .env("PATH", path_with(&fx.bin))
+        .env("GH_ISSUE_FILE", &fx.issue_file)
+        .env("GH_PR_FILE", &fx.pr_file)
+        .env("FZF_PICK_ITEM", ISSUE_LINE)
+        .env("FZF_EXIT_ACTION", "1")
+        .assert()
+        .success()
+        .stdout("");
+}

--- a/crates/fzf-picker/tests/e2e/fzf_gh.rs
+++ b/crates/fzf-picker/tests/e2e/fzf_gh.rs
@@ -1,10 +1,15 @@
-//! `fzf-gh` の E2E（実バイナリ + gh/fzf スタブで検証）。
+//! `fzf-gh` の E2E（実バイナリ + gh/fzf スタブ + 実 jq で検証）。
 //!
 //! 検証: gh 不在で失敗、Issue 選択→アクション選択で `gh issue edit 341` 出力、
 //! PR 選択で `gh pr checkout 7` 出力、項目段キャンセルで無出力、アクション段キャンセルで
-//! 無出力。`gh` は第1引数で issue/pr を出し分け、あらかじめ `表示\tkind\t番号` に整形した
-//! canned TSV を返すスタブ（`--jq` はバイパス）。`fzf` は stdin にタブを含むかで
-//! 項目段/アクション段を判別する 2 段対応スタブ。
+//! 無出力、そして **title のタブ/改行が候補表示でサニタイズされる**こと（列ずれ・行割れの
+//! デグレ防止）。
+//!
+//! `gh` スタブは bin が渡す `--jq` 式を **実 jq** で canned JSON に適用する（`gh` の
+//! `--jq` と等価）。これにより `jq_for` のサニタイズ（`gsub`）まで通しで効いているかを
+//! 検証できる。`fzf` スタブは stdin にタブを含むかで項目段/アクション段を判別し、項目段は
+//! `$FZF_PICK_NTH` 行目の **実際の候補行** を選ぶ（表示フォーマットにハードコードで依存
+//! しない）。`git`/`jq` は実 PATH に残るので実物を使い、`gh`/`fzf` だけ差し替える。
 
 use std::fs;
 use std::path::PathBuf;
@@ -15,17 +20,21 @@ use tempfile::TempDir;
 
 use crate::{EMPTY_PATH, path_with, write_exec};
 
-/// `gh` スタブ: `issue`/`pr` を第1引数で判定し、canned TSV をファイルから返す。
-const GH_STUB: &str = "#!/bin/sh\ncase \"$1\" in\n  issue) cat \"${GH_ISSUE_FILE:-/dev/null}\" ;;\n  pr) cat \"${GH_PR_FILE:-/dev/null}\" ;;\nesac\n";
+/// `gh` スタブ: 第1引数（issue/pr）に応じ、bin が渡した `--jq` 式を実 jq で canned JSON に
+/// 適用する（`gh issue list … --jq` と等価）。
+const GH_STUB: &str = "#!/bin/sh\ngroup=\"$1\"\nprog=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = \"--jq\" ]; then prog=\"$2\"; fi\n  shift\ndone\ncase \"$group\" in\n  issue) jq -r \"$prog\" \"${GH_ISSUE_JSON:-/dev/null}\" ;;\n  pr) jq -r \"$prog\" \"${GH_PR_JSON:-/dev/null}\" ;;\nesac\n";
 
-/// `fzf` スタブ（2段対応）: stdin にタブを含めば項目段
-/// （`$FZF_PICK_ITEM` / `$FZF_EXIT_ITEM`）、含まなければアクション段
-/// （`$FZF_PICK_ACTION` / `$FZF_EXIT_ACTION`）として振る舞う。終了コードが 0 のときだけ
-/// 選択行を出力する（非 0 = fzf キャンセル相当）。
-const FZF_STUB: &str = "#!/bin/sh\ninput=$(cat)\nif printf '%s' \"$input\" | grep -q \"$(printf '\\t')\"; then\n  sel=\"$FZF_PICK_ITEM\"; code=\"${FZF_EXIT_ITEM:-0}\"\nelse\n  sel=\"$FZF_PICK_ACTION\"; code=\"${FZF_EXIT_ACTION:-0}\"\nfi\n[ \"$code\" = \"0\" ] && [ -n \"$sel\" ] && printf '%s\\n' \"$sel\"\nexit \"$code\"\n";
+/// `fzf` スタブ（2段対応）: stdin にタブを含めば項目段、含まなければアクション段。
+/// 項目段は `$FZF_DUMP` に候補を保存し、`$FZF_PICK_NTH`（既定 1）行目の実候補行を選ぶ。
+/// アクション段は `$FZF_PICK_ACTION` を返す。終了コードが 0 のときだけ選択行を出す
+/// （`$FZF_EXIT_ITEM` / `$FZF_EXIT_ACTION` で各段のキャンセルを再現）。
+const FZF_STUB: &str = "#!/bin/sh\ninput=$(cat)\nif printf '%s' \"$input\" | grep -q \"$(printf '\\t')\"; then\n  [ -n \"$FZF_DUMP\" ] && printf '%s\\n' \"$input\" > \"$FZF_DUMP\"\n  code=\"${FZF_EXIT_ITEM:-0}\"\n  sel=$(printf '%s\\n' \"$input\" | sed -n \"${FZF_PICK_NTH:-1}p\")\nelse\n  code=\"${FZF_EXIT_ACTION:-0}\"\n  sel=\"$FZF_PICK_ACTION\"\nfi\n[ \"$code\" = \"0\" ] && [ -n \"$sel\" ] && printf '%s\\n' \"$sel\"\nexit \"$code\"\n";
 
-const ISSUE_LINE: &str = "[issue] #341 demo @me\tissue\t341";
-const PR_LINE: &str = "[pr] #7 fix @you\tpr\t7";
+const NORMAL_ISSUE: &str =
+    r#"[{"number":341,"title":"demo issue","author":{"login":"me"},"assignees":[]}]"#;
+const NORMAL_PR: &str =
+    r#"[{"number":7,"title":"fix bug","author":{"login":"you"},"assignees":[]}]"#;
+const EMPTY_JSON: &str = "[]";
 
 fn fzf_gh() -> Command {
     Command::cargo_bin("fzf-gh").unwrap()
@@ -34,27 +43,43 @@ fn fzf_gh() -> Command {
 struct GhFixture {
     _root: TempDir,
     bin: PathBuf,
-    issue_file: PathBuf,
-    pr_file: PathBuf,
+    issue_json: PathBuf,
+    pr_json: PathBuf,
+    dump: PathBuf,
 }
 
-fn fixture() -> GhFixture {
+/// gh/fzf スタブを置き、issue/pr の canned JSON を書き出した一時環境を用意する。
+fn setup(issue_json: &str, pr_json: &str) -> GhFixture {
     let root = TempDir::new().unwrap();
     let bin = root.path().join("bin");
     fs::create_dir_all(&bin).unwrap();
     write_exec(&bin, "gh", GH_STUB);
     write_exec(&bin, "fzf", FZF_STUB);
 
-    let issue_file = root.path().join("issues.tsv");
-    let pr_file = root.path().join("prs.tsv");
-    fs::write(&issue_file, format!("{ISSUE_LINE}\n")).unwrap();
-    fs::write(&pr_file, format!("{PR_LINE}\n")).unwrap();
+    let issue = root.path().join("issues.json");
+    let pr = root.path().join("prs.json");
+    fs::write(&issue, issue_json).unwrap();
+    fs::write(&pr, pr_json).unwrap();
+    let dump = root.path().join("fzf-candidates.txt");
 
     GhFixture {
         _root: root,
         bin,
-        issue_file,
-        pr_file,
+        issue_json: issue,
+        pr_json: pr,
+        dump,
+    }
+}
+
+impl GhFixture {
+    /// スタブを効かせた `fzf-gh` コマンド（PATH 差し替え + JSON/ダンプ env）を組む。
+    fn cmd(&self) -> Command {
+        let mut c = fzf_gh();
+        c.env("PATH", path_with(&self.bin))
+            .env("GH_ISSUE_JSON", &self.issue_json)
+            .env("GH_PR_JSON", &self.pr_json)
+            .env("FZF_DUMP", &self.dump);
+        c
     }
 }
 
@@ -69,12 +94,9 @@ fn gh_missing_fails() {
 
 #[test]
 fn issue_selection_builds_edit_command() {
-    let fx = fixture();
-    fzf_gh()
-        .env("PATH", path_with(&fx.bin))
-        .env("GH_ISSUE_FILE", &fx.issue_file)
-        .env("GH_PR_FILE", &fx.pr_file)
-        .env("FZF_PICK_ITEM", ISSUE_LINE)
+    let fx = setup(NORMAL_ISSUE, NORMAL_PR);
+    fx.cmd()
+        .env("FZF_PICK_NTH", "1") // 1 件目 = Issue #341
         .env("FZF_PICK_ACTION", "edit")
         .assert()
         .success()
@@ -83,12 +105,9 @@ fn issue_selection_builds_edit_command() {
 
 #[test]
 fn pr_selection_builds_checkout_command() {
-    let fx = fixture();
-    fzf_gh()
-        .env("PATH", path_with(&fx.bin))
-        .env("GH_ISSUE_FILE", &fx.issue_file)
-        .env("GH_PR_FILE", &fx.pr_file)
-        .env("FZF_PICK_ITEM", PR_LINE)
+    let fx = setup(NORMAL_ISSUE, NORMAL_PR);
+    fx.cmd()
+        .env("FZF_PICK_NTH", "2") // 2 件目 = PR #7
         .env("FZF_PICK_ACTION", "checkout")
         .assert()
         .success()
@@ -97,11 +116,8 @@ fn pr_selection_builds_checkout_command() {
 
 #[test]
 fn cancel_item_stage_no_output() {
-    let fx = fixture();
-    fzf_gh()
-        .env("PATH", path_with(&fx.bin))
-        .env("GH_ISSUE_FILE", &fx.issue_file)
-        .env("GH_PR_FILE", &fx.pr_file)
+    let fx = setup(NORMAL_ISSUE, NORMAL_PR);
+    fx.cmd()
         .env("FZF_EXIT_ITEM", "1")
         .assert()
         .success()
@@ -110,14 +126,38 @@ fn cancel_item_stage_no_output() {
 
 #[test]
 fn cancel_action_stage_no_output() {
-    let fx = fixture();
-    fzf_gh()
-        .env("PATH", path_with(&fx.bin))
-        .env("GH_ISSUE_FILE", &fx.issue_file)
-        .env("GH_PR_FILE", &fx.pr_file)
-        .env("FZF_PICK_ITEM", ISSUE_LINE)
+    let fx = setup(NORMAL_ISSUE, NORMAL_PR);
+    fx.cmd()
+        .env("FZF_PICK_NTH", "1")
         .env("FZF_EXIT_ACTION", "1")
         .assert()
         .success()
         .stdout("");
+}
+
+/// レビュー指摘の回帰テスト: title にタブ・改行が含まれても、候補の表示列が空白へ
+/// サニタイズされ（`jq_for` の `gsub`）、機械列（kind/番号）がずれないこと。`jq` の
+/// サニタイズを外すとこの候補行が崩れて落ちる。
+#[test]
+fn title_with_tab_and_newline_is_sanitized() {
+    let dirty_issue = r#"[{"number":341,"title":"foo\tbar\nbaz qux","author":{"login":"me"},"assignees":[{"login":"a"}]}]"#;
+    let fx = setup(dirty_issue, EMPTY_JSON);
+
+    // 最終コマンドは正しく組める（末尾読みの保険込み）。
+    fx.cmd()
+        .env("FZF_PICK_NTH", "1")
+        .env("FZF_PICK_ACTION", "edit")
+        .assert()
+        .success()
+        .stdout("gh issue edit 341\n");
+
+    // fzf に渡った候補行は、表示列にタブ・改行を含まない 3 列ちょうど。
+    let dumped = fs::read_to_string(&fx.dump).unwrap();
+    let line = dumped.trim_end_matches('\n');
+    assert_eq!(line, "[issue] #341 foo bar baz qux @me →a\tissue\t341");
+    assert_eq!(
+        line.split('\t').count(),
+        3,
+        "display column must stay tab-free (kind/number は末尾2列のまま): {line:?}"
+    );
 }

--- a/crates/fzf-picker/tests/e2e/mod.rs
+++ b/crates/fzf-picker/tests/e2e/mod.rs
@@ -9,6 +9,7 @@
 //!   リンク worktree のツリー構築（メイン除外）
 //! - [`fzf_worktree_remove`]: 引数・非 git repo・削除候補なし・確認 y で削除・確認 n で
 //!   残置・fzf キャンセルで残置・削除対象の内側からの実行で退避パス出力
+//! - [`fzf_gh`]: gh 不在・Issue/PR 選択→アクション選択でコマンド組立・各段キャンセルで無出力
 //! - [`cdabbr`]: 引数・相対パス拒否・該当なし・fzf 不在で単一/再帰/複数・fzf 選択
 //!
 //! 外部コマンド `ghq` / `fzf` は PATH 先頭に置くスタブで差し替え、`git` は実物を使う
@@ -19,6 +20,7 @@ use std::fs;
 use std::path::Path;
 
 mod cdabbr;
+mod fzf_gh;
 mod fzf_ghq_cd;
 mod fzf_worktree_remove;
 

--- a/home/dot_config/fish/completions/gh.fish.tmpl
+++ b/home/dot_config/fish/completions/gh.fish.tmpl
@@ -3,39 +3,35 @@
 
 # Custom completions: ID selection for targeted commands
 
+# 最初の ID 位置でだけ補完を出す共有判定。`commandline -poc` はカーソルで切り、入力中の
+# 部分トークンを除いた「確定済みトークン列」を返す。それがちょうど `gh <group> <sub>`
+# （3 トークン）のときだけ真。これにより `gh issue edit 341 ` のように ID 入力済みでは
+# 候補が出なくなり、`gh issue edit 3` のように最初の ID 入力中は出る。
+function __gh_completing_first_id --argument-names group
+    set -l tokens (commandline -poc)
+    test (count $tokens) -eq 3
+        and test "$tokens[2]" = "$group"
+        and contains -- "$tokens[3]" $argv[2..-1]
+end
+
 function __gh_completing_issue_id
-    set -l cmd (commandline -po)
-    test (count $cmd) -ge 3
-        and test "$cmd[2]" = issue
-        and contains -- "$cmd[3]" view edit close reopen comment pin
+    __gh_completing_first_id issue view edit close reopen comment pin
 end
 
 function __gh_completing_pr_id
-    set -l cmd (commandline -po)
-    test (count $cmd) -ge 3
-        and test "$cmd[2]" = pr
-        and contains -- "$cmd[3]" view checkout review diff merge checks update-branch
+    __gh_completing_first_id pr view checkout review diff merge checks update-branch
 end
 
 function __gh_completing_run_id
-    set -l cmd (commandline -po)
-    test (count $cmd) -ge 3
-        and test "$cmd[2]" = run
-        and contains -- "$cmd[3]" view rerun cancel watch
+    __gh_completing_first_id run view rerun cancel watch
 end
 
 function __gh_completing_release_id
-    set -l cmd (commandline -po)
-    test (count $cmd) -ge 3
-        and test "$cmd[2]" = release
-        and contains -- "$cmd[3]" view delete edit upload
+    __gh_completing_first_id release view delete edit upload
 end
 
 function __gh_completing_gist_id
-    set -l cmd (commandline -po)
-    test (count $cmd) -ge 3
-        and test "$cmd[2]" = gist
-        and contains -- "$cmd[3]" view edit
+    __gh_completing_first_id gist view edit
 end
 
 function __gh_issue_candidates

--- a/home/dot_config/fish/conf.d/20-fzf-bindings.fish
+++ b/home/dot_config/fish/conf.d/20-fzf-bindings.fish
@@ -5,7 +5,9 @@ bind -M default ctrl-j,ctrl-h _fzf_history
 bind -M default ctrl-j,ctrl-t _fzf_file
 bind -M default ctrl-j,ctrl-g _fzf_ghq_cd
 bind -M default ctrl-j,ctrl-w _fzf_worktree_remove
+bind -M default ctrl-j,ctrl-i _fzf_gh
 bind -M insert ctrl-j,ctrl-h _fzf_history
 bind -M insert ctrl-j,ctrl-t _fzf_file
 bind -M insert ctrl-j,ctrl-g _fzf_ghq_cd
 bind -M insert ctrl-j,ctrl-w _fzf_worktree_remove
+bind -M insert ctrl-j,ctrl-i _fzf_gh

--- a/home/dot_config/fish/functions/_fzf_gh.fish
+++ b/home/dot_config/fish/functions/_fzf_gh.fish
@@ -1,0 +1,10 @@
+# ロジックは Rust バイナリ（crates/fzf-picker の fzf-gh）に移した。
+# Issue/PR 混在リストを fzf で選び、種別に応じたアクションを fzf で選んで、
+# 組み上げた `gh <group> <action> <number>` を stdout に出す。fish はそれを
+# コマンドラインへ挿入するだけの薄い shim（実行は Enter で自分が行う）。
+function _fzf_gh
+    set -l cmd (command fzf-gh)
+    or return
+    test -n "$cmd"; and commandline -i -- "$cmd "
+    commandline -f repaint
+end


### PR DESCRIPTION
## 概要

gh の補完まわりを 2 点改善する。

1. **Tab 補完バグ修正**: `gh issue edit 341 419` のように **ID を入力済みでも候補が出続ける**バグを是正。
2. **fzf-gh ピッカー追加**: `Ctrl+J Ctrl+I` で Issue/PR を横断検索し、種別に応じたアクションを選んで `gh issue edit 341` をコマンドラインへ挿入する。

## 1. Tab 補完バグ修正 (`fix(gh)`)

原因は `__gh_completing_*_id` が `commandline -po`（カーソル無視で行全体）+ `count >= 3` で判定していたこと。ID が何個あっても成立して候補が出ていた。

位置判定を共有ヘルパ `__gh_completing_first_id` に集約し、`commandline -poc`（カーソルで切り、入力中の部分トークンを除いた確定済みトークン列）がちょうど `gh <group> <sub>`（3 トークン）のときだけ真にした。`complete -C` で実機検証済み:

| 入力 | 候補 |
|---|---|
| `gh issue edit ` | 出る ✓ |
| `gh issue edit 3` | 出る ✓ |
| `gh issue edit 341 ` | **出ない** ✓ |
| `gh issue edit 341 41` | **出ない** ✓ |

issue/pr/run/release/gist の全 5 サブコマンドに適用。

## 2. fzf-gh ピッカー (`feat(fzf-picker)`)

`Ctrl+J Ctrl+I` → Issue/PR 混在リストを fzf 表示（ID・title・author・assignee で検索）→ 項目選択 → 種別別アクションを fzf 選択 → コマンド組立 → `commandline -i` で挿入（実行は手動 Enter）。

- アクション集合: issue=`view/edit/close/reopen/comment/pin`、pr=`view/checkout/review/diff/merge/checks/update-branch`
- ロジックは `crates/fzf-picker` の新 bin `fzf-gh`。新規ドメイン 1 ファイル `gh.rs`（`Kind`・選択行パース・コマンド組立の純ロジック + 一覧取得 IO）に凝集し、worktree 色の `format`/`parse` には混ぜない。表示成形は gh の `--jq` に委譲し依存追加なし。
- 既存定石どおり bin は選択結果を stdout に出し、薄い fish shim `_fzf_gh` が挿入。配布フックは無変更（cargo がクレート全 bin を自動検出）。

## 検証

- `cargo test -p fzf-picker`: 51 passed（`gh.rs` ユニット + `fzf-gh` E2E 含む）
- `cargo fmt --all --check` / `cargo clippy -D warnings`: OK
- `mise run check`: 問題なし
- fish 構文・テンプレート展開: OK

## 補足・残課題

- `Ctrl+I` は端末上 Tab と同一バイトだが、`Ctrl+J` プレフィクス後の第 2 キーなので素の Tab 補完とは競合しない。気になれば差し替え可。
- ピッカーは **open な Issue/PR のみ**（`gh list` デフォルト）。`reopen` 用に closed も出すなら別途調整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)