### PR TITLE
feat(dotfiles): generate 層＋deps gate、補完5本を configs 化 [S2 #456]

### DIFF
--- a/configs/bat/completion/manifest.toml
+++ b/configs/bat/completion/manifest.toml
@@ -1,0 +1,8 @@
+# bat の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
+# `bat --completion fish` の出力を dst のファイルへ書き出す。
+# 親の configs/bat（kind=copy）からはこの単位（自前 manifest）は委譲され除外される。
+# deps = bat が PATH に無ければ生成をスキップ（gate）。
+cmd  = [ "bat", "--completion", "fish" ]
+deps = [ "bat" ]
+dst  = "~/.config/fish/completions/bat.fish"
+kind = "generate"

--- a/configs/clip/completion/manifest.toml
+++ b/configs/clip/completion/manifest.toml
@@ -1,0 +1,8 @@
+# clip（crates/clip）の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
+# `clip completions fish` の出力を dst のファイルへ書き出す。
+# deps = clip が PATH に無ければ生成をスキップ（gate）。chezmoi apply 初回など
+# clip 未 install の段階では生成されない。
+cmd  = [ "clip", "completions", "fish" ]
+deps = [ "clip" ]
+dst  = "~/.config/fish/completions/clip.fish"
+kind = "generate"

--- a/configs/docker/completion/manifest.toml
+++ b/configs/docker/completion/manifest.toml
@@ -1,0 +1,7 @@
+# docker の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
+# `docker completion fish` の出力を dst のファイルへ書き出す。
+# deps = docker が PATH に無ければ生成をスキップ（gate）。
+cmd  = [ "docker", "completion", "fish" ]
+deps = [ "docker" ]
+dst  = "~/.config/fish/completions/docker.fish"
+kind = "generate"

--- a/configs/gh/completion/custom.fish
+++ b/configs/gh/completion/custom.fish
@@ -1,0 +1,63 @@
+# Custom completions: ID selection for targeted commands
+
+# 最初の ID 位置でだけ補完を出す共有判定。`commandline -poc` はカーソルで切り、入力中の
+# 部分トークンを除いた「確定済みトークン列」を返す。それがちょうど `gh <group> <sub>`
+# （3 トークン）のときだけ真。これにより `gh issue edit 341 ` のように ID 入力済みでは
+# 候補が出なくなり、`gh issue edit 3` のように最初の ID 入力中は出る。
+function __gh_completing_first_id --argument-names group
+    set -l tokens (commandline -poc)
+    test (count $tokens) -eq 3
+    and test "$tokens[2]" = "$group"
+    and contains -- "$tokens[3]" $argv[2..-1]
+end
+
+function __gh_completing_issue_id
+    __gh_completing_first_id issue view edit close reopen comment pin
+end
+
+function __gh_completing_pr_id
+    __gh_completing_first_id pr view checkout review diff merge checks update-branch
+end
+
+function __gh_completing_run_id
+    __gh_completing_first_id run view rerun cancel watch
+end
+
+function __gh_completing_release_id
+    __gh_completing_first_id release view delete edit upload
+end
+
+function __gh_completing_gist_id
+    __gh_completing_first_id gist view edit
+end
+
+function __gh_issue_candidates
+    gh issue list --limit 100 --json number,title,state \
+        --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null
+end
+
+function __gh_pr_candidates
+    gh pr list --limit 100 --json number,title,state \
+        --jq '.[] | "\(.number)\t[\(.state)] \(.title)"' 2>/dev/null
+end
+
+function __gh_run_candidates
+    gh run list --limit 50 --json databaseId,displayTitle,status \
+        --jq '.[] | "\(.databaseId)\t[\(.status)] \(.displayTitle)"' 2>/dev/null
+end
+
+function __gh_release_candidates
+    gh release list --limit 30 --json tagName,name,publishedAt \
+        --jq '.[] | "\(.tagName)\t\(.name) (\(.publishedAt))"' 2>/dev/null
+end
+
+function __gh_gist_candidates
+    gh gist list --limit 100 2>/dev/null \
+        | awk -F'\t' '{print $1 "\t" $2}'
+end
+
+complete -c gh -n __gh_completing_issue_id -f -a '(__gh_issue_candidates)'
+complete -c gh -n __gh_completing_pr_id -f -a '(__gh_pr_candidates)'
+complete -c gh -n __gh_completing_run_id -f -a '(__gh_run_candidates)'
+complete -c gh -n __gh_completing_release_id -f -a '(__gh_release_candidates)'
+complete -c gh -n __gh_completing_gist_id -f -a '(__gh_gist_candidates)'

--- a/configs/gh/completion/manifest.toml
+++ b/configs/gh/completion/manifest.toml
@@ -1,0 +1,10 @@
+# gh の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
+# `gh completion --shell fish` の出力に、同ディレクトリの custom.fish（ID 補完の独自
+# ブロック）を連結して dst へ書き出す（生成物の後ろへ sibling を追記する generate の規則）。
+# fish は補完をコマンド名のファイル（gh.fish）でのみ autoload するため、独自補完も
+# 同じ gh.fish へ同梱する必要がある。
+# deps = gh が PATH に無ければ生成をスキップ（gate）。
+cmd  = [ "gh", "completion", "--shell", "fish" ]
+deps = [ "gh" ]
+dst  = "~/.config/fish/completions/gh.fish"
+kind = "generate"

--- a/configs/merge-ready/completion/manifest.toml
+++ b/configs/merge-ready/completion/manifest.toml
@@ -1,0 +1,7 @@
+# merge-ready（外部ツール）の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
+# `merge-ready completions fish` の出力を dst のファイルへ書き出す。
+# deps = merge-ready が PATH に無ければ生成をスキップ（gate）。
+cmd  = [ "merge-ready", "completions", "fish" ]
+deps = [ "merge-ready" ]
+dst  = "~/.config/fish/completions/merge-ready.fish"
+kind = "generate"

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,14 +1,22 @@
 //! `dotfiles apply`：固定ソース `configs/` を走査し配置を実行する。
 //!
-//! 走査（manifest 発見・再帰委譲）は [`crate::discover`] に委譲する。本モジュールは
-//! copy 層の実体配置を担う: ディレクトリ単位 copy・複数ファイル・サブディレクトリ再帰、
-//! および manifest の `private` / `executable` 属性に基づくパーミッション付与（§7）。
-//! ソース解決（検出 / 判定 / 埋め込み）は持たない（→ S8）。generate / merge / hooks も
-//! 後続スライス。
+//! 走査（manifest 発見・再帰委譲）は [`crate::discover`]、実体配置は kind ごとに
+//! [`crate::copy`]（copy 層）/ [`crate::generate`]（generate 層）へ委譲する。本モジュールは
+//! オーケストレーション（単位ごとに kind で分岐し結果を表示）と、両層が共有する小道具
+//! （dst の `~` 展開・パーミッション適用）だけを持つ。merge / hooks は後続スライス。
 
-use crate::discover::{self, MANIFEST};
+use crate::discover::{self, MANIFEST, Unit};
 use crate::manifest::{Kind, Manifest};
+use crate::{copy, generate};
 use std::path::{Path, PathBuf};
+
+/// 1 単位の配置結果。配置済みと「gate でスキップ」を表示で区別するために返す。
+pub enum Outcome {
+    /// 配置/生成した。
+    Placed,
+    /// 条件（deps gate / os 等）を満たさず配置しなかった。理由を持つ。
+    Skipped(String),
+}
 
 /// `source`（= `configs/`）配下を走査し、各 manifest の配置を実行する。
 /// `home` は dst の `~` 展開先。
@@ -23,67 +31,32 @@ pub fn run(source: &Path, home: &Path) -> Result<(), String> {
     }
 
     for unit in &units {
-        apply_unit(&unit.dir, home)?;
+        apply_unit(unit, home)?;
     }
     Ok(())
 }
 
-/// 1 単位を配置する。S1 は kind=copy のみ。
-fn apply_unit(dir: &Path, home: &Path) -> Result<(), String> {
-    let manifest = Manifest::load(&dir.join(MANIFEST))?;
+/// 1 単位を kind で分岐して配置し、結果を 1 行で表示する。
+fn apply_unit(unit: &Unit, home: &Path) -> Result<(), String> {
+    let manifest = Manifest::load(&unit.dir.join(MANIFEST))?;
     let dst = expand_home(&manifest.dst, home);
-    match manifest.kind {
-        Kind::Copy => copy_tree(dir, dir, &dst, &manifest)?,
-    }
-    println!(
-        "apply: {} → {} (copy)",
-        dir.file_name().and_then(|n| n.to_str()).unwrap_or("?"),
-        manifest.dst,
-    );
-    Ok(())
-}
+    let (kind, outcome) = match manifest.kind {
+        Kind::Copy => ("copy", copy::place(&unit.dir, &dst, &manifest)?),
+        Kind::Generate => ("generate", generate::place(&unit.dir, &dst, &manifest)?),
+    };
 
-/// `src_root` 配下の実ファイルを、相対構造を保ったまま `dst_root` へコピーする。
-/// `manifest.toml` 自体と、別 manifest を持つサブツリーは除外する（委譲先の責務）。
-fn copy_tree(
-    current: &Path,
-    src_root: &Path,
-    dst_root: &Path,
-    manifest: &Manifest,
-) -> Result<(), String> {
-    for entry in discover::read_dir(current)? {
-        let path = entry.path();
-        if path.is_dir() {
-            // サブ manifest を持つディレクトリは別単位なので委譲（コピー対象外）。
-            if path.join(MANIFEST).is_file() {
-                continue;
-            }
-            copy_tree(&path, src_root, dst_root, manifest)?;
-        } else if entry.file_name() != MANIFEST {
-            let rel = path
-                .strip_prefix(src_root)
-                .map_err(|e| format!("{}: 相対パス算出失敗: {e}", path.display()))?;
-            copy_file(&path, &dst_root.join(rel), manifest)?;
-        }
+    let name = unit.rel.to_string_lossy();
+    match outcome {
+        Outcome::Placed => println!("apply: {name} → {} ({kind})", manifest.dst),
+        Outcome::Skipped(why) => println!("apply: {name} → skip ({kind}: {why})"),
     }
-    Ok(())
-}
-
-/// 親ディレクトリを作りつつ 1 ファイルをコピーし、manifest のパーミッションを与える。
-fn copy_file(src: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
-    if let Some(parent) = dst.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
-    }
-    std::fs::copy(src, dst)
-        .map_err(|e| format!("{} → {}: コピー失敗: {e}", src.display(), dst.display()))?;
-    set_mode(dst, manifest)?;
     Ok(())
 }
 
 /// 配置済みファイルへ manifest のパーミッションを適用する（Unix のみ）。
+/// copy / generate 両層が共有する。
 #[cfg(unix)]
-fn set_mode(dst: &Path, manifest: &Manifest) -> Result<(), String> {
+pub fn set_mode(dst: &Path, manifest: &Manifest) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(dst, std::fs::Permissions::from_mode(manifest.mode()))
         .map_err(|e| format!("{}: パーミッション設定失敗: {e}", dst.display()))
@@ -91,7 +64,7 @@ fn set_mode(dst: &Path, manifest: &Manifest) -> Result<(), String> {
 
 /// 非 Unix では no-op（パーミッションモデルが異なるため）。
 #[cfg(not(unix))]
-fn set_mode(_dst: &Path, _manifest: &Manifest) -> Result<(), String> {
+pub fn set_mode(_dst: &Path, _manifest: &Manifest) -> Result<(), String> {
     Ok(())
 }
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,0 +1,55 @@
+//! `dotfiles apply` の copy 層: ディレクトリ単位で実体をそのまま書き出す。
+//!
+//! 設計書 §5 の3層のうち大多数を占める層。`dst`（ディレクトリ）の下へ、単位ディレクトリ
+//! 配下の実ファイルを相対構造を保ったまま copy する。`manifest.toml` 自体と、別 manifest を
+//! 持つサブツリー（委譲先の責務）は除外する。パーミッションは manifest の
+//! `private` / `executable` 属性に従う（§7、適用は [`crate::apply::set_mode`]）。
+
+use crate::apply::{Outcome, set_mode};
+use crate::discover::{self, MANIFEST};
+use crate::manifest::Manifest;
+use std::path::Path;
+
+/// 1 単位（`dir`）を copy で `dst`（ディレクトリ）へ配置する。
+pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<Outcome, String> {
+    copy_tree(dir, dir, dst, manifest)?;
+    Ok(Outcome::Placed)
+}
+
+/// `src_root` 配下の実ファイルを、相対構造を保ったまま `dst_root` へコピーする。
+/// `manifest.toml` 自体と、別 manifest を持つサブツリーは除外する（委譲先の責務）。
+fn copy_tree(
+    current: &Path,
+    src_root: &Path,
+    dst_root: &Path,
+    manifest: &Manifest,
+) -> Result<(), String> {
+    for entry in discover::read_dir(current)? {
+        let path = entry.path();
+        if path.is_dir() {
+            // サブ manifest を持つディレクトリは別単位なので委譲（コピー対象外）。
+            if path.join(MANIFEST).is_file() {
+                continue;
+            }
+            copy_tree(&path, src_root, dst_root, manifest)?;
+        } else if entry.file_name() != MANIFEST {
+            let rel = path
+                .strip_prefix(src_root)
+                .map_err(|e| format!("{}: 相対パス算出失敗: {e}", path.display()))?;
+            copy_file(&path, &dst_root.join(rel), manifest)?;
+        }
+    }
+    Ok(())
+}
+
+/// 親ディレクトリを作りつつ 1 ファイルをコピーし、manifest のパーミッションを与える。
+fn copy_file(src: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
+    }
+    std::fs::copy(src, dst)
+        .map_err(|e| format!("{} → {}: コピー失敗: {e}", src.display(), dst.display()))?;
+    set_mode(dst, manifest)?;
+    Ok(())
+}

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,0 +1,111 @@
+//! `dotfiles apply` の generate 層: コマンドを実行して 1 ファイルを生成・配置する。
+//!
+//! 設計書 §5（generate）/ §7（deps）。補完5本（gh / docker / bat / clip / merge-ready）が
+//! 対象。copy 層（dst=ディレクトリ・実体コピー）と異なり、generate は **dst=ファイル**で、
+//! `cmd` の標準出力をそこへ書き出す。単位ディレクトリに `manifest.toml` 以外のファイルが
+//! あれば、生成物の後ろへ連結する（gh の独自補完ブロックの注入に使う）。
+//! `deps` の依存バイナリが PATH に揃わないときは生成をスキップする（gate）。
+
+use crate::apply::{Outcome, set_mode};
+use crate::discover::{self, MANIFEST};
+use crate::manifest::Manifest;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 1 単位（`dir`）を generate で `dst`（ファイル）へ生成・配置する。
+pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<Outcome, String> {
+    if manifest.cmd.is_empty() {
+        return Err(format!(
+            "{}: generate には cmd が必要です",
+            dir.join(MANIFEST).display()
+        ));
+    }
+    // deps gate（§7）: PATH に無い依存が 1 つでもあれば生成しない。
+    if let Some(missing) = first_missing_dep(&manifest.deps) {
+        return Ok(Outcome::Skipped(format!("依存 `{missing}` が PATH にない")));
+    }
+
+    let mut bytes = run_cmd(&manifest.cmd)?;
+    append_siblings(dir, &mut bytes)?;
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
+    }
+    std::fs::write(dst, &bytes).map_err(|e| format!("{}: 書き込み失敗: {e}", dst.display()))?;
+    set_mode(dst, manifest)?;
+    Ok(Outcome::Placed)
+}
+
+/// `cmd`（argv）を実行し標準出力を返す。非ゼロ終了は stderr 付きでエラーにする。
+fn run_cmd(cmd: &[String]) -> Result<Vec<u8>, String> {
+    let output = Command::new(&cmd[0])
+        .args(&cmd[1..])
+        .output()
+        .map_err(|e| format!("{}: 実行失敗: {e}", cmd[0]))?;
+    if !output.status.success() {
+        return Err(format!(
+            "{cmd:?} が異常終了 ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(output.stdout)
+}
+
+/// 単位ディレクトリ直下の `manifest.toml` 以外のファイルを、名前順に `bytes` へ連結する。
+/// 連結の境目には改行を 1 つ補い、生成物と静的ブロックが行頭で接ぐようにする。
+fn append_siblings(dir: &Path, bytes: &mut Vec<u8>) -> Result<(), String> {
+    let mut files: Vec<PathBuf> = discover::read_dir(dir)?
+        .into_iter()
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.file_name() != Some(OsStr::new(MANIFEST)))
+        .collect();
+    files.sort();
+
+    for f in &files {
+        if bytes.last().is_some_and(|&b| b != b'\n') {
+            bytes.push(b'\n');
+        }
+        let content =
+            std::fs::read(f).map_err(|e| format!("{}: 読み込み失敗: {e}", f.display()))?;
+        bytes.extend_from_slice(&content);
+    }
+    Ok(())
+}
+
+/// `deps` のうち最初に PATH 上で見つからないものを返す（全て揃えば None）。
+fn first_missing_dep(deps: &[String]) -> Option<&str> {
+    deps.iter()
+        .map(String::as_str)
+        .find(|dep| which(dep).is_none())
+}
+
+/// `name` の実行ファイルを `$PATH` から探す（簡易 which）。
+fn which(name: &str) -> Option<PathBuf> {
+    // パス区切りを含む名前は PATH 探索せず、そのまま実行ファイルとして扱う。
+    if name.contains('/') {
+        let p = PathBuf::from(name);
+        return is_executable(&p).then_some(p);
+    }
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|candidate| is_executable(candidate))
+}
+
+/// 実ファイルかつ実行ビットが立っているか（Unix）。
+#[cfg(unix)]
+fn is_executable(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+/// 非 Unix では実ファイルの存在のみで判定する。
+#[cfg(not(unix))]
+fn is_executable(p: &Path) -> bool {
+    p.is_file()
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -38,16 +38,23 @@ pub fn run(source: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// 1 単位の属性ラベル（kind ＋ private / executable）。
+/// 1 単位の属性ラベル（kind ＋ private / executable ＋ deps）。
 fn attrs(manifest: &Manifest) -> String {
-    let mut parts = vec![match manifest.kind {
-        Kind::Copy => "copy",
-    }];
+    let mut parts = vec![
+        match manifest.kind {
+            Kind::Copy => "copy",
+            Kind::Generate => "generate",
+        }
+        .to_string(),
+    ];
     if manifest.private {
-        parts.push("private");
+        parts.push("private".to_string());
     }
     if manifest.executable {
-        parts.push("executable");
+        parts.push("executable".to_string());
+    }
+    if !manifest.deps.is_empty() {
+        parts.push(format!("deps={}", manifest.deps.join("+")));
     }
     parts.join(", ")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,17 @@
 //! `--version` / `--help` はバージョンの source of truth（タグ `v{version}`）を担う。
 //!
 //! `apply` / `list` サブコマンドは dotfiles ネイティブ化（Epic #453）の一部：
-//! 固定ソース `configs/` を走査し、`manifest.toml` に従って copy 層で配置する（S1 / #455）。
-//! `apply` は配置（ディレクトリ単位 copy・再帰・パーミッション）、`list` は分散 manifest を
-//! 集約した配置先一覧を担う。
+//! 固定ソース `configs/` を走査し、`manifest.toml` に従って配置する。copy 層（S1 / #455）に
+//! 加え、generate 層（コマンド実行で補完を生成・配置＋ deps gate。S2 / #456）に対応する。
+//! `apply` は配置、`list` は分散 manifest を集約した配置先一覧を担う。
 
 use clap::{Parser, Subcommand};
 use std::path::Path;
 
 mod apply;
+mod copy;
 mod discover;
+mod generate;
 mod list;
 mod manifest;
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,8 +1,9 @@
 //! `manifest.toml` のスキーマと読み込み。
 //!
-//! 設計書（docs/dotfiles-native-design.md §6.2 / §7）のスキーマのうち、現スライス（S1）
-//! で必要な部分を解釈する: `dst`（必須）/ `kind`（省略時 copy）/ `private` / `executable`。
-//! generate / merge / theme / deps / hooks / os / secrets は後続スライスで追加する。
+//! 設計書（docs/dotfiles-native-design.md §6.2 / §7）のスキーマのうち、現スライスまでで
+//! 必要な部分を解釈する: `dst`（必須）/ `kind`（省略時 copy）/ `private` / `executable`、
+//! および generate 用の `cmd` / `deps`（S2）。merge / theme / hooks / os / secrets は
+//! 後続スライスで追加する。
 
 use serde::Deserialize;
 use std::path::Path;
@@ -11,8 +12,9 @@ use std::path::Path;
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
     /// 配置先（必須）。`~` は HOME に展開する。
+    /// copy は実体を置くディレクトリ、generate は生成物を書き出すファイルパス。
     pub dst: String,
-    /// 配置種別（省略時 = copy）。S1 は copy のみ対応。
+    /// 配置種別（省略時 = copy）。S2 までで copy / generate に対応。
     #[serde(default)]
     pub kind: Kind,
     /// 所有者のみアクセス可（chezmoi `private_` = 0600 相当）。省略時 false。
@@ -21,14 +23,22 @@ pub struct Manifest {
     /// 実行ビットを付与（chezmoi `executable_` 相当。0644→0755 / 0600→0700）。省略時 false。
     #[serde(default)]
     pub executable: bool,
+    /// generate のとき実行するコマンド（argv）。先頭が実行ファイル名、以降が引数。
+    /// 標準出力を `dst` のファイルへ書き出す。copy では未使用。
+    #[serde(default)]
+    pub cmd: Vec<String>,
+    /// 依存バイナリ（gate, §7）。PATH に揃わないものがあれば配置/生成をスキップする。
+    #[serde(default)]
+    pub deps: Vec<String>,
 }
 
-/// 配置種別。S1 では copy のみ。generate / merge は後続スライス（S2 / S3）。
+/// 配置種別。S2 までで copy / generate。merge は後続スライス（S3）。
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Kind {
     #[default]
     Copy,
+    Generate,
 }
 
 impl Manifest {

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -293,3 +293,166 @@ fn list_errors_when_source_missing() {
         .failure()
         .stderr(predicate::str::contains("が見つかりません"));
 }
+
+// --- generate 層（S2 / #456） --------------------------------------------
+//
+// 実バイナリ（gh/bat 等）に依存せず、PATH 先頭に置いたスタブで `cmd` 実行と
+// deps gate を検証する。スタブは sh スクリプトなので unix 限定。
+
+/// PATH に置く実行可能スタブを書き出す（固定テキストを stdout に出す）。
+#[cfg(unix)]
+fn write_stub(dir: &Path, name: &str, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{body}")).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// generate 単位 `configs/foo/completion`（dst=ファイル / cmd=foo / deps=foo）を書き出す。
+#[cfg(unix)]
+fn write_generate_unit(work: &Path) -> std::path::PathBuf {
+    let unit = work.join("configs/foo/completion");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/fish/completions/foo.fish\"\n\
+         kind = \"generate\"\n\
+         cmd = [\"foo\"]\n\
+         deps = [\"foo\"]\n",
+    )
+    .unwrap();
+    unit
+}
+
+/// kind=generate が `cmd` を実行し、その標準出力を dst のファイルへ書き出すことを検証する。
+#[cfg(unix)]
+#[test]
+fn apply_generate_runs_cmd_and_writes_output() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let bin = tempfile::tempdir().unwrap();
+
+    write_stub(bin.path(), "foo", "printf 'complete -c foo -f\\n'\n");
+    write_generate_unit(work.path());
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", bin.path()) // スタブのみ。foo は PATH 上で解決される。
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/fish/completions/foo.fish");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "complete -c foo -f\n",
+        "cmd の stdout がそのまま dst に書かれていない",
+    );
+}
+
+/// deps gate: 依存バイナリが PATH に無ければ生成をスキップし、ファイルを作らない（成功終了）。
+#[cfg(unix)]
+#[test]
+fn apply_generate_gate_skips_when_dep_missing() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let empty_bin = tempfile::tempdir().unwrap(); // foo を置かない＝依存欠落。
+
+    write_generate_unit(work.path());
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", empty_bin.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skip"))
+        .stdout(predicate::str::contains("foo"));
+
+    assert!(
+        !home
+            .path()
+            .join(".config/fish/completions/foo.fish")
+            .exists(),
+        "gate が効かず依存欠落でも生成された",
+    );
+}
+
+/// generate は単位内の `manifest.toml` 以外のファイル（gh の独自補完ブロック相当）を
+/// 生成物の後ろへ連結する。
+#[cfg(unix)]
+#[test]
+fn apply_generate_appends_sibling_files() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let bin = tempfile::tempdir().unwrap();
+
+    write_stub(bin.path(), "foo", "printf 'GENERATED\\n'\n");
+    let unit = write_generate_unit(work.path());
+    fs::write(unit.join("custom.fish"), "# CUSTOM\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", bin.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/fish/completions/foo.fish");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "GENERATED\n# CUSTOM\n",
+        "生成物の後ろへ sibling が連結されていない",
+    );
+}
+
+/// generate で `cmd` が無い manifest はエラー終了する。
+#[test]
+fn apply_generate_without_cmd_errors() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/foo/completion");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/fish/completions/foo.fish\"\nkind = \"generate\"\n",
+    )
+    .unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cmd が必要"));
+}
+
+/// `dotfiles list` が generate 単位を generate ＋ deps 付きで表示することを検証する。
+#[test]
+fn list_shows_generate_kind_with_deps() {
+    let work = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/foo/completion");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/fish/completions/foo.fish\"\n\
+         kind = \"generate\"\n\
+         cmd = [\"foo\"]\n\
+         deps = [\"foo\"]\n",
+    )
+    .unwrap();
+
+    dotfiles()
+        .arg("list")
+        .current_dir(work.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("generate"))
+        .stdout(predicate::str::contains("deps=foo"));
+}


### PR DESCRIPTION
## 概要

Epic #453 の縦スライス **S2（generate＋deps）**。Closes #456。

補完の動的生成を `dotfiles apply` に取り込み、`kind=generate` の manifest から
`cmd` を実行して dst（ファイル）へ書き出す **generate 層** と、依存バイナリが
PATH に無ければスキップする **deps gate** を実装する。補完5本（gh / docker /
bat / clip / merge-ready）を `configs/` へ移行する。

## 受け入れ条件

- [x] kind=generate を解釈し `cmd` を実行して dst に書き出す
- [x] deps gate（依存バイナリが無ければスキップ）
- [x] 補完5本（gh / docker / bat / clip / merge-ready）を生成配置
- [x] E2E: スタブバイナリで生成と gate を検証

## 主な変更

- **`src/generate.rs`（新規）**: `cmd`（argv）を実行し標準出力を dst へ書き出す。
  単位ディレクトリ内の `manifest.toml` 以外のファイルを生成物の後ろへ連結する
  （gh の独自 ID 補完を同梱するため）。deps gate は簡易 `which`（PATH 探索）で
  全 dep の存在を確認し、欠落時は配置せず成功終了。
- **`src/copy.rs`（新規）**: copy 層を `apply.rs` から分離（役割別1ファイル）。
  `apply.rs` は kind で分岐する薄いオーケストレータ＋両層共有の小道具
  （`expand_home` / `set_mode`）に整理。
- **`src/manifest.rs`**: `Kind::Generate` / `cmd` / `deps` を追加。
- **`src/list.rs`**: generate kind と `deps` を属性表示。
- **`configs/<tool>/completion/manifest.toml`**: 補完5本を追加。

## 設計判断

- generate の dst は**ファイル**（copy はディレクトリ）— 設計書 §6.1 の例に準拠。
- fish は補完を `<cmd>.fish` でしか autoload しないため、gh の独自補完は別ファイルに
  できない。generate の「単位内の manifest 以外のファイルを生成物の後ろへ連結する」
  規則で `custom.fish` を同梱する。
- deps は明示宣言（`deps=[cmd[0]]`）。gate は宣言された全 dep が PATH に揃うことを要求。

## 検証

- `cargo test -p dotfiles`: 22 passed（generate の生成 / gate / sibling 連結 /
  cmd 欠落 / list 表示をスタブバイナリで hermetic に検証）
- `cargo fmt --all --check` clean / `cargo clippy` no issues / `mise run check` exit 0
- 実 `configs/` への apply スモーク: 5本すべて生成、`gh.fish` に custom ブロック同梱・
  `fish -n` 構文OK、生成物→custom の境界も元の chezmoi テンプレートと一致

## 移行状況

apply はまだ chezmoi のフックに未接続（`home/` と併存）。本 PR は generate 層の
configs 化のみで、`home/dot_config/fish/completions/*.tmpl` の撤去は移行完了
（S9）で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)