### PR TITLE
feat(dotfiles): apply 最小骨格（固定ソース configs/・copy のみ）[S0 #454]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,9 @@ dependencies = [
  "clap",
  "predicates",
  "rstest",
+ "serde",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -592,7 +595,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -764,6 +767,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +818,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,14 +849,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -832,8 +879,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -957,6 +1010,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ repository  = { workspace = true }
 version     = "0.69.4"
 
 [dependencies]
-clap = { workspace = true }
+clap  = { workspace = true }
+serde = { workspace = true }
+toml  = { workspace = true }
 
 [lints]
 workspace = true
@@ -22,6 +24,7 @@ workspace = true
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
+tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"
@@ -49,6 +52,7 @@ libc          = "0.2"
 serde         = { version = "1", features = [ "derive" ] }
 serde_json    = "1"
 tempfile      = "3"
+toml          = "0.8"
 # E2E（dev-dependencies）
 assert_cmd = "2.2"
 predicates = "3.1"

--- a/configs/zellij/config.kdl
+++ b/configs/zellij/config.kdl
@@ -1,0 +1,532 @@
+keybinds clear-defaults=true {
+    locked {
+        bind "Ctrl Esc" { SwitchToMode "normal"; }
+    }
+    pane {
+        bind "left" { MoveFocus "left"; }
+        bind "down" { MoveFocus "down"; }
+        bind "up" { MoveFocus "up"; }
+        bind "right" { MoveFocus "right"; }
+        bind "c" { SwitchToMode "renamepane"; PaneNameInput 0; }
+        bind "d" { NewPane "down"; SwitchToMode "normal"; }
+        bind "e" { TogglePaneEmbedOrFloating; SwitchToMode "normal"; }
+        bind "f" { ToggleFocusFullscreen; SwitchToMode "normal"; }
+        bind "h" { MoveFocus "left"; }
+        bind "i" { TogglePanePinned; SwitchToMode "normal"; }
+        bind "j" { MoveFocus "down"; }
+        bind "k" { MoveFocus "up"; }
+        bind "l" { MoveFocus "right"; }
+        bind "n" { NewPane; SwitchToMode "normal"; }
+        bind "p" { SwitchFocus; }
+        bind "Ctrl p" { SwitchToMode "normal"; }
+        bind "r" { NewPane "right"; SwitchToMode "normal"; }
+        bind "s" { NewPane "stacked"; SwitchToMode "normal"; }
+        bind "w" { ToggleFloatingPanes; SwitchToMode "normal"; }
+        bind "z" { TogglePaneFrames; SwitchToMode "normal"; }
+    }
+    tab {
+        bind "left" { GoToPreviousTab; }
+        bind "down" { GoToNextTab; }
+        bind "up" { GoToPreviousTab; }
+        bind "right" { GoToNextTab; }
+        bind "1" { GoToTab 1; SwitchToMode "normal"; }
+        bind "2" { GoToTab 2; SwitchToMode "normal"; }
+        bind "3" { GoToTab 3; SwitchToMode "normal"; }
+        bind "4" { GoToTab 4; SwitchToMode "normal"; }
+        bind "5" { GoToTab 5; SwitchToMode "normal"; }
+        bind "6" { GoToTab 6; SwitchToMode "normal"; }
+        bind "7" { GoToTab 7; SwitchToMode "normal"; }
+        bind "8" { GoToTab 8; SwitchToMode "normal"; }
+        bind "9" { GoToTab 9; SwitchToMode "normal"; }
+        bind "[" { BreakPaneLeft; SwitchToMode "normal"; }
+        bind "]" { BreakPaneRight; SwitchToMode "normal"; }
+        bind "b" { BreakPane; SwitchToMode "normal"; }
+        bind "h" { GoToPreviousTab; }
+        bind "j" { GoToNextTab; }
+        bind "k" { GoToPreviousTab; }
+        bind "l" { GoToNextTab; }
+        bind "n" { NewTab; SwitchToMode "normal"; }
+        bind "r" { SwitchToMode "renametab"; TabNameInput 0; }
+        bind "s" { ToggleActiveSyncTab; SwitchToMode "normal"; }
+        bind "Ctrl t" { SwitchToMode "normal"; }
+        bind "x" { CloseTab; SwitchToMode "normal"; }
+        bind "tab" { ToggleTab; }
+    }
+    resize {
+        bind "left" { Resize "Increase left"; }
+        bind "down" { Resize "Increase down"; }
+        bind "up" { Resize "Increase up"; }
+        bind "right" { Resize "Increase right"; }
+        bind "+" { Resize "Increase"; }
+        bind "-" { Resize "Decrease"; }
+        bind "=" { Resize "Increase"; }
+        bind "H" { Resize "Decrease left"; }
+        bind "J" { Resize "Decrease down"; }
+        bind "K" { Resize "Decrease up"; }
+        bind "L" { Resize "Decrease right"; }
+        bind "h" { Resize "Increase left"; }
+        bind "j" { Resize "Increase down"; }
+        bind "k" { Resize "Increase up"; }
+        bind "l" { Resize "Increase right"; }
+        bind "Ctrl r" { SwitchToMode "normal"; }
+    }
+    move {
+        bind "left" { MovePane "left"; }
+        bind "down" { MovePane "down"; }
+        bind "up" { MovePane "up"; }
+        bind "right" { MovePane "right"; }
+        bind "h" { MovePane "left"; }
+        bind "Ctrl m" { SwitchToMode "normal"; }
+        bind "j" { MovePane "down"; }
+        bind "k" { MovePane "up"; }
+        bind "l" { MovePane "right"; }
+        bind "n" { MovePane; }
+        bind "p" { MovePaneBackwards; }
+        bind "tab" { MovePane; }
+    }
+    scroll {
+        bind "e" { EditScrollback; SwitchToMode "normal"; }
+        bind "s" { SwitchToMode "entersearch"; SearchInput 0; }
+    }
+    search {
+        bind "c" { SearchToggleOption "CaseSensitivity"; }
+        bind "n" { Search "down"; }
+        bind "o" { SearchToggleOption "WholeWord"; }
+        bind "p" { Search "up"; }
+        bind "w" { SearchToggleOption "Wrap"; }
+    }
+    session {
+        bind "a" {
+            LaunchOrFocusPlugin "zellij:about" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "c" {
+            LaunchOrFocusPlugin "configuration" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "Ctrl o" { SwitchToMode "normal"; }
+        bind "p" {
+            LaunchOrFocusPlugin "plugin-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "s" {
+            LaunchOrFocusPlugin "zellij:share" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+        bind "w" {
+            LaunchOrFocusPlugin "session-manager" {
+                floating true
+                move_to_focused_tab true
+            }
+            SwitchToMode "normal"
+        }
+    }
+    shared_except "locked" {
+        bind "Alt left" { MoveFocusOrTab "left"; }
+        bind "Alt down" { MoveFocus "down"; }
+        bind "Alt up" { MoveFocus "up"; }
+        bind "Alt right" { MoveFocusOrTab "right"; }
+        bind "Alt +" { Resize "Increase"; }
+        bind "Alt -" { Resize "Decrease"; }
+        bind "Alt =" { Resize "Increase"; }
+        bind "Alt [" { PreviousSwapLayout; }
+        bind "Alt ]" { NextSwapLayout; }
+        bind "Alt f" { ToggleFloatingPanes; }
+        bind "Ctrl Esc" { SwitchToMode "locked"; }
+        bind "Alt h" { MoveFocusOrTab "left"; }
+        bind "Alt i" { MoveTab "left"; }
+        bind "Alt j" { MoveFocus "down"; }
+        bind "Alt k" { MoveFocus "up"; }
+        bind "Alt l" { MoveFocusOrTab "right"; }
+        bind "Alt n" { NewPane; }
+        bind "Alt o" { MoveTab "right"; }
+        bind "Alt p" { TogglePaneInGroup; }
+        bind "Alt Shift p" { ToggleGroupMarking; }
+        bind "Ctrl q" { Quit; }
+    }
+    shared_except "locked" "move" {
+        bind "Ctrl m" { SwitchToMode "move"; }
+    }
+    shared_except "locked" "session" {
+        bind "Ctrl o" { SwitchToMode "session"; }
+    }
+    shared_except "locked" "scroll" "search" "tmux" {
+        bind "Ctrl b" { SwitchToMode "tmux"; }
+    }
+    shared_except "locked" "scroll" "search" {
+        bind "Ctrl s" { SwitchToMode "scroll"; }
+    }
+    shared_except "locked" "tab" {
+        bind "Ctrl t" { SwitchToMode "tab"; }
+    }
+    shared_except "locked" "pane" {
+        bind "Ctrl p" { SwitchToMode "pane"; }
+    }
+    shared_except "locked" "resize" {
+        bind "Ctrl r" { SwitchToMode "resize"; }
+    }
+    shared_except "normal" "locked" "entersearch" {
+        bind "enter" { SwitchToMode "normal"; }
+    }
+    shared_except "normal" "locked" "entersearch" "renametab" "renamepane" {
+        bind "esc" { SwitchToMode "normal"; }
+    }
+    shared_among "pane" "tmux" {
+        bind "x" { CloseFocus; SwitchToMode "normal"; }
+    }
+    shared_among "scroll" "search" {
+        bind "PageDown" { PageScrollDown; }
+        bind "PageUp" { PageScrollUp; }
+        bind "left" { PageScrollUp; }
+        bind "down" { ScrollDown; }
+        bind "up" { ScrollUp; }
+        bind "right" { PageScrollDown; }
+        bind "Ctrl b" { PageScrollUp; }
+        bind "Ctrl c" { ScrollToBottom; SwitchToMode "normal"; }
+        bind "d" { HalfPageScrollDown; }
+        bind "Ctrl f" { PageScrollDown; }
+        bind "h" { PageScrollUp; }
+        bind "j" { ScrollDown; }
+        bind "k" { ScrollUp; }
+        bind "l" { PageScrollDown; }
+        bind "Ctrl s" { SwitchToMode "normal"; }
+        bind "u" { HalfPageScrollUp; }
+    }
+    entersearch {
+        bind "Ctrl c" { SwitchToMode "scroll"; }
+        bind "esc" { SwitchToMode "scroll"; }
+        bind "enter" { SwitchToMode "search"; }
+    }
+    renametab {
+        bind "esc" { UndoRenameTab; SwitchToMode "tab"; }
+    }
+    shared_among "renametab" "renamepane" {
+        bind "Ctrl c" { SwitchToMode "normal"; }
+    }
+    renamepane {
+        bind "esc" { UndoRenamePane; SwitchToMode "pane"; }
+    }
+    shared_among "session" "tmux" {
+        bind "d" { Detach; }
+    }
+    tmux {
+        bind "left" { MoveFocus "left"; SwitchToMode "normal"; }
+        bind "down" { MoveFocus "down"; SwitchToMode "normal"; }
+        bind "up" { MoveFocus "up"; SwitchToMode "normal"; }
+        bind "right" { MoveFocus "right"; SwitchToMode "normal"; }
+        bind "space" { NextSwapLayout; }
+        bind "\"" { NewPane "down"; SwitchToMode "normal"; }
+        bind "%" { NewPane "right"; SwitchToMode "normal"; }
+        bind "," { SwitchToMode "renametab"; }
+        bind "[" { SwitchToMode "scroll"; }
+        bind "Ctrl b" { Write 2; SwitchToMode "normal"; }
+        bind "c" { NewTab; SwitchToMode "normal"; }
+        bind "h" { MoveFocus "left"; SwitchToMode "normal"; }
+        bind "j" { MoveFocus "down"; SwitchToMode "normal"; }
+        bind "k" { MoveFocus "up"; SwitchToMode "normal"; }
+        bind "l" { MoveFocus "right"; SwitchToMode "normal"; }
+        bind "n" { GoToNextTab; SwitchToMode "normal"; }
+        bind "o" { FocusNextPane; }
+        bind "p" { GoToPreviousTab; SwitchToMode "normal"; }
+        bind "z" { ToggleFocusFullscreen; SwitchToMode "normal"; }
+    }
+}
+
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
+plugins {
+    about location="zellij:about"
+    compact-bar location="zellij:compact-bar"
+    configuration location="zellij:configuration"
+    filepicker location="zellij:strider" {
+        cwd "/"
+    }
+    plugin-manager location="zellij:plugin-manager"
+    session-manager location="zellij:session-manager"
+    status-bar location="zellij:status-bar"
+    strider location="zellij:strider"
+    tab-bar location="zellij:tab-bar"
+    welcome-screen location="zellij:session-manager" {
+        welcome_screen true
+    }
+}
+
+// Plugins to load in the background when a new session starts
+// eg. "file:/path/to/my-plugin.wasm"
+// eg. "https://example.com/my-plugin.wasm"
+load_plugins {
+}
+web_client {
+    font "monospace"
+}
+ 
+// Use a simplified UI without special fonts (arrow glyphs)
+// Options:
+//   - true
+//   - false (Default)
+// 
+// simplified_ui true
+ 
+// Choose the theme that is specified in the themes section.
+// Default: default
+// 
+// theme "dracula"
+ 
+// Choose the base input mode of zellij.
+// Default: normal
+// 
+// default_mode "locked"
+ 
+// Choose the path to the default shell that zellij will use for opening new panes
+// Default: $SHELL
+// 
+// default_shell "fish"
+ 
+// Choose the path to override cwd that zellij will use for opening new panes
+// 
+// default_cwd "/tmp"
+ 
+// The name of the default layout to load on startup
+// Default: "default"
+// 
+// default_layout "compact"
+ 
+// The folder in which Zellij will look for layouts
+// (Requires restart)
+// 
+// layout_dir "/tmp"
+ 
+// The folder in which Zellij will look for themes
+// (Requires restart)
+// 
+// theme_dir "/tmp"
+ 
+// Toggle enabling the mouse mode.
+// On certain configurations, or terminals this could
+// potentially interfere with copying text.
+// Options:
+//   - true (default)
+//   - false
+// 
+// mouse_mode false
+ 
+// Toggle having pane frames around the panes
+// Options:
+//   - true (default, enabled)
+//   - false
+// 
+// pane_frames false
+ 
+// When attaching to an existing session with other users,
+// should the session be mirrored (true)
+// or should each user have their own cursor (false)
+// (Requires restart)
+// Default: false
+// 
+// mirror_session true
+ 
+// Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
+// eg. when terminal window with an active zellij session is closed
+// (Requires restart)
+// Options:
+//   - detach (Default)
+//   - quit
+// 
+// on_force_close "quit"
+ 
+// Configure the scroll back buffer size
+// This is the number of lines zellij stores for each pane in the scroll back
+// buffer. Excess number of lines are discarded in a FIFO fashion.
+// (Requires restart)
+// Valid values: positive integers
+// Default value: 10000
+// 
+// scroll_buffer_size 10000
+ 
+// Provide a command to execute when copying text. The text will be piped to
+// the stdin of the program to perform the copy. This can be used with
+// terminal emulators which do not support the OSC 52 ANSI control sequence
+// that will be used by default if this option is not set.
+// Examples:
+//
+// copy_command "xclip -selection clipboard" // x11
+// copy_command "wl-copy"                    // wayland
+// copy_command "pbcopy"                     // osx
+// 
+// copy_command "pbcopy"
+ 
+// Choose the destination for copied text
+// Allows using the primary selection buffer (on x11/wayland) instead of the system clipboard.
+// Does not apply when using copy_command.
+// Options:
+//   - system (default)
+//   - primary
+// 
+// copy_clipboard "primary"
+ 
+// Enable automatic copying (and clearing) of selection when releasing mouse
+// Default: true
+// 
+// copy_on_select true
+ 
+// Path to the default editor to use to edit pane scrollbuffer
+// Default: $EDITOR or $VISUAL
+// scrollback_editor "/usr/bin/vim"
+ 
+// A fixed name to always give the Zellij session.
+// Consider also setting `attach_to_session true,`
+// otherwise this will error if such a session exists.
+// Default: <RANDOM>
+// 
+// session_name "My singleton session"
+ 
+// When `session_name` is provided, attaches to that session
+// if it is already running or creates it otherwise.
+// Default: false
+// 
+// attach_to_session true
+ 
+// Toggle between having Zellij lay out panes according to a predefined set of layouts whenever possible
+// Options:
+//   - true (default)
+//   - false
+// 
+// auto_layout false
+ 
+// Whether sessions should be serialized to the cache folder (including their tabs/panes, cwds and running commands) so that they can later be resurrected
+// Options:
+//   - true (default)
+//   - false
+// 
+// session_serialization false
+ 
+// Whether pane viewports are serialized along with the session, default is false
+// Options:
+//   - true
+//   - false (default)
+// 
+// serialize_pane_viewport false
+ 
+// Scrollback lines to serialize along with the pane viewport when serializing sessions, 0
+// defaults to the scrollback size. If this number is higher than the scrollback size, it will
+// also default to the scrollback size. This does nothing if `serialize_pane_viewport` is not true.
+// 
+// scrollback_lines_to_serialize 10000
+ 
+// Enable or disable the rendering of styled and colored underlines (undercurl).
+// May need to be disabled for certain unsupported terminals
+// (Requires restart)
+// Default: true
+// 
+// styled_underlines false
+ 
+// How often in seconds sessions are serialized
+// 
+// serialization_interval 10000
+ 
+// Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
+// metadata info on this session)
+// (Requires restart)
+// Default: false
+// 
+// disable_session_metadata false
+ 
+// Enable or disable support for the enhanced Kitty Keyboard Protocol (the host terminal must also support it)
+// (Requires restart)
+// Default: true (if the host terminal supports it)
+// 
+// support_kitty_keyboard_protocol false
+// Whether to make sure a local web server is running when a new Zellij session starts.
+// This web server will allow creating new sessions and attaching to existing ones that have
+// opted in to being shared in the browser.
+// When enabled, navigate to http://127.0.0.1:8082
+// (Requires restart)
+// 
+// Note: a local web server can still be manually started from within a Zellij session or from the CLI.
+// If this is not desired, one can use a version of Zellij compiled without
+// `web_server_capability`
+// 
+// Possible values:
+// - true
+// - false
+// Default: false
+// 
+// web_server false
+// Whether to allow sessions started in the terminal to be shared through a local web server, assuming one is
+// running (see the `web_server` option for more details).
+// (Requires restart)
+// 
+// Note: This is an administrative separation and not intended as a security measure.
+// 
+// Possible values:
+// - "on" (allow web sharing through the local web server if it
+// is online)
+// - "off" (do not allow web sharing unless sessions explicitly opt-in to it)
+// - "disabled" (do not allow web sharing and do not permit sessions started in the terminal to opt-in to it)
+// Default: "off"
+// 
+// web_sharing "off"
+// A path to a certificate file to be used when setting up the web client to serve the
+// connection over HTTPs
+// 
+// web_server_cert "/path/to/cert.pem"
+// A path to a key file to be used when setting up the web client to serve the
+// connection over HTTPs
+// 
+// web_server_key "/path/to/key.pem"
+/// Whether to enforce https connections to the web server when it is bound to localhost
+/// (127.0.0.0/8)
+///
+/// Note: https is ALWAYS enforced when bound to non-local interfaces
+///
+/// Default: false
+// 
+// enforce_https_for_localhost false
+ 
+// Whether to stack panes when resizing beyond a certain size
+// Default: true
+// 
+// stacked_resize false
+ 
+// Whether to show tips on startup
+// Default: true
+// 
+// show_startup_tips false
+ 
+// Whether to show release notes on first version run
+// Default: true
+// 
+// show_release_notes false
+ 
+// Whether to enable mouse hover effects and pane grouping functionality
+// default is true
+// advanced_mouse_actions false
+ 
+// The ip address the web server should listen on when it starts
+// Default: "127.0.0.1"
+// (Requires restart)
+// web_server_ip "127.0.0.1"
+ 
+// The port the web server should listen on when it starts
+// Default: 8082
+// (Requires restart)
+// web_server_port 8082
+ 
+// A command to run (will be wrapped with sh -c and provided the RESURRECT_COMMAND env variable) 
+// after Zellij attempts to discover a command inside a pane when resurrecting sessions, the STDOUT
+// of this command will be used instead of the discovered RESURRECT_COMMAND
+// can be useful for removing wrappers around commands
+// Note: be sure to escape backslashes and similar characters properly
+// post_command_discovery_hook "echo $RESURRECT_COMMAND | sed <your_regex_here>"

--- a/configs/zellij/manifest.toml
+++ b/configs/zellij/manifest.toml
@@ -1,0 +1,6 @@
+# zellij の設定配置（S0: copy-only の最小骨格）。
+# 設計: docs/dotfiles-native-design.md §6
+#
+# dst は配置先（必須）。`~` は HOME に展開される。
+# kind は省略時 "copy"。S0 は copy のみ対応。
+dst = "~/.config/zellij"

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -13,7 +13,16 @@ const MANIFEST: &str = "manifest.toml";
 /// `home` は dst の `~` 展開先。
 pub fn run(source: &Path, home: &Path) -> Result<(), String> {
     if !source.is_dir() {
-        return Err(format!("ソースが見つからない: {}", source.display()));
+        let looked = std::env::current_dir()
+            .map(|cwd| cwd.join(source))
+            .unwrap_or_else(|_| source.to_path_buf());
+        return Err(format!(
+            "ソース {src} が見つかりません（探索先: {looked}）。\n\
+             {src} はカレントディレクトリからの相対パスです。\
+             configs/ のあるリポジトリのルートに移動してから実行してください。",
+            src = source.display(),
+            looked = looked.display(),
+        ));
     }
 
     let mut units = Vec::new();

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,0 +1,119 @@
+//! `dotfiles apply`：固定ソース `configs/` を走査し配置を実行する（S0 最小骨格）。
+//!
+//! S0 はソース解決（検出 / 判定 / 埋め込み）を持たない（→ S8）。呼び出し側が渡す
+//! 固定パスをそのまま読む。走査は `manifest.toml` を持つディレクトリ単位で、copy
+//! のみを実行する。複数ツール対応や `dotfiles list` は S1 以降。
+
+use crate::manifest::{Kind, Manifest};
+use std::path::{Path, PathBuf};
+
+const MANIFEST: &str = "manifest.toml";
+
+/// `source`（= `configs/`）配下を走査し、各 manifest の配置を実行する。
+/// `home` は dst の `~` 展開先。
+pub fn run(source: &Path, home: &Path) -> Result<(), String> {
+    if !source.is_dir() {
+        return Err(format!("ソースが見つからない: {}", source.display()));
+    }
+
+    let mut units = Vec::new();
+    collect_manifests(source, &mut units)?;
+    if units.is_empty() {
+        println!(
+            "apply: 対象なし（{} に manifest.toml がない）",
+            source.display()
+        );
+        return Ok(());
+    }
+
+    for dir in units {
+        apply_unit(&dir, home)?;
+    }
+    Ok(())
+}
+
+/// `manifest.toml` を持つディレクトリ（= 設定単位）を再帰的に収集する。
+/// サブディレクトリに別の manifest があればそれも別ユニットとして収集する
+/// （ツリーを manifest で分割統治。設計書 §6.3 ルール1）。
+fn collect_manifests(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    if dir.join(MANIFEST).is_file() {
+        out.push(dir.to_path_buf());
+    }
+    for entry in read_dir(dir)? {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_manifests(&path, out)?;
+        }
+    }
+    Ok(())
+}
+
+/// 1 ユニットを配置する。S0 は kind=copy のみ。
+fn apply_unit(dir: &Path, home: &Path) -> Result<(), String> {
+    let manifest = Manifest::load(&dir.join(MANIFEST))?;
+    let dst = expand_home(&manifest.dst, home);
+    match manifest.kind {
+        Kind::Copy => copy_tree(dir, dir, &dst)?,
+    }
+    println!(
+        "apply: {} → {} (copy)",
+        dir.file_name().and_then(|n| n.to_str()).unwrap_or("?"),
+        manifest.dst,
+    );
+    Ok(())
+}
+
+/// `src_root` 配下の実ファイルを、相対構造を保ったまま `dst_root` へコピーする。
+/// `manifest.toml` 自体と、別 manifest を持つサブツリーは除外する（委譲先の責務）。
+fn copy_tree(current: &Path, src_root: &Path, dst_root: &Path) -> Result<(), String> {
+    for entry in read_dir(current)? {
+        let path = entry.path();
+        if path.is_dir() {
+            // サブ manifest を持つディレクトリは別ユニットなので委譲（コピー対象外）。
+            if path.join(MANIFEST).is_file() {
+                continue;
+            }
+            copy_tree(&path, src_root, dst_root)?;
+        } else if entry.file_name() != MANIFEST {
+            let rel = path
+                .strip_prefix(src_root)
+                .map_err(|e| format!("{}: 相対パス算出失敗: {e}", path.display()))?;
+            copy_file(&path, &dst_root.join(rel))?;
+        }
+    }
+    Ok(())
+}
+
+/// 親ディレクトリを作りつつ 1 ファイルをコピーする。
+fn copy_file(src: &Path, dst: &Path) -> Result<(), String> {
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
+    }
+    std::fs::copy(src, dst)
+        .map_err(|e| format!("{} → {}: コピー失敗: {e}", src.display(), dst.display()))?;
+    Ok(())
+}
+
+/// dst の `~` / `~/...` を `home` に展開する。
+/// S0 は `~` のみ対応（`$XDG_*` 等の正規化は設計書 §14 で確定）。
+fn expand_home(dst: &str, home: &Path) -> PathBuf {
+    if let Some(rest) = dst.strip_prefix("~/") {
+        home.join(rest)
+    } else if dst == "~" {
+        home.to_path_buf()
+    } else {
+        PathBuf::from(dst)
+    }
+}
+
+/// `std::fs::read_dir` を `Vec<DirEntry>` に集約しつつエラーメッセージを整える。
+fn read_dir(dir: &Path) -> Result<Vec<std::fs::DirEntry>, String> {
+    let mut entries = Vec::new();
+    let iter =
+        std::fs::read_dir(dir).map_err(|e| format!("{}: 読み込み失敗: {e}", dir.display()))?;
+    for entry in iter {
+        entries.push(entry.map_err(|e| format!("{}: エントリ取得失敗: {e}", dir.display()))?);
+    }
+    Ok(entries)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,16 @@
 //! `dotfiles` 本体（core）コマンド。
 //!
-//! 現状は chezmoi と各コマンド（`crates/*`）に委譲しており、本体は将来
-//! それらを取り込む器（all-in-one 化の予定地）。当面は clap で `--version` /
-//! `--help` を提供し、バージョンの source of truth（タグ `v{version}`）を担う。
+//! 現状は chezmoi と各コマンド（`crates/*`）に委譲しつつ、それらを取り込む器。
+//! `--version` / `--help` はバージョンの source of truth（タグ `v{version}`）を担う。
+//!
+//! `apply` サブコマンドは dotfiles ネイティブ化（Epic #453）の最小骨格（S0 / #454）：
+//! 固定ソース `configs/` を走査し、`manifest.toml`（dst / kind=copy）に従って配置する。
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use std::path::Path;
+
+mod apply;
+mod manifest;
 
 /// toshiki670/dotfiles 本体（core）。
 #[derive(Parser)]
@@ -12,12 +18,35 @@ use clap::Parser;
     name = "dotfiles",
     version,
     about = "toshiki670/dotfiles 本体（core）コマンド",
-    long_about = "toshiki670/dotfiles 本体（core）。現状は chezmoi と各コマンドに委譲しており、\n将来それらを取り込む器。当面はバージョン確認用。"
+    long_about = "toshiki670/dotfiles 本体（core）。設定の管理・配置を担う。\nサブコマンドを指定しない場合はバージョンを表示する。"
 )]
-struct Cli {}
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// 固定ソース `configs/` を走査し設定を配置する（S0: copy のみ）。
+    Apply,
+}
 
 fn main() {
-    let _ = Cli::parse();
-    // 現状サブコマンドは持たない。`--version` / `--help` は clap が処理する。
-    println!("dotfiles {}", env!("CARGO_PKG_VERSION"));
+    let cli = Cli::parse();
+    match cli.command {
+        Some(Commands::Apply) => {
+            if let Err(e) = run_apply() {
+                eprintln!("dotfiles apply: {e}");
+                std::process::exit(1);
+            }
+        }
+        // サブコマンドなし: 従来どおりバージョンを表示する。
+        None => println!("dotfiles {}", env!("CARGO_PKG_VERSION")),
+    }
+}
+
+/// `dotfiles apply`：CWD 相対の固定ソース `configs/` を、HOME を基点に配置する。
+fn run_apply() -> Result<(), String> {
+    let home = std::env::var_os("HOME").ok_or_else(|| "HOME が未設定".to_string())?;
+    apply::run(Path::new("configs"), Path::new(&home))
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,35 @@
+//! `manifest.toml` の最小スキーマと読み込み（S0）。
+//!
+//! 設計書（docs/dotfiles-native-design.md §6.2）のスキーマのうち、S0 で必要な
+//! 最小部分だけを解釈する。`dst`（必須）と `kind`（省略時 copy）のみ。
+//! generate / merge / theme / deps / hooks / os / secrets は後続スライスで追加する。
+
+use serde::Deserialize;
+use std::path::Path;
+
+/// 1 つの設定単位（`manifest.toml` を持つディレクトリ）の配置仕様。
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    /// 配置先（必須）。`~` は HOME に展開する。
+    pub dst: String,
+    /// 配置種別（省略時 = copy）。S0 は copy のみ対応。
+    #[serde(default)]
+    pub kind: Kind,
+}
+
+/// 配置種別。S0 では copy のみ。generate / merge は後続スライス（S2 / S3）。
+#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    #[default]
+    Copy,
+}
+
+impl Manifest {
+    /// `manifest.toml` を読み込んでパースする。
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("{}: 読み込み失敗: {e}", path.display()))?;
+        toml::from_str(&text).map_err(|e| format!("{}: パース失敗: {e}", path.display()))
+    }
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -3,6 +3,8 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use rstest::rstest;
+use std::fs;
+use std::path::Path;
 
 fn dotfiles() -> Command {
     Command::cargo_bin("dotfiles").unwrap()
@@ -34,4 +36,77 @@ fn no_args_prints_version() {
         .success()
         .stdout(predicate::str::contains("dotfiles"))
         .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+/// `dotfiles apply` が固定ソース `configs/` を読み、`manifest.toml`（dst / kind=copy 既定）
+/// に従って一時 HOME へ実体を配置することを検証する（S0 / #454 の受け入れ条件）。
+/// 実ソースである repo の `configs/zellij` をそのまま使い、configs 化が機能することを確かめる。
+#[test]
+fn apply_places_real_zellij_config_into_home() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let src = Path::new(repo_root).join("configs/zellij/config.kdl");
+    let home = tempfile::tempdir().unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(repo_root)
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/zellij/config.kdl");
+    assert!(
+        placed.is_file(),
+        "zellij config が配置されていない: {placed:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        fs::read_to_string(&src).unwrap(),
+        "配置された内容がソースと一致しない",
+    );
+}
+
+/// kind 省略時に copy として扱われ、`~` が HOME に展開されることを、
+/// 一時ソース fixture で検証する（hermetic）。
+#[test]
+fn apply_defaults_to_copy_and_expands_tilde() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    // 一時ソース configs/demo/{manifest.toml, hello.conf} を用意（kind は省略）。
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(unit.join("manifest.toml"), "dst = \"~/.config/demo\"\n").unwrap();
+    fs::write(unit.join("hello.conf"), "hello = 1\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/demo/hello.conf");
+    assert!(placed.is_file(), "fixture が配置されていない: {placed:?}");
+    assert_eq!(fs::read_to_string(&placed).unwrap(), "hello = 1\n");
+    // manifest.toml 自体は配置対象外。
+    assert!(
+        !home.path().join(".config/demo/manifest.toml").exists(),
+        "manifest.toml が誤って配置された",
+    );
+}
+
+/// `configs/` が無い場所で apply するとエラー終了することを検証する。
+#[test]
+fn apply_errors_when_source_missing() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ソースが見つからない"));
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -108,5 +108,7 @@ fn apply_errors_when_source_missing() {
         .env("HOME", home.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("ソースが見つからない"));
+        .stderr(predicate::str::contains("が見つかりません"))
+        .stderr(predicate::str::contains("探索先:"))
+        .stderr(predicate::str::contains("リポジトリのルート"));
 }


### PR DESCRIPTION
## 届く価値

`dotfiles apply`（引数なし）で copy-only の1ツール（zellij）が `~/` に配置される。dotfiles ネイティブ化（Epic #453）の最小骨格。

## 受け入れ条件

- [x] `dotfiles apply`（引数なし）が固定ソース `configs/` を読む（CWD 相対の固定 `"configs"`）
- [x] `manifest.toml` 最小スキーマ（`dst` 必須 / `kind` 省略時 copy）を解釈
- [x] copy-only の1ツール zellij を configs 化し `~/` に配置
- [x] ソース解決ロジック（検出/判定/埋め込み）は持たない（→ S8）
- [x] chezmoi 併用を壊さない（`.chezmoiroot=home` で `configs/` はスコープ外。`chezmoi apply` → `dotfiles apply` で同一内容を後勝ち上書き）
- [x] E2E: 一時 HOME へ apply して配置を検証

## 実装

- `apply` サブコマンド追加（`src/main.rs`）。サブコマンドなしは従来どおりバージョン表示。
- `src/manifest.rs`: `manifest.toml` 最小スキーマ（`dst` / `kind`=copy 既定）。
- `src/apply.rs`: `configs/` 走査 → `manifest.toml` 単位で copy。`~` を HOME 展開。`manifest.toml` 自体とサブ manifest サブツリーは除外。
- `configs/zellij/`（`manifest.toml` + `config.kdl`）を追加。`home/dot_config/zellij/` は移行期のため残置（§12.1 併存）。
- 依存に `toml` / `serde`、dev に `tempfile` を追加。

## 検証

- `cargo test -p dotfiles` … 8 passed（E2E 3件追加: 実 zellij 配置 / kind 既定 copy・`~` 展開 / ソース欠如エラー）
- `cargo clippy --all-targets -D warnings` / `cargo fmt --check` / `mise run check`（taplo）… clean
- 手動: 一時 HOME へ `dotfiles apply` → `~/.config/zellij/config.kdl` がソースと一致

## スコープ外（後続スライス）

複数ツール・`dotfiles list`（S1）、generate（S2）、merge（S3）、ソース解決の二段構え（S8）。

## 参照

- 設計書: `docs/dotfiles-native-design.md`（§4–6, §12）
- Epic: #453 / Issue: Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
