### PR TITLE
refactor(dotfiles): settings 既存温存を $local+$forced 意味論へ（preserve=true・json-shallow 土台化） [#475]

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -4,7 +4,7 @@
 //! ①**ユニット gate（`deps` / `os`）を最初に評価し false なら短絡**（[`crate::gate`]、dst を
 //! 一切触らず skip）。生き残った単位は dst 種別で配置経路が分かれる ―
 //! dst=ディレクトリの copy は [`crate::copy`]（ツリー配置）、dst=ファイルの generate /
-//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve 最後の合成）。本モジュールは
+//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve=既存 dst を土台に敷く合成）。本モジュールは
 //! オーケストレーションと、両経路が共有する小道具（`~` 展開・パーミッション適用）を持つ。
 
 use crate::discover::{self, MANIFEST, Unit};

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -2,7 +2,7 @@
 //!
 //! copy のツリー配置（dst=ディレクトリ）と異なり、generate と overlay 明示はここを通る。
 //! 評価順の不変条件（§5.5）を実装する: ②overlay は宣言順に `when` 評価し満たす断片だけ採用、
-//! ③`preserve`（既存 dst を読む built-in overlay）は宣言位置に関わらず最後に重ねる。
+//! ③`preserve = true` の既存 dst は最下層（土台）として断片の下に敷く。
 //! 不変条件①（ユニット gate 先・false で短絡）は [`crate::apply`] が前段で担う。
 
 use crate::apply::set_mode;
@@ -12,8 +12,8 @@ use std::path::Path;
 
 /// 1 単位（`dir`）を overlay 合成で `dst`（ファイル）へ生成・配置する。
 pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
-    let (frags, preserve_keys) = resolve_fragments(dir, manifest)?;
-    let bytes = combine(manifest, dst, &frags, &preserve_keys)?;
+    let frags = resolve_fragments(dir, manifest)?;
+    let bytes = combine(manifest, dst, &frags)?;
 
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)
@@ -24,33 +24,23 @@ pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> 
     Ok(())
 }
 
-/// 採用する断片列と preserve キーを解決する（不変条件②③）。
+/// 採用する断片列を解決する（不変条件②）。`preserve`（土台＝既存 dst）の配線は [`combine`]。
 ///
 /// overlay 未記述時は生成方式の既定挙動（compose に来るのは generate のみ ＝ cmd 出力＋sibling）。
-/// overlay 明示時は preserve 以外を宣言順に `when` 評価し、preserve overlay は最後へ畳む。
-fn resolve_fragments(
-    dir: &Path,
-    manifest: &Manifest,
-) -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+/// overlay 明示時は宣言順に `when` 評価し、満たす断片だけを採用する。
+fn resolve_fragments(dir: &Path, manifest: &Manifest) -> Result<Vec<Vec<u8>>, String> {
     if manifest.overlay.is_empty() {
-        return Ok((generate::default_fragments(dir, manifest)?, Vec::new()));
+        return generate::default_fragments(dir, manifest);
     }
 
-    // ②宣言順に when を評価し、満たす断片だけ採用（preserve 以外）。
+    // ②宣言順に when を評価し、満たす断片だけ採用。
     let mut frags = Vec::new();
-    for ov in manifest.overlay.iter().filter(|o| !o.is_preserve()) {
+    for ov in &manifest.overlay {
         if gate::when_satisfied(&ov.when) {
             frags.push(materialize(dir, ov)?);
         }
     }
-    // ③preserve（既存 dst を読む built-in overlay）は宣言位置に関わらず最後に重ねる。
-    let mut preserve_keys = Vec::new();
-    for ov in manifest.overlay.iter().filter(|o| o.is_preserve()) {
-        if gate::when_satisfied(&ov.when) {
-            preserve_keys.extend(ov.preserve.iter().cloned());
-        }
-    }
-    Ok((frags, preserve_keys))
+    Ok(frags)
 }
 
 /// overlay 断片を実体化する（生成方式）: `src`（copy）/ `cmd`（generate）の択一。
@@ -61,30 +51,25 @@ fn materialize(dir: &Path, ov: &Overlay) -> Result<Vec<u8>, String> {
     } else if !ov.cmd.is_empty() {
         generate::run_cmd(&ov.cmd)
     } else {
-        Err("overlay は src / cmd / preserve のいずれかが必要です".to_string())
+        Err("overlay は src / cmd のいずれかが必要です".to_string())
     }
 }
 
 /// `strategy` で断片を 1 ファイル分のバイト列へ合成する。
 ///
 /// overlay 明示時は `strategy` を load 時に必須化済み（[`Manifest::validate`]）なので、`unwrap_or`
-/// の暗黙 `concat` は overlay 未記述の generate 既定挙動だけに効く。`json-shallow` のときだけ、
-/// preserve があれば既存 dst を読み最後に重ねる（既存が無ければ温存なし）。
-fn combine(
-    manifest: &Manifest,
-    dst: &Path,
-    frags: &[Vec<u8>],
-    preserve_keys: &[String],
-) -> Result<Vec<u8>, String> {
+/// の暗黙 `concat` は overlay 未記述の generate 既定挙動だけに効く。`json-shallow` ＋ `preserve`
+/// のときだけ既存 dst を読み、最下層の土台として断片の下に敷く（既存が無ければ土台なし）。
+fn combine(manifest: &Manifest, dst: &Path, frags: &[Vec<u8>]) -> Result<Vec<u8>, String> {
     match manifest.strategy.unwrap_or(Strategy::Concat) {
         Strategy::Concat => Ok(strategy::concat(frags)),
         Strategy::JsonShallow => {
-            let existing = if preserve_keys.is_empty() {
-                None
-            } else {
+            let base = if manifest.preserve {
                 std::fs::read(dst).ok()
+            } else {
+                None
             };
-            strategy::json_shallow(frags, preserve_keys, existing.as_deref())
+            strategy::json_shallow(frags, base.as_deref())
         }
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -39,7 +39,7 @@ pub fn run(source: &Path) -> Result<(), String> {
 }
 
 /// 1 単位の属性ラベル（2軸モデル, §7）。
-/// kind ＋ strategy ＋ overlay 数 ＋ private / executable ＋ deps / os。
+/// kind ＋ strategy ＋ overlay 数 ＋ preserve ＋ private / executable ＋ deps / os。
 fn attrs(manifest: &Manifest) -> String {
     let mut parts = vec![
         match manifest.kind {
@@ -59,6 +59,9 @@ fn attrs(manifest: &Manifest) -> String {
     }
     if !manifest.overlay.is_empty() {
         parts.push(format!("overlay={}", manifest.overlay.len()));
+    }
+    if manifest.preserve {
+        parts.push("preserve".to_string());
     }
     if manifest.private {
         parts.push("private".to_string());

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -124,6 +124,10 @@ impl Manifest {
     /// - **`preserve = true` は `strategy = "json-shallow"` 専用**。既存 dst を土台に重ねる
     ///   意味論は JSON shallow merge でしか定義しないため、他 strategy・省略との併記は typo
     ///   として弾く（静かに無視しない）。
+    /// - **`preserve = true` は compose 経路（overlay 明示 か `kind = generate`）を要する**。
+    ///   ファイル合成は [`crate::apply`] の `uses_compose`（overlay 非空 or generate）でだけ
+    ///   起動するため、overlay 無しの copy 直行では preserve が黙って無視される。実行されない
+    ///   構成を load 時に弾く（土台だけ再直列化する退化形に意味は無い）。
     /// - **各 overlay は `src` / `cmd` のうちちょうど 1 つ**（生成方式は択一）。2 つは一方が
     ///   黙って無視される typo、0 個は断片を実体化できない。
     fn validate(&self) -> Result<(), String> {
@@ -134,6 +138,13 @@ impl Manifest {
         }
         if self.preserve && self.strategy != Some(Strategy::JsonShallow) {
             return Err("preserve = true は strategy = \"json-shallow\" 専用です".to_string());
+        }
+        if self.preserve && self.overlay.is_empty() && self.kind != Kind::Generate {
+            return Err(
+                "preserve = true は overlay か kind = generate を要します（overlay 無しの copy は \
+                 compose 経路に入らず preserve が無視されます）"
+                    .to_string(),
+            );
         }
         for (i, ov) in self.overlay.iter().enumerate() {
             let kinds = [ov.src.is_some(), !ov.cmd.is_empty()]
@@ -221,13 +232,33 @@ mod tests {
 
     #[test]
     fn validate_accepts_preserve_with_json_shallow() {
-        // preserve = true ＋ json-shallow は正規形（overlay 無しでも可＝土台のみ再直列化）。
+        // preserve = true ＋ json-shallow ＋ overlay は正規形（claude/settings 相当）。
         assert!(
             parse(
                 "dst = \"~/x\"\nstrategy = \"json-shallow\"\npreserve = true\n\
                  [[overlay]]\nsrc = \"settings.json\"\n",
             )
             .is_ok()
+        );
+        // generate（cmd 出力を土台へ重ねる）も compose 経路なので overlay 無しでも可。
+        assert!(
+            parse(
+                "dst = \"~/x\"\nkind = \"generate\"\nstrategy = \"json-shallow\"\n\
+                 preserve = true\ncmd = [\"foo\"]\n",
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_rejects_preserve_without_compose_routing() {
+        // preserve = true ＋ json-shallow だが overlay 無し ＋ kind=copy（既定）→ copy 直行で
+        // preserve が黙って無視される構成。load 時に弾く（静かな no-op を許さない）。
+        let err =
+            parse("dst = \"~/x\"\nstrategy = \"json-shallow\"\npreserve = true\n").unwrap_err();
+        assert!(
+            err.contains("preserve") && err.contains("overlay"),
+            "overlay 無しの copy 直行 preserve が弾かれていない: {err}"
         );
     }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,8 +5,8 @@
 //! - **合成 `strategy`**（複数の条件付き断片を1 dst=ファイルへどう重ねるか）= `concat` /
 //!   `json-shallow`。`merge` は独立 kind ではなく合成軸の JSON 戦略（§5.5）。
 //! - **条件付き overlay**（`[[overlay]]` ＋ `when`）= dst を「base ＋ gate された断片」の合成
-//!   として組む。各 overlay は `src`（copy 断片）/ `cmd`（generate 断片）/ `preserve`（既存 dst
-//!   を読む built-in overlay）のいずれか ＋ `when`（`dep` / `os`）。
+//!   として組む。各 overlay は `src`（copy 断片）/ `cmd`（generate 断片）のどちらか ＋
+//!   `when`（`dep` / `os`）。既存 dst の温存はユニット属性 `preserve = true`（§5.5）。
 //!
 //! `deps` / `os` はユニット単位 gate（＝ ユニット全体に係る `when` の退化形, §5.5）。
 //! theme / hooks / secrets は後続スライスで追加する。
@@ -27,6 +27,12 @@ pub struct Manifest {
     /// generate の既定挙動（cmd 出力＋sibling 連結）は暗黙 `concat`。
     #[serde(default)]
     pub strategy: Option<Strategy>,
+    /// 既存 dst を `json-shallow` の最下層（土台）として温存する（§5.5）。`true` で dotfiles が
+    /// 定義しないトップレベルキー（例 `model` / `effortLevel` や任意のローカル固有キー）を
+    /// 全保持し、dotfiles 所有キーだけ断片で上書きする（旧 `jq '$local + $forced'` と同値）。
+    /// `json-shallow` 専用（他 strategy・省略との併記は load 時エラー）。省略時 false。
+    #[serde(default)]
+    pub preserve: bool,
     /// 所有者のみアクセス可（chezmoi `private_` = 0600 相当）。省略時 false。
     #[serde(default)]
     pub private: bool,
@@ -46,7 +52,7 @@ pub struct Manifest {
     #[serde(default)]
     pub os: Option<String>,
     /// 合成 overlay（条件付き断片の配列, §5.5）。空 = 生成方式の既定挙動。
-    /// 各 overlay は `src` / `cmd` / `preserve` のいずれか ＋ `when?` を持つ。
+    /// 各 overlay は `src` / `cmd` のどちらか ＋ `when?` を持つ。
     #[serde(default)]
     pub overlay: Vec<Overlay>,
 }
@@ -71,7 +77,8 @@ pub enum Strategy {
 }
 
 /// 1 つの overlay（条件付き断片, §5.5）。`when` を満たす時だけ合成に参加する。
-/// 断片の実体化方法は `src`（copy）/ `cmd`（generate）/ `preserve`（既存 dst 読み）の択一。
+/// 断片の実体化方法は `src`（copy）/ `cmd`（generate）の択一。既存 dst の温存は overlay では
+/// なくユニット属性 [`Manifest::preserve`]。
 #[derive(Debug, Deserialize)]
 pub struct Overlay {
     /// copy 断片: 単位ディレクトリからの相対ファイル。内容をそのまま断片にする。
@@ -80,10 +87,6 @@ pub struct Overlay {
     /// generate 断片: 実行する argv。標準出力を断片にする。
     #[serde(default)]
     pub cmd: Vec<String>,
-    /// 既存 dst から温存するトップレベルキー（built-in overlay の糖衣, §5.5）。
-    /// `json-shallow` で常に最後に重なり、ローカル値を勝たせる。
-    #[serde(default)]
-    pub preserve: Vec<String>,
     /// 採用条件（省略 = 常時採用）。`dep` / `os` を AND で評価する。
     #[serde(default)]
     pub when: Option<When>,
@@ -98,13 +101,6 @@ pub struct When {
     /// OS 一致時だけ採用（旧 `{{ if eq .chezmoi.os … }}`）。chezmoi 互換表記。
     #[serde(default)]
     pub os: Option<String>,
-}
-
-impl Overlay {
-    /// 既存 dst を読む built-in overlay（`preserve` だけを持つ）か。
-    pub fn is_preserve(&self) -> bool {
-        !self.preserve.is_empty()
-    }
 }
 
 impl Manifest {
@@ -125,26 +121,28 @@ impl Manifest {
     /// - **overlay 明示時は `strategy` 必須**。合成戦略を一意に決めるため、暗黙の `concat` は
     ///   overlay 未記述の generate 既定挙動だけに限る（overlay を書いて戦略を省くと、意図しない
     ///   text concat になりうるのを防ぐ）。
-    /// - **各 overlay は `src` / `cmd` / `preserve` のうちちょうど 1 つ**（生成方式は択一）。
-    ///   2 つ以上は一方が黙って無視される typo、0 個は断片を実体化できない。
+    /// - **`preserve = true` は `strategy = "json-shallow"` 専用**。既存 dst を土台に重ねる
+    ///   意味論は JSON shallow merge でしか定義しないため、他 strategy・省略との併記は typo
+    ///   として弾く（静かに無視しない）。
+    /// - **各 overlay は `src` / `cmd` のうちちょうど 1 つ**（生成方式は択一）。2 つは一方が
+    ///   黙って無視される typo、0 個は断片を実体化できない。
     fn validate(&self) -> Result<(), String> {
         if !self.overlay.is_empty() && self.strategy.is_none() {
             return Err(
                 "overlay を明示する場合は strategy（concat / json-shallow）が必要です".to_string(),
             );
         }
+        if self.preserve && self.strategy != Some(Strategy::JsonShallow) {
+            return Err("preserve = true は strategy = \"json-shallow\" 専用です".to_string());
+        }
         for (i, ov) in self.overlay.iter().enumerate() {
-            let kinds = [
-                ov.src.is_some(),
-                !ov.cmd.is_empty(),
-                !ov.preserve.is_empty(),
-            ]
-            .into_iter()
-            .filter(|&set| set)
-            .count();
+            let kinds = [ov.src.is_some(), !ov.cmd.is_empty()]
+                .into_iter()
+                .filter(|&set| set)
+                .count();
             if kinds != 1 {
                 return Err(format!(
-                    "overlay[{i}] は src / cmd / preserve のうちちょうど 1 つを持つ必要があります（現在 {kinds} 個）"
+                    "overlay[{i}] は src / cmd のうちちょうど 1 つを持つ必要があります（現在 {kinds} 個）"
                 ));
             }
         }
@@ -195,14 +193,41 @@ mod tests {
 
     #[test]
     fn validate_rejects_overlay_with_multiple_kinds() {
-        // preserve と src を併記 → 一方が黙って無視される typo。
+        // src と cmd を併記 → 一方が黙って無視される typo。
         let err = parse(
-            "dst = \"~/x\"\nstrategy = \"json-shallow\"\n[[overlay]]\nsrc = \"a\"\npreserve = [\"k\"]\n",
+            "dst = \"~/x\"\nstrategy = \"concat\"\n[[overlay]]\nsrc = \"a\"\ncmd = [\"foo\"]\n",
         )
         .unwrap_err();
         assert!(
             err.contains("ちょうど 1 つ"),
             "排他違反が検知されていない: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_preserve_without_json_shallow() {
+        // preserve = true は json-shallow 専用。concat と併記 → load 時エラー（typo 黙殺しない）。
+        let err = parse(
+            "dst = \"~/x\"\nstrategy = \"concat\"\npreserve = true\n[[overlay]]\nsrc = \"a\"\n",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("preserve") && err.contains("json-shallow"),
+            "preserve × 非 json-shallow が弾かれていない: {err}"
+        );
+        // strategy 省略との併記も同様にエラー。
+        assert!(parse("dst = \"~/x\"\npreserve = true\n").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_preserve_with_json_shallow() {
+        // preserve = true ＋ json-shallow は正規形（overlay 無しでも可＝土台のみ再直列化）。
+        assert!(
+            parse(
+                "dst = \"~/x\"\nstrategy = \"json-shallow\"\npreserve = true\n\
+                 [[overlay]]\nsrc = \"settings.json\"\n",
+            )
+            .is_ok()
         );
     }
 
@@ -220,13 +245,12 @@ mod tests {
 
     #[test]
     fn validate_accepts_well_formed_overlays() {
-        // base(src) ＋ rtk(src+when) ＋ preserve の正規形。
+        // preserve = true（ユニット属性）＋ base(src) ＋ rtk(src+when) の正規形。
         assert!(
             parse(
-                "dst = \"~/x\"\nstrategy = \"json-shallow\"\n\
+                "dst = \"~/x\"\nstrategy = \"json-shallow\"\npreserve = true\n\
                  [[overlay]]\nsrc = \"base.json\"\n\
-                 [[overlay]]\nsrc = \"rtk.json\"\nwhen = { dep = \"rtk\" }\n\
-                 [[overlay]]\npreserve = [\"model\"]\n",
+                 [[overlay]]\nsrc = \"rtk.json\"\nwhen = { dep = \"rtk\" }\n",
             )
             .is_ok()
         );

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -2,9 +2,10 @@
 //!
 //! - `concat` … テキスト連結（後ろへ連結。境目に改行を 1 つ補う）。generate の
 //!   「cmd 出力＋sibling 連結」もこの戦略へ統一する（出力は従来と不変）。
-//! - `json_shallow` … JSON のトップレベル shallow merge（後勝ち）。`preserve` キーは
-//!   既存 dst の値で最後に上書きし、ローカル値を勝たせる（旧 `modify_` の `$local + $forced`
-//!   と同じ粒度。deep merge はしない）。
+//! - `json_shallow` … JSON のトップレベル shallow merge（後勝ち）。`base`（既存 dst）を
+//!   与えると最下層の土台として最初に畳み、dotfiles 所有のトップレベルキーだけを断片で
+//!   上書きする。dotfiles が定義しない非管理キーは土台のまま全保持される（旧 `modify_` の
+//!   `jq '$local + $forced'` と同値。deep merge はしない）。
 //!
 //! どちらも副作用のない純関数で、配置（書き込み）は [`crate::compose`] が行う。
 
@@ -25,32 +26,27 @@ pub fn concat(frags: &[Vec<u8>]) -> Vec<u8> {
     out
 }
 
-/// JSON 断片をトップレベル shallow merge（宣言順・後勝ち）し、`preserve` キーだけ既存 dst の
-/// 値で最後に上書きする。各断片・既存 dst は JSON オブジェクトであることを要する。
+/// JSON 断片をトップレベル shallow merge（宣言順・後勝ち）する。`base`（既存 dst）を与えると
+/// 最下層の土台として最初に畳み、その上に断片を重ねる。各断片・`base` は JSON オブジェクトを要する。
 ///
-/// 出力は pretty JSON ＋末尾改行。`existing` が無い／`preserve` キーが既存に無い場合は温存をしない。
-pub fn json_shallow(
-    frags: &[Vec<u8>],
-    preserve_keys: &[String],
-    existing: Option<&[u8]>,
-) -> Result<Vec<u8>, String> {
+/// `base` の意味は「dotfiles 非管理のトップレベルキーを全保持し、dotfiles 所有キー（断片が
+/// 定義するキー）だけを断片で上書きする」（旧 `$local + $forced`）。`base` が無ければ純粋に
+/// 断片だけを合成する。出力は pretty JSON ＋末尾改行。
+pub fn json_shallow(frags: &[Vec<u8>], base: Option<&[u8]>) -> Result<Vec<u8>, String> {
     let mut merged = Map::new();
-    for (i, frag) in frags.iter().enumerate() {
-        let obj = parse_object(frag).map_err(|e| format!("overlay {} {e}", i + 1))?;
+
+    // preserve = true のとき、既存 dst を最下層の土台として最初に畳む（非管理キーを保持）。
+    if let Some(base) = base {
+        let obj = parse_object(base).map_err(|e| format!("既存 dst {e}"))?;
         for (k, v) in obj {
-            merged.insert(k, v); // 後勝ち（BTreeMap.insert が既存キーを置換）。
+            merged.insert(k, v);
         }
     }
 
-    // preserve（既存 dst を読む built-in overlay）は常に最後に重ね、ローカル値を勝たせる。
-    if !preserve_keys.is_empty()
-        && let Some(existing) = existing
-    {
-        let obj = parse_object(existing).map_err(|e| format!("既存 dst {e}"))?;
-        for key in preserve_keys {
-            if let Some(v) = obj.get(key) {
-                merged.insert(key.clone(), v.clone());
-            }
+    for (i, frag) in frags.iter().enumerate() {
+        let obj = parse_object(frag).map_err(|e| format!("overlay {} {e}", i + 1))?;
+        for (k, v) in obj {
+            merged.insert(k, v); // 後勝ち。dotfiles 所有キーが土台を上書き（トップレベル粒度）。
         }
     }
 
@@ -110,7 +106,7 @@ mod tests {
 
     #[test]
     fn json_shallow_later_frag_wins() {
-        let out = json_shallow(&[b(r#"{"a":1,"b":2}"#), b(r#"{"b":3,"c":4}"#)], &[], None).unwrap();
+        let out = json_shallow(&[b(r#"{"a":1,"b":2}"#), b(r#"{"b":3,"c":4}"#)], None).unwrap();
         let v: Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(v["a"], 1);
         assert_eq!(v["b"], 3); // 後勝ち。
@@ -118,41 +114,46 @@ mod tests {
     }
 
     #[test]
-    fn json_shallow_preserve_keeps_existing_value() {
-        let base = b(r#"{"model":"shared","hook":"x"}"#);
-        let existing = b(r#"{"model":"local","other":"y"}"#);
-        let out = json_shallow(&[base], &["model".to_string()], Some(&existing)).unwrap();
+    fn json_shallow_base_preserves_unmanaged_and_overwrites_owned() {
+        // base＝既存 dst。dotfiles 断片が定義するキー（language）は断片が勝ち、断片が
+        // 定義しない非管理キー（model / effortLevel）は土台のまま全保持される（旧 $local+$forced）。
+        let frag = b(r#"{"language":"ja","hook":"base"}"#);
+        let existing = b(r#"{"model":"local","effortLevel":"high","language":"en"}"#);
+        let out = json_shallow(&[frag], Some(&existing)).unwrap();
         let v: Value = serde_json::from_slice(&out).unwrap();
-        assert_eq!(v["model"], "local"); // 既存（ローカル）値が勝つ。
-        assert_eq!(v["hook"], "x"); // base のキーは残る。
+        assert_eq!(v["model"], "local"); // 非管理キーは保持。
+        assert_eq!(v["effortLevel"], "high"); // 非管理キーは保持。
+        assert_eq!(v["language"], "ja"); // dotfiles 所有キーは断片が土台を上書き。
+        assert_eq!(v["hook"], "base"); // 断片のキーは残る。
+    }
+
+    #[test]
+    fn json_shallow_owned_key_replaces_wholesale_not_deep_merge() {
+        // dotfiles 所有のトップレベルキーはオブジェクトごと置き換え（deep merge しない）。
+        let frag = b(r#"{"hooks":{"a":1}}"#);
+        let existing = b(r#"{"hooks":{"b":2}}"#);
+        let out = json_shallow(&[frag], Some(&existing)).unwrap();
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["hooks"]["a"], 1);
         assert!(
-            v.get("other").is_none(),
-            "preserve 外の既存キーは持ち込まない"
+            v["hooks"].get("b").is_none(),
+            "トップレベル粒度で丸ごと置換（配下を deep merge しない）"
         );
     }
 
     #[test]
-    fn json_shallow_preserve_noop_when_key_absent_or_no_existing() {
-        // 既存に preserve キーが無い → 温存しない（base 値のまま）。
-        let empty = b(r#"{}"#);
-        let out = json_shallow(
-            &[b(r#"{"model":"shared"}"#)],
-            &["model".to_string()],
-            Some(&empty),
-        )
-        .unwrap();
+    fn json_shallow_without_base_is_frags_only() {
+        // base が無ければ純粋に断片だけを合成する（preserve 無しの純 dotfiles 所有 json）。
+        let out = json_shallow(&[b(r#"{"model":"shared"}"#)], None).unwrap();
         let v: Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(v["model"], "shared");
-        // 既存ファイルが無い → エラーにせず base のまま。
-        let out2 =
-            json_shallow(&[b(r#"{"model":"shared"}"#)], &["model".to_string()], None).unwrap();
-        let v2: Value = serde_json::from_slice(&out2).unwrap();
-        assert_eq!(v2["model"], "shared");
     }
 
     #[test]
-    fn json_shallow_rejects_non_object_fragment() {
-        assert!(json_shallow(&[b("[1,2,3]")], &[], None).is_err());
-        assert!(json_shallow(&[b("\"scalar\"")], &[], None).is_err());
+    fn json_shallow_rejects_non_object_fragment_or_base() {
+        assert!(json_shallow(&[b("[1,2,3]")], None).is_err());
+        assert!(json_shallow(&[b("\"scalar\"")], None).is_err());
+        let bad_base = b("[1,2,3]");
+        assert!(json_shallow(&[b("{}")], Some(&bad_base)).is_err());
     }
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -916,3 +916,29 @@ fn apply_errors_when_preserve_without_json_shallow() {
         .failure()
         .stderr(predicate::str::contains("preserve"));
 }
+
+/// preserve = true ＋ json-shallow でも overlay 無し ＋ kind=copy（既定）なら load 時にエラー。
+/// この構成は compose 経路に入らず preserve が黙って無視されるため、配置前に弾いて固定する。
+#[test]
+fn apply_errors_when_preserve_without_compose_routing() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo/out.json\"\n\
+         strategy = \"json-shallow\"\n\
+         preserve = true\n",
+    )
+    .unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("preserve"));
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -619,8 +619,9 @@ fn apply_unit_os_gate_short_circuits_without_touching_dst() {
     );
 }
 
-/// claude/settings.json 相当（json-shallow）の合成単位を書き出す。
-/// overlay 宣言順: preserve（先頭）→ base → rtk（when.dep）。不変条件③で preserve は最後に効く。
+/// claude/settings.json 相当（json-shallow ＋ preserve）の合成単位を書き出す。
+/// preserve=true で既存 dst を最下層の土台にし、overlay は base → rtk（when.dep）の宣言順で重なる。
+/// base は dotfiles 所有キー（language / hook）だけを持ち、model 等の非管理キーは定義しない。
 fn write_json_shallow_unit(work: &Path) {
     let unit = work.join("configs/claude/settings");
     fs::create_dir_all(&unit).unwrap();
@@ -628,8 +629,7 @@ fn write_json_shallow_unit(work: &Path) {
         unit.join("manifest.toml"),
         "dst = \"~/.claude/settings.json\"\n\
          strategy = \"json-shallow\"\n\
-         [[overlay]]\n\
-         preserve = [\"model\"]\n\
+         preserve = true\n\
          [[overlay]]\n\
          src = \"settings.json\"\n\
          [[overlay]]\n\
@@ -637,19 +637,20 @@ fn write_json_shallow_unit(work: &Path) {
          when = { dep = \"rtk\" }\n",
     )
     .unwrap();
-    // base は model を共有値で持つ（preserve でローカル値に上書きされる対象）。
+    // base は dotfiles 所有キー（language=共有値 / hook）を持つ。model は定義しない（=非管理）。
     fs::write(
         unit.join("settings.json"),
-        "{\"model\":\"shared\",\"hook\":\"base\"}\n",
+        "{\"language\":\"ja\",\"hook\":\"base\"}\n",
     )
     .unwrap();
     fs::write(unit.join("rtk.json"), "{\"rtkHook\":\"on\"}\n").unwrap();
 }
 
-/// json-shallow: rtk present＋既存ローカル値あり。後勝ち合成＋ preserve は宣言位置に関わらず最後。
+/// json-shallow ＋ preserve: rtk present。既存 dst を土台に非管理キー（model / effortLevel）を
+/// 全保持し、dotfiles 所有キー（language）は断片が土台を上書きする（旧 $local + $forced）。
 #[cfg(unix)]
 #[test]
-fn apply_json_shallow_merges_and_preserve_wins_last() {
+fn apply_json_shallow_preserves_unmanaged_and_overwrites_owned() {
     let work = tempfile::tempdir().unwrap();
     let home = tempfile::tempdir().unwrap();
     let bin = tempfile::tempdir().unwrap();
@@ -657,10 +658,14 @@ fn apply_json_shallow_merges_and_preserve_wins_last() {
     write_stub(bin.path(), "rtk", "exit 0\n");
     write_json_shallow_unit(work.path());
 
-    // 既存 dst にローカル値（model）と preserve 外のキー（extra）を置く。
+    // 既存 dst: model/effortLevel=非管理（保持）、language=dotfiles 所有（断片で上書きされる）。
     let dst = home.path().join(".claude/settings.json");
     fs::create_dir_all(dst.parent().unwrap()).unwrap();
-    fs::write(&dst, "{\"model\":\"local\",\"extra\":\"drop\"}\n").unwrap();
+    fs::write(
+        &dst,
+        "{\"model\":\"local\",\"effortLevel\":\"high\",\"language\":\"en\"}\n",
+    )
+    .unwrap();
 
     dotfiles()
         .arg("apply")
@@ -673,7 +678,15 @@ fn apply_json_shallow_merges_and_preserve_wins_last() {
     let out = fs::read_to_string(&dst).unwrap();
     assert!(
         out.contains("\"model\": \"local\""),
-        "preserve=model が宣言先頭でもローカル値で最後に勝つべき:\n{out}",
+        "dotfiles 非管理キー model は土台のまま保持されるべき:\n{out}",
+    );
+    assert!(
+        out.contains("\"effortLevel\": \"high\""),
+        "dotfiles 非管理キー effortLevel は土台のまま保持されるべき:\n{out}",
+    );
+    assert!(
+        out.contains("\"language\": \"ja\""),
+        "dotfiles 所有キー language は断片が土台を上書きすべき:\n{out}",
     );
     assert!(
         out.contains("\"hook\": \"base\""),
@@ -683,13 +696,9 @@ fn apply_json_shallow_merges_and_preserve_wins_last() {
         out.contains("\"rtkHook\": \"on\""),
         "when.dep=rtk を満たす断片が重なるべき:\n{out}",
     );
-    assert!(
-        !out.contains("extra"),
-        "preserve 外の既存キーは持ち込まれないべき:\n{out}",
-    );
 }
 
-/// json-shallow: rtk 不在でも base＋preserve で settings.json は書かれる（回帰解消の核）。
+/// json-shallow ＋ preserve: rtk 不在でも base＋土台で settings.json は書かれる（回帰解消の核）。
 #[cfg(unix)]
 #[test]
 fn apply_json_shallow_writes_base_without_gated_overlay() {
@@ -718,11 +727,49 @@ fn apply_json_shallow_writes_base_without_gated_overlay() {
     );
     assert!(
         out.contains("\"model\": \"local\""),
-        "preserve が効くべき:\n{out}"
+        "非管理キー model が土台のまま保持されるべき:\n{out}",
     );
     assert!(
         !out.contains("rtkHook"),
         "rtk 不在なら when.dep 断片は脱落するべき:\n{out}",
+    );
+}
+
+/// preserve 無しの json-shallow は既存 dst を土台にしない（純 dotfiles 所有 json は従来挙動）。
+#[test]
+fn apply_json_shallow_without_preserve_ignores_existing() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/owned");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/owned/out.json\"\n\
+         strategy = \"json-shallow\"\n\
+         [[overlay]]\n\
+         src = \"a.json\"\n",
+    )
+    .unwrap();
+    fs::write(unit.join("a.json"), "{\"k\":\"new\"}\n").unwrap();
+
+    // 既存 dst にローカルキーを置いても、preserve 無しなら土台にされず破棄される。
+    let dst = home.path().join(".config/owned/out.json");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::write(&dst, "{\"stale\":\"x\"}\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(&dst).unwrap();
+    assert!(out.contains("\"k\": \"new\""), "断片が書かれるべき:\n{out}");
+    assert!(
+        !out.contains("stale"),
+        "preserve 無しなら既存 dst は土台にされないべき:\n{out}",
     );
 }
 
@@ -785,7 +832,8 @@ fn list_shows_overlay_strategy_and_os_attrs() {
         .assert()
         .success()
         .stdout(predicate::str::contains("json-shallow"))
-        .stdout(predicate::str::contains("overlay=3"))
+        .stdout(predicate::str::contains("overlay=2"))
+        .stdout(predicate::str::contains("preserve"))
         .stdout(predicate::str::contains("os=darwin"));
 }
 
@@ -813,7 +861,7 @@ fn apply_errors_when_overlay_without_strategy() {
         .stderr(predicate::str::contains("strategy"));
 }
 
-/// overlay に src/cmd/preserve を 2 つ以上書くと load 時にエラー（黙殺される typo を弾く）。
+/// overlay に src/cmd を 2 つ以上書くと load 時にエラー（黙殺される typo を弾く）。
 #[test]
 fn apply_errors_when_overlay_mixes_kinds() {
     let work = tempfile::tempdir().unwrap();
@@ -827,7 +875,7 @@ fn apply_errors_when_overlay_mixes_kinds() {
          strategy = \"json-shallow\"\n\
          [[overlay]]\n\
          src = \"a.json\"\n\
-         preserve = [\"k\"]\n",
+         cmd = [\"echo\"]\n",
     )
     .unwrap();
     fs::write(unit.join("a.json"), "{}\n").unwrap();
@@ -839,4 +887,32 @@ fn apply_errors_when_overlay_mixes_kinds() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("ちょうど 1 つ"));
+}
+
+/// preserve = true を json-shallow 以外と併記すると load 時にエラー（typo を黙殺しない）。
+#[test]
+fn apply_errors_when_preserve_without_json_shallow() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo/out.txt\"\n\
+         strategy = \"concat\"\n\
+         preserve = true\n\
+         [[overlay]]\n\
+         src = \"a.txt\"\n",
+    )
+    .unwrap();
+    fs::write(unit.join("a.txt"), "A\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("preserve"));
 }


### PR DESCRIPTION
## 概要

PR #469 のレビュー指摘 — `claude/settings` の既存温存が **`preserve = [キー列挙]`（allowlist）** で、未列挙のローカル固有キーが黙って落ちる破壊的挙動 — に対し、設計書 #474 で確定した **「`preserve = true` で既存 dst を `json-shallow` の最下層（土台）に重ね、dotfiles 所有のトップレベルキーだけ上書き＝非管理キーは全保持」**（旧 chezmoi `jq '$local + $forced'`）へ共有機構を追従させるリファクタ。

Closes #475

## 変更内容

- **`src/strategy.rs`**: `json_shallow(frags, base)` へシグネチャ変更。`base`（既存 dst）を**最下層の土台**として最初に fold し、その上に断片を後勝ちで重ねる。`preserve` キー列挙ロジックを撤去。
- **`src/manifest.rs`**: `Overlay.preserve`（`Vec<String>`）と `is_preserve()` を撤去し、**ユニット属性 `preserve: bool`** を追加。`validate` に **`preserve = true` は `strategy = "json-shallow"` 必須**（他 strategy・省略は load 時エラー）を追加。overlay 種別判定を `src` / `cmd` の2択へ。
- **`src/compose.rs`**: `preserve = true` の時だけ既存 dst を読み、base 層として `json_shallow` へ渡す配線。
- **`src/apply.rs` / `src/list.rs`**: doc 追従、`list` に `preserve` 属性表示を追加。
- **`tests/e2e/mod.rs`**（hermetic）: fixture を `preserve = true` ユニット属性へ更新。非管理キー保持・所有キー上書き・preserve×非 json-shallow の load エラー・preserve 無しは既存を土台にしないことを検証。

## 受け入れ条件

- [x] `preserve = true` で既存の非管理キー（`model` / `effortLevel` / 任意のローカルキー）が**保持**される（旧 `$local + $forced` と同値）
- [x] dotfiles が所有するトップレベルキー（`hooks` 等）は配下ごと上書き（**deep merge しない**＝トップレベル粒度）
- [x] `preserve = true` × 非 `json-shallow` は **load 時エラー**
- [x] `preserve` 無しの `json-shallow`（純 dotfiles 所有 json）は既存を土台にせず従来挙動
- [x] hermetic E2E が新仕様を反映、`cargo fmt` / `clippy -D warnings` / `mise run check` clean

## 後続

本 PR の main マージ後に **#469（スライス #457）** を新仕様へ改修（`manifest.toml` を `preserve = true` へ、実 config E2E を `localOnly` 保持検証へ）。`configs/` 配下に実 `preserve` を使う manifest はまだ無いため、本 PR は共有機構＋テストのみの変更。

## 参照

設計書: `docs/dotfiles-native-design.md` §5.5 / §7（#474）/ レビュー: #469 / 機構導入: #471・#472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
