### PR TITLE
refactor(dotfiles): 配置を2軸（生成方式×合成）＋overlay/when へ再構成 [#471]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "predicates",
  "rstest",
  "serde",
+ "serde_json",
  "tempfile",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ repository  = { workspace = true }
 version     = "0.69.4"
 
 [dependencies]
-clap  = { workspace = true }
-serde = { workspace = true }
-toml  = { workspace = true }
+clap       = { workspace = true }
+serde      = { workspace = true }
+serde_json = { workspace = true }
+toml       = { workspace = true }
 
 [lints]
 workspace = true

--- a/docs/dotfiles-native-design.md
+++ b/docs/dotfiles-native-design.md
@@ -172,9 +172,9 @@ configs/
                            #   dst=~/.config/fish/completions/gh.fish, deps=["gh"]
   claude/
     settings/
-      manifest.toml        # kind=merge, dst=~/.claude/settings.json,
-                           #   preserve=["model","effortLevel"]
-      settings.base.json
+      manifest.toml        # strategy=json-shallow, dst=~/.claude/settings.json,
+                           #   overlay=[base, rtk(when.dep), preserve(model/effortLevel)]
+      settings.json
   ghostty/
     manifest.toml          # dst=~/.config/ghostty, theme="source", os="darwin",
                            #   hooks=[macos-symlink]
@@ -189,7 +189,7 @@ configs/
 ### 6.2 manifest.toml スキーマ
 
 ```toml
-# 配置先（必須）。copy/merge は実体の置き先、generate は生成物の置き先。
+# 配置先（必須）。copy は実体（ツリー）の置き先、generate / 合成は生成物（ファイル）の置き先。
 dst = "~/.config/fish/conf.d"
 
 # 生成方式（省略時 = "copy"）。"generate" のときだけ明記（§5.5 の生成軸）。

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,22 +1,16 @@
 //! `dotfiles apply`：固定ソース `configs/` を走査し配置を実行する。
 //!
-//! 走査（manifest 発見・再帰委譲）は [`crate::discover`]、実体配置は kind ごとに
-//! [`crate::copy`]（copy 層）/ [`crate::generate`]（generate 層）へ委譲する。本モジュールは
-//! オーケストレーション（単位ごとに kind で分岐し結果を表示）と、両層が共有する小道具
-//! （dst の `~` 展開・パーミッション適用）だけを持つ。merge / hooks は後続スライス。
+//! 走査（manifest 発見・再帰委譲）は [`crate::discover`]。各単位は §5.5 の評価順に従う:
+//! ①**ユニット gate（`deps` / `os`）を最初に評価し false なら短絡**（[`crate::gate`]、dst を
+//! 一切触らず skip）。生き残った単位は dst 種別で配置経路が分かれる ―
+//! dst=ディレクトリの copy は [`crate::copy`]（ツリー配置）、dst=ファイルの generate /
+//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve 最後の合成）。本モジュールは
+//! オーケストレーションと、両経路が共有する小道具（`~` 展開・パーミッション適用）を持つ。
 
 use crate::discover::{self, MANIFEST, Unit};
-use crate::manifest::{Kind, Manifest};
-use crate::{copy, generate};
+use crate::manifest::{Kind, Manifest, Strategy};
+use crate::{compose, copy, gate};
 use std::path::{Path, PathBuf};
-
-/// 1 単位の配置結果。配置済みと「gate でスキップ」を表示で区別するために返す。
-pub enum Outcome {
-    /// 配置/生成した。
-    Placed,
-    /// 条件（deps gate / os 等）を満たさず配置しなかった。理由を持つ。
-    Skipped(String),
-}
 
 /// `source`（= `configs/`）配下を走査し、各 manifest の配置を実行する。
 /// `home` は dst の `~` 展開先。
@@ -36,25 +30,51 @@ pub fn run(source: &Path, home: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// 1 単位を kind で分岐して配置し、結果を 1 行で表示する。
+/// 1 単位を評価順（§5.5）に従って配置し、結果を 1 行で表示する。
 fn apply_unit(unit: &Unit, home: &Path) -> Result<(), String> {
     let manifest = Manifest::load(&unit.dir.join(MANIFEST))?;
     let dst = expand_home(&manifest.dst, home);
-    let (kind, outcome) = match manifest.kind {
-        Kind::Copy => ("copy", copy::place(&unit.dir, &dst, &manifest)?),
-        Kind::Generate => ("generate", generate::place(&unit.dir, &dst, &manifest)?),
-    };
-
     let name = unit.rel.to_string_lossy();
-    match outcome {
-        Outcome::Placed => println!("apply: {name} → {} ({kind})", manifest.dst),
-        Outcome::Skipped(why) => println!("apply: {name} → skip ({kind}: {why})"),
+
+    // ①ユニット gate を最初に評価し、満たさなければユニット全体を skip（dst は触らない）。
+    if let Some(reason) = gate::unit_skip_reason(&manifest) {
+        println!("apply: {name} → skip ({reason})");
+        return Ok(());
     }
+
+    let label = placement_label(&manifest);
+    if uses_compose(&manifest) {
+        compose::place(&unit.dir, &dst, &manifest)?;
+    } else {
+        copy::place(&unit.dir, &dst, &manifest)?;
+    }
+    println!("apply: {name} → {} ({label})", manifest.dst);
     Ok(())
 }
 
+/// ファイル合成経路（[`crate::compose`]）を通すか。overlay 明示、または dst=ファイルの
+/// generate はファイル合成。それ以外（overlay 無しの copy）は copy ツリー配置。
+fn uses_compose(manifest: &Manifest) -> bool {
+    !manifest.overlay.is_empty() || manifest.kind == Kind::Generate
+}
+
+/// 表示用の配置ラベル（apply の 1 行出力）。overlay 明示は strategy を併記する。
+fn placement_label(manifest: &Manifest) -> &'static str {
+    if !manifest.overlay.is_empty() {
+        return match manifest.strategy {
+            Some(Strategy::JsonShallow) => "overlay/json-shallow",
+            Some(Strategy::Concat) => "overlay/concat",
+            None => "overlay",
+        };
+    }
+    match manifest.kind {
+        Kind::Copy => "copy",
+        Kind::Generate => "generate",
+    }
+}
+
 /// 配置済みファイルへ manifest のパーミッションを適用する（Unix のみ）。
-/// copy / generate 両層が共有する。
+/// copy / compose 両経路が共有する。
 #[cfg(unix)]
 pub fn set_mode(dst: &Path, manifest: &Manifest) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,0 +1,89 @@
+//! ファイル合成経路（§5.5）: dst=ファイルへ条件付き断片を `strategy` で重ねて書き出す。
+//!
+//! copy のツリー配置（dst=ディレクトリ）と異なり、generate と overlay 明示はここを通る。
+//! 評価順の不変条件（§5.5）を実装する: ②overlay は宣言順に `when` 評価し満たす断片だけ採用、
+//! ③`preserve`（既存 dst を読む built-in overlay）は宣言位置に関わらず最後に重ねる。
+//! 不変条件①（ユニット gate 先・false で短絡）は [`crate::apply`] が前段で担う。
+
+use crate::apply::set_mode;
+use crate::manifest::{Manifest, Overlay, Strategy};
+use crate::{gate, generate, strategy};
+use std::path::Path;
+
+/// 1 単位（`dir`）を overlay 合成で `dst`（ファイル）へ生成・配置する。
+pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
+    let (frags, preserve_keys) = resolve_fragments(dir, manifest)?;
+    let bytes = combine(manifest, dst, &frags, &preserve_keys)?;
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
+    }
+    std::fs::write(dst, &bytes).map_err(|e| format!("{}: 書き込み失敗: {e}", dst.display()))?;
+    set_mode(dst, manifest)?;
+    Ok(())
+}
+
+/// 採用する断片列と preserve キーを解決する（不変条件②③）。
+///
+/// overlay 未記述時は生成方式の既定挙動（compose に来るのは generate のみ ＝ cmd 出力＋sibling）。
+/// overlay 明示時は preserve 以外を宣言順に `when` 評価し、preserve overlay は最後へ畳む。
+fn resolve_fragments(
+    dir: &Path,
+    manifest: &Manifest,
+) -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+    if manifest.overlay.is_empty() {
+        return Ok((generate::default_fragments(dir, manifest)?, Vec::new()));
+    }
+
+    // ②宣言順に when を評価し、満たす断片だけ採用（preserve 以外）。
+    let mut frags = Vec::new();
+    for ov in manifest.overlay.iter().filter(|o| !o.is_preserve()) {
+        if gate::when_satisfied(&ov.when) {
+            frags.push(materialize(dir, ov)?);
+        }
+    }
+    // ③preserve（既存 dst を読む built-in overlay）は宣言位置に関わらず最後に重ねる。
+    let mut preserve_keys = Vec::new();
+    for ov in manifest.overlay.iter().filter(|o| o.is_preserve()) {
+        if gate::when_satisfied(&ov.when) {
+            preserve_keys.extend(ov.preserve.iter().cloned());
+        }
+    }
+    Ok((frags, preserve_keys))
+}
+
+/// overlay 断片を実体化する（生成方式）: `src`（copy）/ `cmd`（generate）の択一。
+fn materialize(dir: &Path, ov: &Overlay) -> Result<Vec<u8>, String> {
+    if let Some(src) = &ov.src {
+        let path = dir.join(src);
+        std::fs::read(&path).map_err(|e| format!("{}: 読み込み失敗: {e}", path.display()))
+    } else if !ov.cmd.is_empty() {
+        generate::run_cmd(&ov.cmd)
+    } else {
+        Err("overlay は src / cmd / preserve のいずれかが必要です".to_string())
+    }
+}
+
+/// `strategy` で断片を 1 ファイル分のバイト列へ合成する。
+///
+/// generate 既定（`strategy` 省略）は `concat`。`json-shallow` のときだけ、preserve があれば
+/// 既存 dst を読み最後に重ねる（既存が無ければ温存なし）。
+fn combine(
+    manifest: &Manifest,
+    dst: &Path,
+    frags: &[Vec<u8>],
+    preserve_keys: &[String],
+) -> Result<Vec<u8>, String> {
+    match manifest.strategy.unwrap_or(Strategy::Concat) {
+        Strategy::Concat => Ok(strategy::concat(frags)),
+        Strategy::JsonShallow => {
+            let existing = if preserve_keys.is_empty() {
+                None
+            } else {
+                std::fs::read(dst).ok()
+            };
+            strategy::json_shallow(frags, preserve_keys, existing.as_deref())
+        }
+    }
+}

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -67,8 +67,9 @@ fn materialize(dir: &Path, ov: &Overlay) -> Result<Vec<u8>, String> {
 
 /// `strategy` で断片を 1 ファイル分のバイト列へ合成する。
 ///
-/// generate 既定（`strategy` 省略）は `concat`。`json-shallow` のときだけ、preserve があれば
-/// 既存 dst を読み最後に重ねる（既存が無ければ温存なし）。
+/// overlay 明示時は `strategy` を load 時に必須化済み（[`Manifest::validate`]）なので、`unwrap_or`
+/// の暗黙 `concat` は overlay 未記述の generate 既定挙動だけに効く。`json-shallow` のときだけ、
+/// preserve があれば既存 dst を読み最後に重ねる（既存が無ければ温存なし）。
 fn combine(
     manifest: &Manifest,
     dst: &Path,

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -5,15 +5,14 @@
 //! 持つサブツリー（委譲先の責務）は除外する。パーミッションは manifest の
 //! `private` / `executable` 属性に従う（§7、適用は [`crate::apply::set_mode`]）。
 
-use crate::apply::{Outcome, set_mode};
+use crate::apply::set_mode;
 use crate::discover::{self, MANIFEST};
 use crate::manifest::Manifest;
 use std::path::Path;
 
 /// 1 単位（`dir`）を copy で `dst`（ディレクトリ）へ配置する。
-pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<Outcome, String> {
-    copy_tree(dir, dir, dst, manifest)?;
-    Ok(Outcome::Placed)
+pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
+    copy_tree(dir, dir, dst, manifest)
 }
 
 /// `src_root` 配下の実ファイルを、相対構造を保ったまま `dst_root` へコピーする。

--- a/src/gate.rs
+++ b/src/gate.rs
@@ -27,10 +27,10 @@ pub fn unit_skip_reason(manifest: &Manifest) -> Option<String> {
     if let Some(missing) = first_missing_dep(&manifest.deps) {
         return Some(format!("依存 `{missing}` が PATH にない"));
     }
-    if let Some(want) = &manifest.os {
-        if want != current_os() {
-            return Some(format!("OS `{want}` 不一致（現在 {}）", current_os()));
-        }
+    if let Some(want) = &manifest.os
+        && want != current_os()
+    {
+        return Some(format!("OS `{want}` 不一致（現在 {}）", current_os()));
     }
     None
 }
@@ -42,15 +42,15 @@ pub fn when_satisfied(when: &Option<When>) -> bool {
     let Some(when) = when else {
         return true;
     };
-    if let Some(dep) = &when.dep {
-        if which(dep).is_none() {
-            return false;
-        }
+    if let Some(dep) = &when.dep
+        && which(dep).is_none()
+    {
+        return false;
     }
-    if let Some(os) = &when.os {
-        if os != current_os() {
-            return false;
-        }
+    if let Some(os) = &when.os
+        && os != current_os()
+    {
+        return false;
     }
     true
 }

--- a/src/gate.rs
+++ b/src/gate.rs
@@ -1,0 +1,155 @@
+//! gate の評価: ユニット単位 gate（`deps` / `os`）と overlay の `when`。
+//!
+//! 設計書 §5.5「評価順と不変条件」の gate 語彙を 1 か所に集約する。`deps` / `os` は
+//! ユニット全体に係る gate（満たさなければユニットごと skip）、overlay の `when`（`dep` /
+//! `os`）はその断片だけの採否で、**同じ評価規則**（PATH 探索・OS 正規化・複数キー AND）を
+//! 共有する。ここはその共有ロジックと、PATH 上の実行ファイル探索（`which`）を持つ。
+
+use crate::manifest::{Manifest, When};
+use std::path::{Path, PathBuf};
+
+/// 現在の OS を chezmoi 互換表記で返す（macOS は `darwin`）。
+///
+/// manifest の `os` / `when.os` は chezmoi の `.chezmoi.os` と同じ表記（`darwin` / `linux`）で
+/// 書くため、Rust の `std::env::consts::OS`（macOS では `macos`）を `darwin` に正規化して比較する。
+pub fn current_os() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "darwin",
+        other => other,
+    }
+}
+
+/// ユニット単位 gate（`deps` / `os`）を評価し、満たさないとき skip 理由を返す（満たせば None）。
+///
+/// 不変条件①（§5.5）の短絡判定に使う。`deps` は 1 つでも PATH に無ければ skip、`os` は
+/// 指定があり現在 OS と一致しなければ skip。複数条件は AND（どれか 1 つでも欠ければ skip）。
+pub fn unit_skip_reason(manifest: &Manifest) -> Option<String> {
+    if let Some(missing) = first_missing_dep(&manifest.deps) {
+        return Some(format!("依存 `{missing}` が PATH にない"));
+    }
+    if let Some(want) = &manifest.os {
+        if want != current_os() {
+            return Some(format!("OS `{want}` 不一致（現在 {}）", current_os()));
+        }
+    }
+    None
+}
+
+/// overlay の `when` を満たすか（省略キーは真、複数キーは AND）。
+///
+/// `dep` は PATH に在れば真、`os` は現在 OS と一致すれば真。`when` 省略（None）は常時採用。
+pub fn when_satisfied(when: &Option<When>) -> bool {
+    let Some(when) = when else {
+        return true;
+    };
+    if let Some(dep) = &when.dep {
+        if which(dep).is_none() {
+            return false;
+        }
+    }
+    if let Some(os) = &when.os {
+        if os != current_os() {
+            return false;
+        }
+    }
+    true
+}
+
+/// `deps` のうち最初に PATH 上で見つからないものを返す（全て揃えば None）。
+fn first_missing_dep(deps: &[String]) -> Option<&str> {
+    deps.iter()
+        .map(String::as_str)
+        .find(|dep| which(dep).is_none())
+}
+
+/// `name` の実行ファイルを `$PATH` から探す（簡易 which）。
+pub fn which(name: &str) -> Option<PathBuf> {
+    // パス区切りを含む名前は PATH 探索せず、そのまま実行ファイルとして扱う。
+    if name.contains('/') {
+        let p = PathBuf::from(name);
+        return is_executable(&p).then_some(p);
+    }
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|candidate| is_executable(candidate))
+}
+
+/// 実ファイルかつ実行ビットが立っているか（Unix）。
+#[cfg(unix)]
+fn is_executable(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+/// 非 Unix では実ファイルの存在のみで判定する。
+#[cfg(not(unix))]
+fn is_executable(p: &Path) -> bool {
+    p.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_os_normalizes_macos_to_darwin() {
+        // ビルドした OS に応じて chezmoi 互換表記を返す。
+        let expected = if cfg!(target_os = "macos") {
+            "darwin"
+        } else {
+            std::env::consts::OS
+        };
+        assert_eq!(current_os(), expected);
+    }
+
+    #[test]
+    fn when_none_is_always_satisfied() {
+        assert!(when_satisfied(&None));
+    }
+
+    #[test]
+    fn when_os_matches_current_only() {
+        let hit = When {
+            dep: None,
+            os: Some(current_os().to_string()),
+        };
+        assert!(when_satisfied(&Some(hit)));
+
+        let miss = When {
+            dep: None,
+            os: Some("nonsuch-os".to_string()),
+        };
+        assert!(!when_satisfied(&Some(miss)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn when_dep_checks_path_via_absolute_executable() {
+        // パス区切りを含む名前は PATH 探索せず直接判定する（/bin/sh は実行可能）。
+        let present = When {
+            dep: Some("/bin/sh".to_string()),
+            os: None,
+        };
+        assert!(when_satisfied(&Some(present)));
+
+        let absent = When {
+            dep: Some("/nonexistent/itic-bin".to_string()),
+            os: None,
+        };
+        assert!(!when_satisfied(&Some(absent)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn when_is_and_of_keys() {
+        // dep は満たすが os が外れる → 全体は false（AND）。
+        let mixed = When {
+            dep: Some("/bin/sh".to_string()),
+            os: Some("nonsuch-os".to_string()),
+        };
+        assert!(!when_satisfied(&Some(mixed)));
+    }
+}

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,45 +1,34 @@
-//! `dotfiles apply` の generate 層: コマンドを実行して 1 ファイルを生成・配置する。
+//! generate 層（§5 generate）: コマンドを実行し、その標準出力を断片にする。
 //!
-//! 設計書 §5（generate）/ §7（deps）。補完5本（gh / docker / bat / clip / merge-ready）が
-//! 対象。copy 層（dst=ディレクトリ・実体コピー）と異なり、generate は **dst=ファイル**で、
-//! `cmd` の標準出力をそこへ書き出す。単位ディレクトリに `manifest.toml` 以外のファイルが
-//! あれば、生成物の後ろへ連結する（gh の独自補完ブロックの注入に使う）。
-//! `deps` の依存バイナリが PATH に揃わないときは生成をスキップする（gate）。
+//! 補完5本（gh / docker / bat / clip / merge-ready）が対象。dst=ファイルで、`cmd` の標準出力に
+//! 同ディレクトリの sibling（`manifest.toml` 以外）を連結する。連結は合成軸の `concat` 戦略へ
+//! 統一した（[`crate::strategy::concat`]、出力は従来と不変）。`deps` gate は apply 前段の
+//! ユニット gate（[`crate::gate`]）へ移し、実体の合成・書き込みは [`crate::compose`] が担う。
+//! 本モジュールはコマンド実行（`run_cmd`）と、既定断片列（cmd 出力＋sibling）の組み立てだけを持つ。
 
-use crate::apply::{Outcome, set_mode};
 use crate::discover::{self, MANIFEST};
 use crate::manifest::Manifest;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// 1 単位（`dir`）を generate で `dst`（ファイル）へ生成・配置する。
-pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<Outcome, String> {
+/// generate（overlay 無し）の既定断片列を作る: `cmd` 出力を先頭に、sibling を名前順で続ける。
+/// `compose` がこれを `concat` 戦略で 1 ファイルへ束ねる。`cmd` 未指定はエラー。
+pub fn default_fragments(dir: &Path, manifest: &Manifest) -> Result<Vec<Vec<u8>>, String> {
     if manifest.cmd.is_empty() {
         return Err(format!(
             "{}: generate には cmd が必要です",
             dir.join(MANIFEST).display()
         ));
     }
-    // deps gate（§7）: PATH に無い依存が 1 つでもあれば生成しない。
-    if let Some(missing) = first_missing_dep(&manifest.deps) {
-        return Ok(Outcome::Skipped(format!("依存 `{missing}` が PATH にない")));
-    }
-
-    let mut bytes = run_cmd(&manifest.cmd)?;
-    append_siblings(dir, &mut bytes)?;
-
-    if let Some(parent) = dst.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
-    }
-    std::fs::write(dst, &bytes).map_err(|e| format!("{}: 書き込み失敗: {e}", dst.display()))?;
-    set_mode(dst, manifest)?;
-    Ok(Outcome::Placed)
+    let mut frags = vec![run_cmd(&manifest.cmd)?];
+    frags.extend(sibling_fragments(dir)?);
+    Ok(frags)
 }
 
 /// `cmd`（argv）を実行し標準出力を返す。非ゼロ終了は stderr 付きでエラーにする。
-fn run_cmd(cmd: &[String]) -> Result<Vec<u8>, String> {
+/// overlay の generate 断片（`cmd`）からも使う。
+pub fn run_cmd(cmd: &[String]) -> Result<Vec<u8>, String> {
     let output = Command::new(&cmd[0])
         .args(&cmd[1..])
         .output()
@@ -54,9 +43,9 @@ fn run_cmd(cmd: &[String]) -> Result<Vec<u8>, String> {
     Ok(output.stdout)
 }
 
-/// 単位ディレクトリ直下の `manifest.toml` 以外のファイルを、名前順に `bytes` へ連結する。
-/// 連結の境目には改行を 1 つ補い、生成物と静的ブロックが行頭で接ぐようにする。
-fn append_siblings(dir: &Path, bytes: &mut Vec<u8>) -> Result<(), String> {
+/// 単位ディレクトリ直下の `manifest.toml` 以外のファイルを名前順に読み、断片列にする。
+/// gh の独自補完ブロック（`custom.fish`）など、生成物の後ろへ接ぐ静的断片に使う。
+fn sibling_fragments(dir: &Path) -> Result<Vec<Vec<u8>>, String> {
     let mut files: Vec<PathBuf> = discover::read_dir(dir)?
         .into_iter()
         .map(|e| e.path())
@@ -64,48 +53,9 @@ fn append_siblings(dir: &Path, bytes: &mut Vec<u8>) -> Result<(), String> {
         .collect();
     files.sort();
 
+    let mut frags = Vec::with_capacity(files.len());
     for f in &files {
-        if bytes.last().is_some_and(|&b| b != b'\n') {
-            bytes.push(b'\n');
-        }
-        let content =
-            std::fs::read(f).map_err(|e| format!("{}: 読み込み失敗: {e}", f.display()))?;
-        bytes.extend_from_slice(&content);
+        frags.push(std::fs::read(f).map_err(|e| format!("{}: 読み込み失敗: {e}", f.display()))?);
     }
-    Ok(())
-}
-
-/// `deps` のうち最初に PATH 上で見つからないものを返す（全て揃えば None）。
-fn first_missing_dep(deps: &[String]) -> Option<&str> {
-    deps.iter()
-        .map(String::as_str)
-        .find(|dep| which(dep).is_none())
-}
-
-/// `name` の実行ファイルを `$PATH` から探す（簡易 which）。
-fn which(name: &str) -> Option<PathBuf> {
-    // パス区切りを含む名前は PATH 探索せず、そのまま実行ファイルとして扱う。
-    if name.contains('/') {
-        let p = PathBuf::from(name);
-        return is_executable(&p).then_some(p);
-    }
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
-        .map(|dir| dir.join(name))
-        .find(|candidate| is_executable(candidate))
-}
-
-/// 実ファイルかつ実行ビットが立っているか（Unix）。
-#[cfg(unix)]
-fn is_executable(p: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(p)
-        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
-}
-
-/// 非 Unix では実ファイルの存在のみで判定する。
-#[cfg(not(unix))]
-fn is_executable(p: &Path) -> bool {
-    p.is_file()
+    Ok(frags)
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -5,7 +5,7 @@
 //! `home` は不要（dst は manifest の生表記 `~/...` をそのまま見せる方が読みやすい）。
 
 use crate::discover::{self, MANIFEST};
-use crate::manifest::{Kind, Manifest};
+use crate::manifest::{Kind, Manifest, Strategy};
 use std::path::Path;
 
 /// `source`（= `configs/`）配下の設定単位を一覧表示する。
@@ -38,7 +38,8 @@ pub fn run(source: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// 1 単位の属性ラベル（kind ＋ private / executable ＋ deps）。
+/// 1 単位の属性ラベル（2軸モデル, §7）。
+/// kind ＋ strategy ＋ overlay 数 ＋ private / executable ＋ deps / os。
 fn attrs(manifest: &Manifest) -> String {
     let mut parts = vec![
         match manifest.kind {
@@ -47,6 +48,18 @@ fn attrs(manifest: &Manifest) -> String {
         }
         .to_string(),
     ];
+    if let Some(strategy) = manifest.strategy {
+        parts.push(
+            match strategy {
+                Strategy::Concat => "concat",
+                Strategy::JsonShallow => "json-shallow",
+            }
+            .to_string(),
+        );
+    }
+    if !manifest.overlay.is_empty() {
+        parts.push(format!("overlay={}", manifest.overlay.len()));
+    }
     if manifest.private {
         parts.push("private".to_string());
     }
@@ -55,6 +68,9 @@ fn attrs(manifest: &Manifest) -> String {
     }
     if !manifest.deps.is_empty() {
         parts.push(format!("deps={}", manifest.deps.join("+")));
+    }
+    if let Some(os) = &manifest.os {
+        parts.push(format!("os={os}"));
     }
     parts.join(", ")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,19 +4,24 @@
 //! `--version` / `--help` はバージョンの source of truth（タグ `v{version}`）を担う。
 //!
 //! `apply` / `list` サブコマンドは dotfiles ネイティブ化（Epic #453）の一部：
-//! 固定ソース `configs/` を走査し、`manifest.toml` に従って配置する。copy 層（S1 / #455）に
-//! 加え、generate 層（コマンド実行で補完を生成・配置＋ deps gate。S2 / #456）に対応する。
+//! 固定ソース `configs/` を走査し、`manifest.toml` に従って配置する。配置は **2軸**
+//! （生成方式 `kind`=copy/generate × 合成 `strategy`=concat/json-shallow）＋条件付き overlay
+//! （`when` gate）で捉える（設計書 §5 / §5.5）。copy はツリー配置、generate / overlay 明示は
+//! ファイル合成（[`compose`]）を通り、`deps` / `os` はユニット単位 gate（[`gate`]）。
 //! `apply` は配置、`list` は分散 manifest を集約した配置先一覧を担う。
 
 use clap::{Parser, Subcommand};
 use std::path::Path;
 
 mod apply;
+mod compose;
 mod copy;
 mod discover;
+mod gate;
 mod generate;
 mod list;
 mod manifest;
+mod strategy;
 
 /// toshiki670/dotfiles 本体（core）。
 #[derive(Parser)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,9 +1,15 @@
 //! `manifest.toml` のスキーマと読み込み。
 //!
-//! 設計書（docs/dotfiles-native-design.md §6.2 / §7）のスキーマのうち、現スライスまでで
-//! 必要な部分を解釈する: `dst`（必須）/ `kind`（省略時 copy）/ `private` / `executable`、
-//! および generate 用の `cmd` / `deps`（S2）。merge / theme / hooks / os / secrets は
-//! 後続スライスで追加する。
+//! 設計書（docs/dotfiles-native-design.md §5 / §5.5 / §6.2 / §7）の **2軸モデル**を解釈する:
+//! - **生成方式 `kind`**（断片をどう実体化するか）= `copy` / `generate`（省略時 copy）。
+//! - **合成 `strategy`**（複数の条件付き断片を1 dst=ファイルへどう重ねるか）= `concat` /
+//!   `json-shallow`。`merge` は独立 kind ではなく合成軸の JSON 戦略（§5.5）。
+//! - **条件付き overlay**（`[[overlay]]` ＋ `when`）= dst を「base ＋ gate された断片」の合成
+//!   として組む。各 overlay は `src`（copy 断片）/ `cmd`（generate 断片）/ `preserve`（既存 dst
+//!   を読む built-in overlay）のいずれか ＋ `when`（`dep` / `os`）。
+//!
+//! `deps` / `os` はユニット単位 gate（＝ ユニット全体に係る `when` の退化形, §5.5）。
+//! theme / hooks / secrets は後続スライスで追加する。
 
 use serde::Deserialize;
 use std::path::Path;
@@ -12,11 +18,15 @@ use std::path::Path;
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
     /// 配置先（必須）。`~` は HOME に展開する。
-    /// copy は実体を置くディレクトリ、generate は生成物を書き出すファイルパス。
+    /// copy は実体を置くディレクトリ、generate / 合成は生成物を書き出すファイルパス。
     pub dst: String,
-    /// 配置種別（省略時 = copy）。S2 までで copy / generate に対応。
+    /// 生成方式（省略時 = copy）。断片をどう実体化するか（copy / generate）。
     #[serde(default)]
     pub kind: Kind,
+    /// 合成戦略（複数 overlay を1 dst=ファイルへ重ねるとき）。単一 overlay なら省略。
+    /// generate の既定挙動（cmd 出力＋sibling 連結）は暗黙 `concat`。
+    #[serde(default)]
+    pub strategy: Option<Strategy>,
     /// 所有者のみアクセス可（chezmoi `private_` = 0600 相当）。省略時 false。
     #[serde(default)]
     pub private: bool,
@@ -24,21 +34,77 @@ pub struct Manifest {
     #[serde(default)]
     pub executable: bool,
     /// generate のとき実行するコマンド（argv）。先頭が実行ファイル名、以降が引数。
-    /// 標準出力を `dst` のファイルへ書き出す。copy では未使用。
+    /// 標準出力を断片とする。copy では未使用。
     #[serde(default)]
     pub cmd: Vec<String>,
-    /// 依存バイナリ（gate, §7）。PATH に揃わないものがあれば配置/生成をスキップする。
+    /// 依存バイナリ（ユニット単位 gate, §7）。PATH に揃わないものがあればユニット全体を
+    /// スキップする（＝ ユニット全体に係る `when.dep` の退化形）。
     #[serde(default)]
     pub deps: Vec<String>,
+    /// OS 条件（ユニット単位 gate, §7）。chezmoi 互換表記（例 `darwin` / `linux`）。
+    /// 不一致ならユニット全体をスキップする（＝ ユニット全体に係る `when.os` の退化形）。
+    #[serde(default)]
+    pub os: Option<String>,
+    /// 合成 overlay（条件付き断片の配列, §5.5）。空 = 生成方式の既定挙動。
+    /// 各 overlay は `src` / `cmd` / `preserve` のいずれか ＋ `when?` を持つ。
+    #[serde(default)]
+    pub overlay: Vec<Overlay>,
 }
 
-/// 配置種別。S2 までで copy / generate。merge は後続スライス（S3）。
+/// 生成方式（断片の実体化方法）。copy / generate。`merge` は kind ではなく `strategy`（§5.5）。
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Kind {
     #[default]
     Copy,
     Generate,
+}
+
+/// 合成戦略（複数断片を1 dst=ファイルへ重ねる方法, §5.5）。
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Strategy {
+    /// テキスト連結（後ろへ連結）。境目に改行を 1 つ補う。
+    Concat,
+    /// JSON のトップレベル shallow merge（後勝ち）。deep merge はしない。
+    JsonShallow,
+}
+
+/// 1 つの overlay（条件付き断片, §5.5）。`when` を満たす時だけ合成に参加する。
+/// 断片の実体化方法は `src`（copy）/ `cmd`（generate）/ `preserve`（既存 dst 読み）の択一。
+#[derive(Debug, Deserialize)]
+pub struct Overlay {
+    /// copy 断片: 単位ディレクトリからの相対ファイル。内容をそのまま断片にする。
+    #[serde(default)]
+    pub src: Option<String>,
+    /// generate 断片: 実行する argv。標準出力を断片にする。
+    #[serde(default)]
+    pub cmd: Vec<String>,
+    /// 既存 dst から温存するトップレベルキー（built-in overlay の糖衣, §5.5）。
+    /// `json-shallow` で常に最後に重なり、ローカル値を勝たせる。
+    #[serde(default)]
+    pub preserve: Vec<String>,
+    /// 採用条件（省略 = 常時採用）。`dep` / `os` を AND で評価する。
+    #[serde(default)]
+    pub when: Option<When>,
+}
+
+/// overlay の採用条件（§5.5）。複数キーは AND（全て満たす時だけ採用）。
+#[derive(Debug, Deserialize, Default)]
+pub struct When {
+    /// 依存バイナリが PATH にある時だけ採用（旧 `{{ if lookPath … }}`）。
+    #[serde(default)]
+    pub dep: Option<String>,
+    /// OS 一致時だけ採用（旧 `{{ if eq .chezmoi.os … }}`）。chezmoi 互換表記。
+    #[serde(default)]
+    pub os: Option<String>,
+}
+
+impl Overlay {
+    /// 既存 dst を読む built-in overlay（`preserve` だけを持つ）か。
+    pub fn is_preserve(&self) -> bool {
+        !self.preserve.is_empty()
+    }
 }
 
 impl Manifest {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -108,11 +108,47 @@ impl Overlay {
 }
 
 impl Manifest {
-    /// `manifest.toml` を読み込んでパースする。
+    /// `manifest.toml` を読み込み、パース後にセマンティックバリデーション（§5.5）を行う。
     pub fn load(path: &Path) -> Result<Self, String> {
         let text = std::fs::read_to_string(path)
             .map_err(|e| format!("{}: 読み込み失敗: {e}", path.display()))?;
-        toml::from_str(&text).map_err(|e| format!("{}: パース失敗: {e}", path.display()))
+        let manifest: Self =
+            toml::from_str(&text).map_err(|e| format!("{}: パース失敗: {e}", path.display()))?;
+        manifest
+            .validate()
+            .map_err(|e| format!("{}: {e}", path.display()))?;
+        Ok(manifest)
+    }
+
+    /// パース後のセマンティック検証（§5.5）。manifest の typo を配置前に弾く。
+    ///
+    /// - **overlay 明示時は `strategy` 必須**。合成戦略を一意に決めるため、暗黙の `concat` は
+    ///   overlay 未記述の generate 既定挙動だけに限る（overlay を書いて戦略を省くと、意図しない
+    ///   text concat になりうるのを防ぐ）。
+    /// - **各 overlay は `src` / `cmd` / `preserve` のうちちょうど 1 つ**（生成方式は択一）。
+    ///   2 つ以上は一方が黙って無視される typo、0 個は断片を実体化できない。
+    fn validate(&self) -> Result<(), String> {
+        if !self.overlay.is_empty() && self.strategy.is_none() {
+            return Err(
+                "overlay を明示する場合は strategy（concat / json-shallow）が必要です".to_string(),
+            );
+        }
+        for (i, ov) in self.overlay.iter().enumerate() {
+            let kinds = [
+                ov.src.is_some(),
+                !ov.cmd.is_empty(),
+                !ov.preserve.is_empty(),
+            ]
+            .into_iter()
+            .filter(|&set| set)
+            .count();
+            if kinds != 1 {
+                return Err(format!(
+                    "overlay[{i}] は src / cmd / preserve のうちちょうど 1 つを持つ必要があります（現在 {kinds} 個）"
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// この単位の配置ファイルへ与える Unix パーミッション（8 進）。
@@ -128,5 +164,71 @@ impl Manifest {
         } else {
             base
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// パース → validate を一括で通す（load のファイル I/O を介さずに検証）。
+    fn parse(toml_src: &str) -> Result<Manifest, String> {
+        let manifest: Manifest = toml::from_str(toml_src).map_err(|e| e.to_string())?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    #[test]
+    fn validate_accepts_generate_default_without_strategy() {
+        // overlay 未記述の generate は strategy 省略可（暗黙 concat）。
+        assert!(parse("dst = \"~/x\"\nkind = \"generate\"\ncmd = [\"foo\"]\n").is_ok());
+    }
+
+    #[test]
+    fn validate_requires_strategy_when_overlay_present() {
+        let err = parse("dst = \"~/x\"\n[[overlay]]\nsrc = \"a\"\n").unwrap_err();
+        assert!(
+            err.contains("strategy"),
+            "strategy 必須のエラーが出ていない: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_overlay_with_multiple_kinds() {
+        // preserve と src を併記 → 一方が黙って無視される typo。
+        let err = parse(
+            "dst = \"~/x\"\nstrategy = \"json-shallow\"\n[[overlay]]\nsrc = \"a\"\npreserve = [\"k\"]\n",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("ちょうど 1 つ"),
+            "排他違反が検知されていない: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_overlay_with_no_kind() {
+        // when だけで src/cmd/preserve が無い → 断片を実体化できない。
+        let err =
+            parse("dst = \"~/x\"\nstrategy = \"concat\"\n[[overlay]]\nwhen = { dep = \"rtk\" }\n")
+                .unwrap_err();
+        assert!(
+            err.contains("ちょうど 1 つ"),
+            "0 個が検知されていない: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_overlays() {
+        // base(src) ＋ rtk(src+when) ＋ preserve の正規形。
+        assert!(
+            parse(
+                "dst = \"~/x\"\nstrategy = \"json-shallow\"\n\
+                 [[overlay]]\nsrc = \"base.json\"\n\
+                 [[overlay]]\nsrc = \"rtk.json\"\nwhen = { dep = \"rtk\" }\n\
+                 [[overlay]]\npreserve = [\"model\"]\n",
+            )
+            .is_ok()
+        );
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -43,13 +43,13 @@ pub fn json_shallow(
     }
 
     // preserve（既存 dst を読む built-in overlay）は常に最後に重ね、ローカル値を勝たせる。
-    if !preserve_keys.is_empty() {
-        if let Some(existing) = existing {
-            let obj = parse_object(existing).map_err(|e| format!("既存 dst {e}"))?;
-            for key in preserve_keys {
-                if let Some(v) = obj.get(key) {
-                    merged.insert(key.clone(), v.clone());
-                }
+    if !preserve_keys.is_empty()
+        && let Some(existing) = existing
+    {
+        let obj = parse_object(existing).map_err(|e| format!("既存 dst {e}"))?;
+        for key in preserve_keys {
+            if let Some(v) = obj.get(key) {
+                merged.insert(key.clone(), v.clone());
             }
         }
     }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,0 +1,158 @@
+//! 合成戦略（§5.5）: 複数の断片を 1 つの dst=ファイルへ重ねる純ロジック。
+//!
+//! - `concat` … テキスト連結（後ろへ連結。境目に改行を 1 つ補う）。generate の
+//!   「cmd 出力＋sibling 連結」もこの戦略へ統一する（出力は従来と不変）。
+//! - `json_shallow` … JSON のトップレベル shallow merge（後勝ち）。`preserve` キーは
+//!   既存 dst の値で最後に上書きし、ローカル値を勝たせる（旧 `modify_` の `$local + $forced`
+//!   と同じ粒度。deep merge はしない）。
+//!
+//! どちらも副作用のない純関数で、配置（書き込み）は [`crate::compose`] が行う。
+
+use serde_json::{Map, Value};
+
+/// テキスト断片を順に連結する。境目では、直前が改行で終わっていなければ改行を 1 つ補う。
+///
+/// 空入力は空、単一断片はそのまま。generate の旧 `append_siblings`（生成物の後ろへ sibling を
+/// 行頭で接ぐ）と同じ規則で、cmd 出力を先頭断片に置けば従来出力と一致する。
+pub fn concat(frags: &[Vec<u8>]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for frag in frags {
+        if out.last().is_some_and(|&b| b != b'\n') {
+            out.push(b'\n');
+        }
+        out.extend_from_slice(frag);
+    }
+    out
+}
+
+/// JSON 断片をトップレベル shallow merge（宣言順・後勝ち）し、`preserve` キーだけ既存 dst の
+/// 値で最後に上書きする。各断片・既存 dst は JSON オブジェクトであることを要する。
+///
+/// 出力は pretty JSON ＋末尾改行。`existing` が無い／`preserve` キーが既存に無い場合は温存をしない。
+pub fn json_shallow(
+    frags: &[Vec<u8>],
+    preserve_keys: &[String],
+    existing: Option<&[u8]>,
+) -> Result<Vec<u8>, String> {
+    let mut merged = Map::new();
+    for (i, frag) in frags.iter().enumerate() {
+        let obj = parse_object(frag).map_err(|e| format!("overlay {} {e}", i + 1))?;
+        for (k, v) in obj {
+            merged.insert(k, v); // 後勝ち（BTreeMap.insert が既存キーを置換）。
+        }
+    }
+
+    // preserve（既存 dst を読む built-in overlay）は常に最後に重ね、ローカル値を勝たせる。
+    if !preserve_keys.is_empty() {
+        if let Some(existing) = existing {
+            let obj = parse_object(existing).map_err(|e| format!("既存 dst {e}"))?;
+            for key in preserve_keys {
+                if let Some(v) = obj.get(key) {
+                    merged.insert(key.clone(), v.clone());
+                }
+            }
+        }
+    }
+
+    let mut out = serde_json::to_vec_pretty(&Value::Object(merged))
+        .map_err(|e| format!("JSON 直列化失敗: {e}"))?;
+    out.push(b'\n');
+    Ok(out)
+}
+
+/// バイト列を JSON オブジェクトとしてパースする（オブジェクト以外はエラー）。
+fn parse_object(bytes: &[u8]) -> Result<Map<String, Value>, String> {
+    let value: Value =
+        serde_json::from_slice(bytes).map_err(|e| format!("の JSON パース失敗: {e}"))?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Err("が JSON オブジェクトでない".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b(s: &str) -> Vec<u8> {
+        s.as_bytes().to_vec()
+    }
+
+    #[test]
+    fn concat_empty_is_empty() {
+        assert!(concat(&[]).is_empty());
+    }
+
+    #[test]
+    fn concat_single_is_verbatim() {
+        assert_eq!(
+            concat(&[b("complete -c foo -f\n")]),
+            b("complete -c foo -f\n")
+        );
+    }
+
+    #[test]
+    fn concat_joins_with_newline_when_missing() {
+        // 先頭断片が改行で終わらない → 境目に改行を 1 つ補う。
+        assert_eq!(concat(&[b("a"), b("b")]), b("a\nb"));
+        // 既に改行で終わる → 二重改行にしない。
+        assert_eq!(concat(&[b("a\n"), b("b")]), b("a\nb"));
+    }
+
+    #[test]
+    fn concat_preserves_generate_output() {
+        // 既存 E2E（generate 出力不変）と同じ: 生成物＋sibling。
+        assert_eq!(
+            concat(&[b("GENERATED\n"), b("# CUSTOM\n")]),
+            b("GENERATED\n# CUSTOM\n")
+        );
+    }
+
+    #[test]
+    fn json_shallow_later_frag_wins() {
+        let out = json_shallow(&[b(r#"{"a":1,"b":2}"#), b(r#"{"b":3,"c":4}"#)], &[], None).unwrap();
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["a"], 1);
+        assert_eq!(v["b"], 3); // 後勝ち。
+        assert_eq!(v["c"], 4);
+    }
+
+    #[test]
+    fn json_shallow_preserve_keeps_existing_value() {
+        let base = b(r#"{"model":"shared","hook":"x"}"#);
+        let existing = b(r#"{"model":"local","other":"y"}"#);
+        let out = json_shallow(&[base], &["model".to_string()], Some(&existing)).unwrap();
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["model"], "local"); // 既存（ローカル）値が勝つ。
+        assert_eq!(v["hook"], "x"); // base のキーは残る。
+        assert!(
+            v.get("other").is_none(),
+            "preserve 外の既存キーは持ち込まない"
+        );
+    }
+
+    #[test]
+    fn json_shallow_preserve_noop_when_key_absent_or_no_existing() {
+        // 既存に preserve キーが無い → 温存しない（base 値のまま）。
+        let empty = b(r#"{}"#);
+        let out = json_shallow(
+            &[b(r#"{"model":"shared"}"#)],
+            &["model".to_string()],
+            Some(&empty),
+        )
+        .unwrap();
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["model"], "shared");
+        // 既存ファイルが無い → エラーにせず base のまま。
+        let out2 =
+            json_shallow(&[b(r#"{"model":"shared"}"#)], &["model".to_string()], None).unwrap();
+        let v2: Value = serde_json::from_slice(&out2).unwrap();
+        assert_eq!(v2["model"], "shared");
+    }
+
+    #[test]
+    fn json_shallow_rejects_non_object_fragment() {
+        assert!(json_shallow(&[b("[1,2,3]")], &[], None).is_err());
+        assert!(json_shallow(&[b("\"scalar\"")], &[], None).is_err());
+    }
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -456,3 +456,335 @@ fn list_shows_generate_kind_with_deps() {
         .stdout(predicate::str::contains("generate"))
         .stdout(predicate::str::contains("deps=foo"));
 }
+
+// --- 合成軸: overlay / strategy / when（S3 enabler / #471） -----------------
+//
+// dst=ファイルへ条件付き断片（overlay）を strategy で重ねる挙動と、§5.5 の評価順
+// 不変条件（①ユニット gate 短絡 / ②宣言順 / ③preserve 最後）を hermetic fixture で検証する。
+// when.dep は PATH 先頭スタブの有無で、when.os は現在 OS（chezmoi 互換表記）で gate する。
+
+/// 現在の OS を chezmoi 互換表記（macOS=darwin）で返す。`when.os` fixture に埋める。
+fn current_os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "darwin"
+    } else {
+        std::env::consts::OS
+    }
+}
+
+/// concat overlay（base 常時 ＋ rtk 断片 when.dep=rtk）の単位を書き出す。
+fn write_concat_overlay_unit(work: &Path) {
+    let unit = work.join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo/out.txt\"\n\
+         strategy = \"concat\"\n\
+         [[overlay]]\n\
+         src = \"base.txt\"\n\
+         [[overlay]]\n\
+         src = \"rtk.txt\"\n\
+         when = { dep = \"rtk\" }\n",
+    )
+    .unwrap();
+    fs::write(unit.join("base.txt"), "BASE\n").unwrap();
+    fs::write(unit.join("rtk.txt"), "RTK\n").unwrap();
+}
+
+/// when.dep を満たす（rtk が PATH にある）と rtk 断片が宣言順で連結される。
+#[cfg(unix)]
+#[test]
+fn apply_overlay_concat_includes_fragment_when_dep_present() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let bin = tempfile::tempdir().unwrap();
+
+    write_stub(bin.path(), "rtk", "exit 0\n"); // 存在＋実行ビットだけで十分（実行はされない）。
+    write_concat_overlay_unit(work.path());
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", bin.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/demo/out.txt");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "BASE\nRTK\n",
+        "when.dep を満たす rtk 断片が宣言順で連結されていない",
+    );
+}
+
+/// when.dep を満たさない（rtk 不在）と rtk 断片だけ脱落し、base は残る（dst は生成される）。
+#[cfg(unix)]
+#[test]
+fn apply_overlay_concat_drops_fragment_when_dep_absent() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let empty_bin = tempfile::tempdir().unwrap(); // rtk を置かない。
+
+    write_concat_overlay_unit(work.path());
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", empty_bin.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/demo/out.txt");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "BASE\n",
+        "rtk 不在でも base だけで dst が生成されるべき（overlay when=false は断片だけ脱落）",
+    );
+}
+
+/// when.os は現在 OS 一致の断片だけ採用し、不一致の断片は脱落する。
+#[test]
+fn apply_overlay_when_os_gates_by_current_os() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        format!(
+            "dst = \"~/.config/demo/out.txt\"\n\
+             strategy = \"concat\"\n\
+             [[overlay]]\n\
+             src = \"base.txt\"\n\
+             [[overlay]]\n\
+             src = \"here.txt\"\n\
+             when = {{ os = \"{os}\" }}\n\
+             [[overlay]]\n\
+             src = \"elsewhere.txt\"\n\
+             when = {{ os = \"nonsuch-os\" }}\n",
+            os = current_os(),
+        ),
+    )
+    .unwrap();
+    fs::write(unit.join("base.txt"), "BASE\n").unwrap();
+    fs::write(unit.join("here.txt"), "HERE\n").unwrap();
+    fs::write(unit.join("elsewhere.txt"), "ELSEWHERE\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/demo/out.txt");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "BASE\nHERE\n",
+        "現在 OS の断片だけ採用され、不一致 OS の断片は脱落するべき",
+    );
+}
+
+/// 不変条件①: ユニット os gate を満たさない単位は丸ごと skip し、dst を一切作らない。
+/// gate がユニット共通（copy にも効く）ことも兼ねて確認する。
+#[test]
+fn apply_unit_os_gate_short_circuits_without_touching_dst() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/maconly");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/maconly\"\nos = \"nonsuch-os\"\n",
+    )
+    .unwrap();
+    fs::write(unit.join("f.txt"), "x\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skip"))
+        .stdout(predicate::str::contains("maconly"));
+
+    assert!(
+        !home.path().join(".config/maconly").exists(),
+        "os gate=false でユニット全体が skip されず dst が作られた",
+    );
+}
+
+/// claude/settings.json 相当（json-shallow）の合成単位を書き出す。
+/// overlay 宣言順: preserve（先頭）→ base → rtk（when.dep）。不変条件③で preserve は最後に効く。
+fn write_json_shallow_unit(work: &Path) {
+    let unit = work.join("configs/claude/settings");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.claude/settings.json\"\n\
+         strategy = \"json-shallow\"\n\
+         [[overlay]]\n\
+         preserve = [\"model\"]\n\
+         [[overlay]]\n\
+         src = \"settings.json\"\n\
+         [[overlay]]\n\
+         src = \"rtk.json\"\n\
+         when = { dep = \"rtk\" }\n",
+    )
+    .unwrap();
+    // base は model を共有値で持つ（preserve でローカル値に上書きされる対象）。
+    fs::write(
+        unit.join("settings.json"),
+        "{\"model\":\"shared\",\"hook\":\"base\"}\n",
+    )
+    .unwrap();
+    fs::write(unit.join("rtk.json"), "{\"rtkHook\":\"on\"}\n").unwrap();
+}
+
+/// json-shallow: rtk present＋既存ローカル値あり。後勝ち合成＋ preserve は宣言位置に関わらず最後。
+#[cfg(unix)]
+#[test]
+fn apply_json_shallow_merges_and_preserve_wins_last() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let bin = tempfile::tempdir().unwrap();
+
+    write_stub(bin.path(), "rtk", "exit 0\n");
+    write_json_shallow_unit(work.path());
+
+    // 既存 dst にローカル値（model）と preserve 外のキー（extra）を置く。
+    let dst = home.path().join(".claude/settings.json");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::write(&dst, "{\"model\":\"local\",\"extra\":\"drop\"}\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", bin.path())
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(&dst).unwrap();
+    assert!(
+        out.contains("\"model\": \"local\""),
+        "preserve=model が宣言先頭でもローカル値で最後に勝つべき:\n{out}",
+    );
+    assert!(
+        out.contains("\"hook\": \"base\""),
+        "base のキーが残るべき:\n{out}"
+    );
+    assert!(
+        out.contains("\"rtkHook\": \"on\""),
+        "when.dep=rtk を満たす断片が重なるべき:\n{out}",
+    );
+    assert!(
+        !out.contains("extra"),
+        "preserve 外の既存キーは持ち込まれないべき:\n{out}",
+    );
+}
+
+/// json-shallow: rtk 不在でも base＋preserve で settings.json は書かれる（回帰解消の核）。
+#[cfg(unix)]
+#[test]
+fn apply_json_shallow_writes_base_without_gated_overlay() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let empty_bin = tempfile::tempdir().unwrap(); // rtk 不在。
+
+    write_json_shallow_unit(work.path());
+
+    let dst = home.path().join(".claude/settings.json");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::write(&dst, "{\"model\":\"local\"}\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .env("PATH", empty_bin.path())
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(&dst).unwrap();
+    assert!(
+        out.contains("\"hook\": \"base\""),
+        "base が書かれるべき:\n{out}"
+    );
+    assert!(
+        out.contains("\"model\": \"local\""),
+        "preserve が効くべき:\n{out}"
+    );
+    assert!(
+        !out.contains("rtkHook"),
+        "rtk 不在なら when.dep 断片は脱落するべき:\n{out}",
+    );
+}
+
+/// 不変条件②（宣言順・後勝ち）: json-shallow で後ろの overlay が同名キーを上書きする。
+#[test]
+fn apply_json_shallow_later_overlay_wins() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo/out.json\"\n\
+         strategy = \"json-shallow\"\n\
+         [[overlay]]\n\
+         src = \"a.json\"\n\
+         [[overlay]]\n\
+         src = \"b.json\"\n",
+    )
+    .unwrap();
+    fs::write(unit.join("a.json"), "{\"k\":\"first\",\"only_a\":1}\n").unwrap();
+    fs::write(unit.join("b.json"), "{\"k\":\"second\"}\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(home.path().join(".config/demo/out.json")).unwrap();
+    assert!(
+        out.contains("\"k\": \"second\""),
+        "宣言順で後ろの overlay が後勝ちすべき:\n{out}",
+    );
+    assert!(
+        out.contains("\"only_a\": 1"),
+        "前の overlay のキーは残るべき:\n{out}"
+    );
+}
+
+/// `dotfiles list` が overlay/strategy/os 属性を表示する。
+#[test]
+fn list_shows_overlay_strategy_and_os_attrs() {
+    let work = tempfile::tempdir().unwrap();
+    write_json_shallow_unit(work.path());
+
+    let os_unit = work.path().join("configs/maconly");
+    fs::create_dir_all(&os_unit).unwrap();
+    fs::write(
+        os_unit.join("manifest.toml"),
+        "dst = \"~/.config/maconly\"\nos = \"darwin\"\n",
+    )
+    .unwrap();
+
+    dotfiles()
+        .arg("list")
+        .current_dir(work.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("json-shallow"))
+        .stdout(predicate::str::contains("overlay=3"))
+        .stdout(predicate::str::contains("os=darwin"));
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -788,3 +788,55 @@ fn list_shows_overlay_strategy_and_os_attrs() {
         .stdout(predicate::str::contains("overlay=3"))
         .stdout(predicate::str::contains("os=darwin"));
 }
+
+/// overlay を明示しながら strategy を省略すると load 時にエラー（暗黙 concat を許さない）。
+#[test]
+fn apply_errors_when_overlay_without_strategy() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo/out.txt\"\n[[overlay]]\nsrc = \"a.txt\"\n",
+    )
+    .unwrap();
+    fs::write(unit.join("a.txt"), "A\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("strategy"));
+}
+
+/// overlay に src/cmd/preserve を 2 つ以上書くと load 時にエラー（黙殺される typo を弾く）。
+#[test]
+fn apply_errors_when_overlay_mixes_kinds() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo/out.json\"\n\
+         strategy = \"json-shallow\"\n\
+         [[overlay]]\n\
+         src = \"a.json\"\n\
+         preserve = [\"k\"]\n",
+    )
+    .unwrap();
+    fs::write(unit.join("a.json"), "{}\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ちょうど 1 つ"));
+}


### PR DESCRIPTION
## 位置づけ（enabler・挙動非変更）

Issue #471 の実装。設計書 PR #470 で確定した配置モデル **2軸（生成方式 `kind` × 合成 `strategy`）＋条件付き overlay（`when` gate）** をコード側へ反映する。**ユーザー向け新機能は無く挙動を変えない**（既存 S0〜S2 E2E は無改変で pass）。狙いは S3（#457）を**回帰なしで rebase できる土台**を先に作ること。

## 実装で固めた判断（設計書 §5.5 留保への回答）

- **strategy は明示宣言**（`strategy = "concat" | "json-shallow"`）。dst 拡張子推測は採らない。generate の既定（overlay 未記述）だけ暗黙 `concat`。
- **`when` 複数キーは AND**（`dep` ＋ `os` 両方充足で採用）。ユニット gate（`deps`/`os`）も同じ AND 規則。
- **`os` は chezmoi 互換表記**（`darwin`/`linux`）。内部で `std::env::consts::OS`（macOS=`macos`）を `darwin` に正規化して比較。
- **配置経路は2つ**: ①copy のツリー配置（dst=ディレクトリ・現状維持）/ ②ファイル合成（dst=ファイル：generate と overlay 明示を overlay 列→strategy へ統合）。

## 変更点

| ファイル | 内容 |
| --- | --- |
| `src/manifest.rs` | `strategy`(Concat/JsonShallow)・`overlay`(src/cmd/preserve+when)・`os` を追加。`merge` は独立 kind ではなく合成軸の戦略として表現 |
| `src/gate.rs`（新規） | `deps`/`os` のユニット gate と overlay の `when` を同一規則で評価（PATH 探索・OS 正規化・複数キー AND）。`which` を generate から移設 |
| `src/strategy.rs`（新規） | `concat`（改行補正）/ `json_shallow`（トップレベル後勝ち＋`preserve`）。純関数＋同居ユニットテスト |
| `src/compose.rs`（新規） | dst=ファイルの合成経路。§5.5 評価順 不変条件（②宣言順 ③preserve 最後）を実装 |
| `src/apply.rs` | ①ユニット gate を最初に評価し false で短絡（dst を触らない）。copy はツリー配置、generate/overlay 明示は compose へ分岐 |
| `src/generate.rs` | `deps` gate を apply 前段へ集約、sibling 連結を `strategy::concat` へ統一（出力不変）。`run_cmd` だけ残し薄く化 |
| `src/list.rs` | 属性表示に `strategy`/`overlay`/`os` を追加 |
| `docs/dotfiles-native-design.md` | §6.1 の旧 `kind=merge` 例を `strategy=json-shallow`＋overlay へ整合 |

## 受け入れ条件

- [x] 既存 E2E（S0–S2: copy tree / generate / deps gate / list）が**無改変で pass**
- [x] `[[overlay]]`＋`when`（dep / os）を解釈し、満たす overlay だけ合成戦略で重ねる
- [x] 評価順の不変条件3つを実装＋テスト（ユニット gate 短絡 / 宣言順 / preserve 最後）
- [x] 合成戦略 `concat` / `json-shallow` を実装（hermetic fixtures でテスト）
- [x] generate の sibling 連結を `concat` 戦略へ統一し、出力不変を E2E で確認
- [x] `merge` 独立 kind を廃し strategy+overlay へ（コード・スキーマ・既存 doc 整合）

## 非スコープ（後続へ）

- `configs/claude/settings` の実配置 ＋ `rtk.json` overlay ＋ 実 config E2E（回帰解消の本体）→ **S3(#457) の rebase 時**
- `when.theme`（S7 / #461）・secrets（#458）・hooks（#459）

## 検証

- `cargo test --workspace` … **177 passed**（既存＋新規。既存 S0〜S2 無改変 pass）
- `cargo fmt --all --check` … clean
- `cargo run -p dotfiles-lint -- check` … EXIT 0（clippy 含む）
- 実 configs での `apply`（一時 HOME）/ `list` … 挙動不変を目視確認

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
