### PR TITLE
chore: release v0.69.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.69.4] - 2026-06-19
+### Features
+- Gradle のプロンプトから via を非表示化 ([#445](https://github.com/toshiki670/dotfiles/pull/445)) ([`9148e25`](https://github.com/toshiki670/dotfiles/commit/9148e25b693ccd2d5807fb1ecd9577b15ddc31dc))
+- コミット時に gitleaks 検査するグローバル hook を全ホストに追加 ([#447](https://github.com/toshiki670/dotfiles/pull/447)) ([`03ac8a3`](https://github.com/toshiki670/dotfiles/commit/03ac8a38cc30e8607d25c71d20e738652551c983))
+- Issue/PR 横断 fzf ピッカー追加 + gh ID 補完バグ修正 ([#448](https://github.com/toshiki670/dotfiles/pull/448)) ([`7236104`](https://github.com/toshiki670/dotfiles/commit/7236104c4ac74173bd2866e0f9d5ccef8591f691))
+- ファイル削除を trash に誘導（指示ルール主役＋ガードフック保険） ([#449](https://github.com/toshiki670/dotfiles/pull/449)) ([`01ecf4e`](https://github.com/toshiki670/dotfiles/commit/01ecf4edc580a22e7018788dd630851787327378))
+
+
 ## [0.69.3] - 2026-06-18
 ### Features
 - Copy-obj / c-file / c-path を clip コマンドへ統合 ([#435](https://github.com/toshiki670/dotfiles/pull/435)) ([`d9d247e`](https://github.com/toshiki670/dotfiles/commit/d9d247eb30bf6235a00594e0b10c84c79d917da0))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.69.3"
+version = "0.69.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "fzf-picker"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.69.3"
+version     = "0.69.4"
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/fzf-picker/CHANGELOG.md
+++ b/crates/fzf-picker/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2026-06-19
+### Features
+- Issue/PR 横断 fzf ピッカー追加 + gh ID 補完バグ修正 ([#448](https://github.com/toshiki670/dotfiles/pull/448)) ([`7236104`](https://github.com/toshiki670/dotfiles/commit/7236104c4ac74173bd2866e0f9d5ccef8591f691))
+
+
 ## [0.1.1] - 2026-06-18
 ### Refactor
 - 引数なしピッカーから clap を外す ([#434](https://github.com/toshiki670/dotfiles/pull/434)) ([`e6cd53e`](https://github.com/toshiki670/dotfiles/commit/e6cd53e2e479d5878ddc04d40efaed2dc5495b71))

--- a/crates/fzf-picker/Cargo.toml
+++ b/crates/fzf-picker/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "fzf-picker"
 repository  = { workspace = true }
-version     = "0.1.1"
+version     = "0.1.2"
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `fzf-picker`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `dotfiles`: 0.69.3 -> 0.69.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `fzf-picker`

<blockquote>

## [0.1.2] - 2026-06-19

### Features
- Issue/PR 横断 fzf ピッカー追加 + gh ID 補完バグ修正 ([#448](https://github.com/toshiki670/dotfiles/pull/448)) ([`7236104`](https://github.com/toshiki670/dotfiles/commit/7236104c4ac74173bd2866e0f9d5ccef8591f691))
</blockquote>

## `dotfiles`

<blockquote>

## [0.69.4] - 2026-06-19

### Features
- Gradle のプロンプトから via を非表示化 ([#445](https://github.com/toshiki670/dotfiles/pull/445)) ([`9148e25`](https://github.com/toshiki670/dotfiles/commit/9148e25b693ccd2d5807fb1ecd9577b15ddc31dc))
- コミット時に gitleaks 検査するグローバル hook を全ホストに追加 ([#447](https://github.com/toshiki670/dotfiles/pull/447)) ([`03ac8a3`](https://github.com/toshiki670/dotfiles/commit/03ac8a38cc30e8607d25c71d20e738652551c983))
- Issue/PR 横断 fzf ピッカー追加 + gh ID 補完バグ修正 ([#448](https://github.com/toshiki670/dotfiles/pull/448)) ([`7236104`](https://github.com/toshiki670/dotfiles/commit/7236104c4ac74173bd2866e0f9d5ccef8591f691))
- ファイル削除を trash に誘導（指示ルール主役＋ガードフック保険） ([#449](https://github.com/toshiki670/dotfiles/pull/449)) ([`01ecf4e`](https://github.com/toshiki670/dotfiles/commit/01ecf4edc580a22e7018788dd630851787327378))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).