### PR TITLE
feat(dotfiles): マシンローカル値(named value)機構を実装 [S4 #458]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ version = "0.69.4"
 dependencies = [
  "assert_cmd",
  "clap",
+ "libc",
  "predicates",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version     = "0.69.4"
 
 [dependencies]
 clap       = { workspace = true }
+libc       = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 toml       = { workspace = true }

--- a/configs/git/manifest.toml
+++ b/configs/git/manifest.toml
@@ -1,0 +1,8 @@
+# git の user identity（マシンローカル値, §9）。`@@git.email@@` / `@@git.name@@` を
+# ストア（~/.config/dotfiles/local.toml）の値で穴埋めして ~/.config/git/user に配置する。
+# email/name は commit に載るため非 sensitive（sensitive 指定しない）。
+#
+# 残りの git 設定（alias/core/delta…）と hooks は当面 chezmoi 管理のまま。chezmoi 側の
+# git config は native [include] で本ファイルを取り込む（env "DOTFILES_GIT_*" 注入は廃止）。
+dst    = "~/.config/git"
+locals = [ "git.email", "git.name" ]

--- a/configs/git/user
+++ b/configs/git/user
@@ -1,0 +1,5 @@
+# Machine-local git identity — `dotfiles apply` が配置し、`@@name@@` を
+# ~/.config/dotfiles/local.toml の値で置換する（`dotfiles secret set git.email <value>`）。
+[user]
+	email = @@git.email@@
+	name = @@git.name@@

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -4,12 +4,15 @@
 //! ①**ユニット gate（`deps` / `os`）を最初に評価し false なら短絡**（[`crate::gate`]、dst を
 //! 一切触らず skip）。生き残った単位は dst 種別で配置経路が分かれる ―
 //! dst=ディレクトリの copy は [`crate::copy`]（ツリー配置）、dst=ファイルの generate /
-//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve=既存 dst を土台に敷く合成）。本モジュールは
+//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve=既存 dst を土台に敷く合成）。
+//! 配置後、`locals` 宣言ユニットは [`resolve_locals`]（ストア [`crate::local_store`]／TTY 対話
+//! [`crate::prompt`]）で値を解決し [`crate::inject`] で `@@name@@` を注入する（§9.1）。本モジュールは
 //! オーケストレーションと、両経路が共有する小道具（`~` 展開・パーミッション適用）を持つ。
 
 use crate::discover::{self, MANIFEST, Unit};
 use crate::manifest::{Kind, Manifest, Strategy};
-use crate::{compose, copy, gate};
+use crate::{compose, copy, gate, inject, local_store, prompt};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// `source`（= `configs/`）配下を走査し、各 manifest の配置を実行する。
@@ -43,13 +46,56 @@ fn apply_unit(unit: &Unit, home: &Path) -> Result<(), String> {
     }
 
     let label = placement_label(&manifest);
-    if uses_compose(&manifest) {
-        compose::place(&unit.dir, &dst, &manifest)?;
+    let written = if uses_compose(&manifest) {
+        compose::place(&unit.dir, &dst, &manifest)?
     } else {
-        copy::place(&unit.dir, &dst, &manifest)?;
-    }
+        copy::place(&unit.dir, &dst, &manifest)?
+    };
     println!("apply: {name} → {} ({label})", manifest.dst);
+
+    // ②locals 宣言があれば、ストア/対話で値を解決し配置ファイルへ `@@name@@` を注入する（§9.1）。
+    // 置換は locals 宣言ユニットだけに走るため、無関係ファイルの `@@…@@` は巻き込まない。
+    if !manifest.locals.is_empty() {
+        let values = resolve_locals(&manifest, home, &name)?;
+        let paths: Vec<&Path> = written.iter().map(PathBuf::as_path).collect();
+        inject::substitute(&paths, &values)?;
+    }
     Ok(())
+}
+
+/// ユニットの `locals` を解決する（§9.1 step3）。ストアにある値を採り、無い値は **TTY なら対話
+/// 取得してストアへ 0600 で書き**、**非 TTY なら警告のみで継続**（apply をブロックしない）。
+/// 戻り値は解決できた名前→値だけ（未解決は含めない ＝ `@@name@@` はリテラルのまま残り doctor が拾う）。
+fn resolve_locals(
+    manifest: &Manifest,
+    home: &Path,
+    unit: &str,
+) -> Result<BTreeMap<String, String>, String> {
+    let store = local_store::load(home)?;
+    let tty = prompt::stdin_is_tty();
+    let mut resolved = BTreeMap::new();
+    for name in &manifest.locals {
+        if let Some(value) = store.get(name) {
+            resolved.insert(name.clone(), value.clone());
+        } else if tty {
+            let sensitive = manifest.sensitive.iter().any(|s| s == name);
+            let value = prompt::prompt(name, sensitive)
+                .map_err(|e| format!("{name}: 対話取得失敗: {e}"))?;
+            if value.is_empty() {
+                eprintln!(
+                    "apply: {unit} → 警告: {name} が空のため未設定のまま（@@{name}@@ は未置換）"
+                );
+                continue;
+            }
+            local_store::set(home, name, &value)?;
+            resolved.insert(name.clone(), value);
+        } else {
+            eprintln!(
+                "apply: {unit} → 警告: {name} が未設定（非 TTY のため対話取得を省略。@@{name}@@ は未置換）"
+            );
+        }
+    }
+    Ok(resolved)
 }
 
 /// ファイル合成経路（[`crate::compose`]）を通すか。overlay 明示、または dst=ファイルの

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -8,10 +8,11 @@
 use crate::apply::set_mode;
 use crate::manifest::{Manifest, Overlay, Strategy};
 use crate::{gate, generate, strategy};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// 1 単位（`dir`）を overlay 合成で `dst`（ファイル）へ生成・配置する。
-pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
+/// 1 単位（`dir`）を overlay 合成で `dst`（ファイル）へ生成・配置し、書き出した dst を返す。
+/// 戻り値は `locals` 注入（[`crate::inject`]）の置換対象になる。
+pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<Vec<PathBuf>, String> {
     let frags = resolve_fragments(dir, manifest)?;
     let bytes = combine(manifest, dst, &frags)?;
 
@@ -21,7 +22,7 @@ pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> 
     }
     std::fs::write(dst, &bytes).map_err(|e| format!("{}: 書き込み失敗: {e}", dst.display()))?;
     set_mode(dst, manifest)?;
-    Ok(())
+    Ok(vec![dst.to_path_buf()])
 }
 
 /// 採用する断片列を解決する（不変条件②）。`preserve`（土台＝既存 dst）の配線は [`combine`]。

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -8,20 +8,25 @@
 use crate::apply::set_mode;
 use crate::discover::{self, MANIFEST};
 use crate::manifest::Manifest;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// 1 単位（`dir`）を copy で `dst`（ディレクトリ）へ配置する。
-pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
-    copy_tree(dir, dir, dst, manifest)
+/// 1 単位（`dir`）を copy で `dst`（ディレクトリ）へ配置し、書き出した実ファイル群を返す。
+/// 戻り値は `locals` 注入（[`crate::inject`]）の置換対象になる。
+pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<Vec<PathBuf>, String> {
+    let mut written = Vec::new();
+    copy_tree(dir, dir, dst, manifest, &mut written)?;
+    Ok(written)
 }
 
 /// `src_root` 配下の実ファイルを、相対構造を保ったまま `dst_root` へコピーする。
 /// `manifest.toml` 自体と、別 manifest を持つサブツリーは除外する（委譲先の責務）。
+/// 書き出した dst パスを `written` に積む。
 fn copy_tree(
     current: &Path,
     src_root: &Path,
     dst_root: &Path,
     manifest: &Manifest,
+    written: &mut Vec<PathBuf>,
 ) -> Result<(), String> {
     for entry in discover::read_dir(current)? {
         let path = entry.path();
@@ -30,12 +35,14 @@ fn copy_tree(
             if path.join(MANIFEST).is_file() {
                 continue;
             }
-            copy_tree(&path, src_root, dst_root, manifest)?;
+            copy_tree(&path, src_root, dst_root, manifest, written)?;
         } else if entry.file_name() != MANIFEST {
             let rel = path
                 .strip_prefix(src_root)
                 .map_err(|e| format!("{}: 相対パス算出失敗: {e}", path.display()))?;
-            copy_file(&path, &dst_root.join(rel), manifest)?;
+            let out = dst_root.join(rel);
+            copy_file(&path, &out, manifest)?;
+            written.push(out);
         }
     }
     Ok(())

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,71 @@
+//! `dotfiles doctor`（雛形）: マシンローカル値（`locals`）の未設定を診断する（§9.1 step5）。
+//!
+//! 全 unit の `locals` 宣言を集約し、ストア（[`crate::local_store`]）に在るかを見るだけ。ツール別
+//! ロジック（git の `git config --includes` 解決スコープ等）に依存しない（設計書 §9.2）。本スライス
+//! では locals の set/unset 診断に限る（依存バイナリ等の他チェックは後続）。値は一切表示しない。
+
+use crate::discover::{self, MANIFEST};
+use crate::local_store;
+use crate::manifest::Manifest;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// 1 つの named value 宣言の集約（複数 unit が同名を宣言しうる）。
+struct Decl {
+    /// 宣言したユニット名（source 相対）。表示用。
+    units: Vec<String>,
+    /// いずれかの unit が秘匿指定したか（表示で `hidden` を添える。値は出さない）。
+    sensitive: bool,
+}
+
+/// `source` 配下の `locals` を集約し、ストア照合で set/unset を診断する。
+/// 未設定があっても **警告のみ・exit 0**（automation をブロックしない）。
+pub fn run(source: &Path, home: &Path) -> Result<(), String> {
+    let units = discover::collect(source)?;
+    let mut decls: BTreeMap<String, Decl> = BTreeMap::new();
+    for unit in &units {
+        let manifest = Manifest::load(&unit.dir.join(MANIFEST))?;
+        let name = unit.rel.to_string_lossy().into_owned();
+        for local in &manifest.locals {
+            let sensitive = manifest.sensitive.iter().any(|s| s == local);
+            let decl = decls.entry(local.clone()).or_insert_with(|| Decl {
+                units: Vec::new(),
+                sensitive: false,
+            });
+            decl.units.push(name.clone());
+            decl.sensitive |= sensitive;
+        }
+    }
+
+    let store = local_store::load(home)?;
+    println!(
+        "dotfiles doctor（source: {}, store: {}）",
+        source.display(),
+        local_store::path(home).display(),
+    );
+    if decls.is_empty() {
+        println!("  locals 宣言なし");
+        return Ok(());
+    }
+
+    let mut unset = 0;
+    for (name, decl) in &decls {
+        let from = decl.units.join(", ");
+        let tag = if decl.sensitive { " (sensitive)" } else { "" };
+        if store.contains_key(name) {
+            println!("  ✓ {name}{tag}  — set  [{from}]");
+        } else {
+            unset += 1;
+            println!("  ⚠ {name}{tag}  — 未設定  [{from}]");
+        }
+    }
+    if unset > 0 {
+        println!(
+            "locals: {total} 件中 {unset} 件が未設定。`dotfiles secret set <name> <value>` で設定できます。",
+            total = decls.len(),
+        );
+    } else {
+        println!("locals: {} 件すべて設定済み。", decls.len());
+    }
+    Ok(())
+}

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -1,0 +1,109 @@
+//! named value の注入（§9.1 step4）: 配置ファイル中の `@@name@@` をストア値で置換する。
+//!
+//! 生成方式（copy / generate）を問わず、`locals` を宣言したユニットの配置ファイル（[`crate::copy`]
+//! / [`crate::compose`] が書き出した実ファイル）に対し materialize 後に走る。置換は **named
+//! placeholder のみ**で、条件分岐・関数を持つ汎用テンプレートは導入しない（設計書 §9.1）。
+//!
+//! 解決済みの名前だけを置換し、**未解決（ストアに無い）の `@@name@@` はリテラルのまま残す**。
+//! 空置換せず可視に残すことで `doctor` が拾え、誤って空値を焼き込まない。バイト列で扱い、
+//! 内容が変わったファイルだけ書き戻す。
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// `paths` の各ファイルについて、`values`（名前 → 値）の `@@name@@` を値へ置換する。
+/// `values` に無い名前のプレースホルダは触らない。内容が変わったファイルだけ書き戻す。
+pub fn substitute(paths: &[&Path], values: &BTreeMap<String, String>) -> Result<(), String> {
+    if values.is_empty() {
+        return Ok(());
+    }
+    for path in paths {
+        let original =
+            std::fs::read(path).map_err(|e| format!("{}: 読み込み失敗: {e}", path.display()))?;
+        let mut content = original.clone();
+        for (name, value) in values {
+            let needle = format!("@@{name}@@");
+            content = replace_bytes(&content, needle.as_bytes(), value.as_bytes());
+        }
+        if content != original {
+            std::fs::write(path, &content)
+                .map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// `input` 中の `from` を全て `to` に置換したバイト列を返す（非 UTF-8 でも安全）。
+fn replace_bytes(input: &[u8], from: &[u8], to: &[u8]) -> Vec<u8> {
+    if from.is_empty() {
+        return input.to_vec();
+    }
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        if input[i..].starts_with(from) {
+            out.extend_from_slice(to);
+            i += from.len();
+        } else {
+            out.push(input[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn values(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn replace_bytes_replaces_all_occurrences() {
+        assert_eq!(
+            replace_bytes(b"a@@x@@b@@x@@", b"@@x@@", b"V"),
+            b"aVbV".to_vec()
+        );
+    }
+
+    #[test]
+    fn substitute_replaces_known_and_keeps_unknown_literal() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("user");
+        std::fs::write(
+            &f,
+            "[user]\n\temail = @@git.email@@\n\tname = @@git.name@@\n",
+        )
+        .unwrap();
+
+        // git.name は与えない → リテラルのまま残るべき。
+        substitute(&[&f], &values(&[("git.email", "me@x")])).unwrap();
+
+        let out = std::fs::read_to_string(&f).unwrap();
+        assert!(
+            out.contains("email = me@x"),
+            "解決値が置換されるべき:\n{out}"
+        );
+        assert!(
+            out.contains("name = @@git.name@@"),
+            "未解決の placeholder はリテラルのまま残るべき:\n{out}"
+        );
+    }
+
+    #[test]
+    fn substitute_empty_values_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("user");
+        std::fs::write(&f, "email = @@git.email@@\n").unwrap();
+        substitute(&[&f], &values(&[])).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&f).unwrap(),
+            "email = @@git.email@@\n"
+        );
+    }
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -75,5 +75,11 @@ fn attrs(manifest: &Manifest) -> String {
     if let Some(os) = &manifest.os {
         parts.push(format!("os={os}"));
     }
+    if !manifest.locals.is_empty() {
+        parts.push(format!("locals={}", manifest.locals.join("+")));
+    }
+    if !manifest.sensitive.is_empty() {
+        parts.push(format!("sensitive={}", manifest.sensitive.join("+")));
+    }
     parts.join(", ")
 }

--- a/src/local_store.rs
+++ b/src/local_store.rs
@@ -1,0 +1,201 @@
+//! マシンローカル値ストア（§9.1）: `~/.config/dotfiles/local.toml` の read/write。
+//!
+//! named value（`git.email` 等）を全ツール横断で 1 ファイルに集約する。dotfiles 非管理
+//! （gitignore 相当）で、apply の `@@name@@` 置換（[`crate::inject`]）・`secret set`・`doctor` が
+//! 共有する唯一のストア。**repo には値を一切置かない**（設計書 §9.2）。
+//!
+//! 名前はドット区切り（`git.email`）。ファイル上はネストテーブル（`[git] email = ".."`）で
+//! 持ち、read 時にドット区切りキーへ flatten、write 時に再ネストする。人が手で開いて読み書き
+//! しやすい自然な TOML 形を保ちつつ、エンジン内部はフラットな名前→値で扱う。
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// ストアファイルのパス（`<home>/.config/dotfiles/local.toml`）。
+///
+/// XDG 正規化（`$XDG_CONFIG_HOME` 等）は設計書 §14 の未決事項のため、S4 では設計書 §9.2 の
+/// 表記どおり素直に `~/.config` 直下に置く。
+pub fn path(home: &Path) -> PathBuf {
+    home.join(".config/dotfiles/local.toml")
+}
+
+/// ストアを読み、名前（ドット区切り）→ 値のフラットな map にして返す。
+/// ファイルが無ければ空 map（未設定 ＝ エラーではない）。
+pub fn load(home: &Path) -> Result<BTreeMap<String, String>, String> {
+    let p = path(home);
+    let text = match std::fs::read_to_string(&p) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(e) => return Err(format!("{}: 読み込み失敗: {e}", p.display())),
+    };
+    let value: toml::Value =
+        toml::from_str(&text).map_err(|e| format!("{}: パース失敗: {e}", p.display()))?;
+    let mut out = BTreeMap::new();
+    flatten(&value, String::new(), &mut out);
+    Ok(out)
+}
+
+/// 名前 `name` に `value` を設定する（load → 上書き → write の read-modify-write）。
+/// 既存の他の値は保持する。親ディレクトリ・ファイルのパーミッションは [`write`] が整える。
+pub fn set(home: &Path, name: &str, value: &str) -> Result<(), String> {
+    let mut map = load(home)?;
+    map.insert(name.to_string(), value.to_string());
+    write(home, &map)
+}
+
+/// フラットな名前→値 map をネストテーブルへ再構成し、0600 で書き出す（親 dir は 0700 で作成）。
+pub fn write(home: &Path, map: &BTreeMap<String, String>) -> Result<(), String> {
+    let p = path(home);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
+        set_dir_mode(parent)?;
+    }
+    let text = toml::to_string(&unflatten(map)).map_err(|e| format!("TOML 直列化失敗: {e}"))?;
+    std::fs::write(&p, text).map_err(|e| format!("{}: 書き込み失敗: {e}", p.display()))?;
+    set_file_mode(&p)?;
+    Ok(())
+}
+
+/// ネストした TOML テーブルを、ドット区切りキー → 文字列値のフラット map へ畳む。
+/// 文字列以外の leaf（配列・数値等）は S4 の named value 形式外として無視する。
+fn flatten(value: &toml::Value, prefix: String, out: &mut BTreeMap<String, String>) {
+    match value {
+        toml::Value::Table(table) => {
+            for (k, v) in table {
+                let key = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                flatten(v, key, out);
+            }
+        }
+        toml::Value::String(s) if !prefix.is_empty() => {
+            out.insert(prefix, s.clone());
+        }
+        _ => {}
+    }
+}
+
+/// フラットなドット区切りキー map を、ネストした TOML テーブルへ再構成する。
+fn unflatten(map: &BTreeMap<String, String>) -> toml::Value {
+    let mut root = toml::value::Table::new();
+    for (name, value) in map {
+        let mut table = &mut root;
+        let parts: Vec<&str> = name.split('.').collect();
+        for seg in &parts[..parts.len() - 1] {
+            table = table
+                .entry(seg.to_string())
+                .or_insert_with(|| toml::Value::Table(toml::value::Table::new()))
+                .as_table_mut()
+                .expect("nested key segment is a table");
+        }
+        table.insert(
+            parts[parts.len() - 1].to_string(),
+            toml::Value::String(value.clone()),
+        );
+    }
+    toml::Value::Table(root)
+}
+
+/// ストアファイルを所有者のみ読み書き可（0600）にする。秘匿値を含みうるため。
+#[cfg(unix)]
+fn set_file_mode(p: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| format!("{}: パーミッション設定失敗: {e}", p.display()))
+}
+
+/// 親ディレクトリを所有者のみ（0700）にする。
+#[cfg(unix)]
+fn set_dir_mode(p: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700))
+        .map_err(|e| format!("{}: パーミッション設定失敗: {e}", p.display()))
+}
+
+#[cfg(not(unix))]
+fn set_file_mode(_p: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_dir_mode(_p: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flatten_nested_tables_to_dotted_keys() {
+        let value: toml::Value =
+            toml::from_str("[git]\nemail = \"me@x\"\nname = \"Me\"\n[github]\ntoken = \"t\"\n")
+                .unwrap();
+        let mut out = BTreeMap::new();
+        flatten(&value, String::new(), &mut out);
+        assert_eq!(out.get("git.email").map(String::as_str), Some("me@x"));
+        assert_eq!(out.get("git.name").map(String::as_str), Some("Me"));
+        assert_eq!(out.get("github.token").map(String::as_str), Some("t"));
+    }
+
+    #[test]
+    fn flatten_ignores_non_string_leaves() {
+        let value: toml::Value =
+            toml::from_str("[a]\nn = 1\narr = [1, 2]\ns = \"keep\"\n").unwrap();
+        let mut out = BTreeMap::new();
+        flatten(&value, String::new(), &mut out);
+        assert_eq!(out.get("a.s").map(String::as_str), Some("keep"));
+        assert!(!out.contains_key("a.n"));
+        assert!(!out.contains_key("a.arr"));
+    }
+
+    #[test]
+    fn unflatten_round_trips_through_toml() {
+        let mut map = BTreeMap::new();
+        map.insert("git.email".to_string(), "me@x".to_string());
+        map.insert("git.name".to_string(), "Me".to_string());
+        map.insert("flat".to_string(), "v".to_string());
+        // 再ネスト → 直列化 → 再パース → flatten で同一に戻る。
+        let text = toml::to_string(&unflatten(&map)).unwrap();
+        let value: toml::Value = toml::from_str(&text).unwrap();
+        let mut back = BTreeMap::new();
+        flatten(&value, String::new(), &mut back);
+        assert_eq!(map, back);
+    }
+
+    #[test]
+    fn load_missing_store_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(load(home.path()).unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_creates_store_0600_and_persists() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = tempfile::tempdir().unwrap();
+        set(home.path(), "git.email", "me@x").unwrap();
+        // 再 load で読める。
+        assert_eq!(
+            load(home.path())
+                .unwrap()
+                .get("git.email")
+                .map(String::as_str),
+            Some("me@x")
+        );
+        // ファイルは 0600。
+        let mode = std::fs::metadata(path(home.path()))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "ストアは 0600 であるべき");
+        // 既存値を保ったまま追記できる。
+        set(home.path(), "git.name", "Me").unwrap();
+        let map = load(home.path()).unwrap();
+        assert_eq!(map.get("git.email").map(String::as_str), Some("me@x"));
+        assert_eq!(map.get("git.name").map(String::as_str), Some("Me"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,10 @@
 //! （`when` gate）で捉える（設計書 §5 / §5.5）。copy はツリー配置、generate / overlay 明示は
 //! ファイル合成（[`compose`]）を通り、`deps` / `os` はユニット単位 gate（[`gate`]）。
 //! `apply` は配置、`list` は分散 manifest を集約した配置先一覧を担う。
+//!
+//! `secret` / `doctor` はマシンローカル値（named value, §9）: `secret set` がストア
+//! （[`local_store`]）へ値を書き、`apply` が `locals` 宣言ユニットの `@@name@@` を置換注入し
+//! （[`inject`]・未設定は [`prompt`] で TTY 対話）、`doctor` が未設定を診断する。
 
 use clap::{Parser, Subcommand};
 use std::path::Path;
@@ -17,10 +21,14 @@ mod apply;
 mod compose;
 mod copy;
 mod discover;
+mod doctor;
 mod gate;
 mod generate;
+mod inject;
 mod list;
+mod local_store;
 mod manifest;
+mod prompt;
 mod strategy;
 
 /// toshiki670/dotfiles 本体（core）。
@@ -42,6 +50,22 @@ enum Commands {
     Apply,
     /// configs の manifest を集約し、配置先一覧を表示する。
     List,
+    /// マシンローカル値（named value）をストアへ設定する（§9）。
+    ///
+    /// コマンド名は仮称（§14）。`secret` は秘匿値以外（email/name 等）も扱うため、
+    /// `local` 系への改名を含めて最終命名は後で確定する。
+    Secret {
+        #[command(subcommand)]
+        action: SecretCmd,
+    },
+    /// マシンローカル値（`locals`）の未設定を診断する（雛形, §9）。
+    Doctor,
+}
+
+#[derive(Subcommand)]
+enum SecretCmd {
+    /// `<name>`（例 `git.email`）に `<value>` を設定する（ストアは 0600）。
+    Set { name: String, value: String },
 }
 
 fn main() {
@@ -59,13 +83,49 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Some(Commands::Secret {
+            action: SecretCmd::Set { name, value },
+        }) => {
+            if let Err(e) = run_secret_set(&name, &value) {
+                eprintln!("dotfiles secret set: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Doctor) => {
+            if let Err(e) = run_doctor() {
+                eprintln!("dotfiles doctor: {e}");
+                std::process::exit(1);
+            }
+        }
         // サブコマンドなし: 従来どおりバージョンを表示する。
         None => println!("dotfiles {}", env!("CARGO_PKG_VERSION")),
     }
 }
 
+/// HOME を解決する（apply / secret / doctor 共通）。dst の `~` 展開・ストア配置の基点。
+fn home_dir() -> Result<std::path::PathBuf, String> {
+    std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .ok_or_else(|| "HOME が未設定".to_string())
+}
+
 /// `dotfiles apply`：CWD 相対の固定ソース `configs/` を、HOME を基点に配置する。
 fn run_apply() -> Result<(), String> {
-    let home = std::env::var_os("HOME").ok_or_else(|| "HOME が未設定".to_string())?;
-    apply::run(Path::new("configs"), Path::new(&home))
+    apply::run(Path::new("configs"), &home_dir()?)
+}
+
+/// `dotfiles secret set <name> <value>`：ストアへ値を設定する。値は決して表示しない（§9.1）。
+fn run_secret_set(name: &str, value: &str) -> Result<(), String> {
+    let home = home_dir()?;
+    local_store::set(&home, name, value)?;
+    println!(
+        "dotfiles secret set: {name} を設定しました（{}）",
+        local_store::path(&home).display()
+    );
+    Ok(())
+}
+
+/// `dotfiles doctor`：configs の `locals` 未設定を診断する。
+fn run_doctor() -> Result<(), String> {
+    doctor::run(Path::new("configs"), &home_dir()?)
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -9,7 +9,8 @@
 //!   `when`（`dep` / `os`）。既存 dst の温存はユニット属性 `preserve = true`（§5.5）。
 //!
 //! `deps` / `os` はユニット単位 gate（＝ ユニット全体に係る `when` の退化形, §5.5）。
-//! theme / hooks / secrets は後続スライスで追加する。
+//! `locals` / `sensitive` はマシンローカル値（named value）の宣言（§9）= 配置ファイルの
+//! `@@name@@` をストア値で穴埋めする対象。theme / hooks は後続スライスで追加する。
 
 use serde::Deserialize;
 use std::path::Path;
@@ -55,6 +56,15 @@ pub struct Manifest {
     /// 各 overlay は `src` / `cmd` のどちらか ＋ `when?` を持つ。
     #[serde(default)]
     pub overlay: Vec<Overlay>,
+    /// マシンローカル値（named value）の宣言（§9）。ここに挙げた名前は、配置ファイル中の
+    /// `@@name@@` プレースホルダがストア（`~/.config/dotfiles/local.toml`）の値で置換される。
+    /// 宣言の無いユニットは置換対象外（無関係ファイルの `@@…@@` を巻き込まない）。
+    #[serde(default)]
+    pub locals: Vec<String>,
+    /// `locals` のうち秘匿値（対話取得時にエコー/ログを抑制）。`sensitive ⊆ locals` を load 時に
+    /// 検証する（typo で名前が `locals` とズレると非エコーが黙って効かない footgun を防ぐ, §9.1）。
+    #[serde(default)]
+    pub sensitive: Vec<String>,
 }
 
 /// 生成方式（断片の実体化方法）。copy / generate。`merge` は kind ではなく `strategy`（§5.5）。
@@ -130,6 +140,8 @@ impl Manifest {
     ///   構成を load 時に弾く（土台だけ再直列化する退化形に意味は無い）。
     /// - **各 overlay は `src` / `cmd` のうちちょうど 1 つ**（生成方式は択一）。2 つは一方が
     ///   黙って無視される typo、0 個は断片を実体化できない。
+    /// - **`sensitive ⊆ locals`**（§9.1）。`sensitive` に `locals` 外の名前があれば typo として
+    ///   弾く（名前がズレると非エコー/ログ抑制が黙って効かず秘匿値が漏れる footgun を防ぐ）。
     fn validate(&self) -> Result<(), String> {
         if !self.overlay.is_empty() && self.strategy.is_none() {
             return Err(
@@ -156,6 +168,11 @@ impl Manifest {
                     "overlay[{i}] は src / cmd のうちちょうど 1 つを持つ必要があります（現在 {kinds} 個）"
                 ));
             }
+        }
+        if let Some(orphan) = self.sensitive.iter().find(|s| !self.locals.contains(s)) {
+            return Err(format!(
+                "sensitive `{orphan}` が locals に宣言されていません（sensitive ⊆ locals）"
+            ));
         }
         Ok(())
     }
@@ -271,6 +288,31 @@ mod tests {
         assert!(
             err.contains("ちょうど 1 つ"),
             "0 個が検知されていない: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_sensitive_subset_of_locals() {
+        // sensitive ⊆ locals（github.token は locals にも在る）→ 正規形。
+        assert!(
+            parse(
+                "dst = \"~/x\"\nlocals = [\"git.email\", \"github.token\"]\n\
+                 sensitive = [\"github.token\"]\n",
+            )
+            .is_ok()
+        );
+        // sensitive 空・locals のみも可。
+        assert!(parse("dst = \"~/x\"\nlocals = [\"git.email\"]\n").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_sensitive_not_in_locals() {
+        // sensitive に locals 外の名前（typo）→ load 時エラー（footgun を弾く）。
+        let err = parse("dst = \"~/x\"\nlocals = [\"git.email\"]\nsensitive = [\"githb.token\"]\n")
+            .unwrap_err();
+        assert!(
+            err.contains("sensitive") && err.contains("locals"),
+            "sensitive ⊄ locals が弾かれていない: {err}"
         );
     }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,66 @@
+//! named value の対話取得（§9.1 step3）: apply が TTY のとき未設定値をその場で尋ねる。
+//!
+//! [`stdin_is_tty`] で TTY を判定し（非 TTY は呼び出し側が警告のみで継続）、[`prompt`] で 1 値を
+//! 読む。`sensitive` 指定の値はエコーを抑制する（unix は termios の `ECHO` を一時 off。非 unix は
+//! 抑制非対応のため通常読みにフォールバック）。プロンプト・改行は stdout を汚さないよう stderr へ出す。
+
+use std::io::{self, IsTerminal, Write};
+
+/// 標準入力が TTY か（対話取得が可能か）。非 TTY ではフック実行等とみなし呼び出し側が警告のみで継続する。
+pub fn stdin_is_tty() -> bool {
+    io::stdin().is_terminal()
+}
+
+/// `name` の値を 1 行読む。`sensitive` ならエコーを抑制する。末尾の改行は除去する。
+pub fn prompt(name: &str, sensitive: bool) -> io::Result<String> {
+    let hint = if sensitive {
+        "machine-local, hidden"
+    } else {
+        "machine-local"
+    };
+    eprint!("dotfiles: {name} を入力してください ({hint}): ");
+    io::stderr().flush()?;
+    let line = if sensitive {
+        read_line_no_echo()?
+    } else {
+        let mut s = String::new();
+        io::stdin().read_line(&mut s)?;
+        s
+    };
+    Ok(line.trim_end_matches(['\n', '\r']).to_string())
+}
+
+/// エコーを抑制して 1 行読む（unix: termios の `ECHO` を一時 off にして復元）。
+#[cfg(unix)]
+fn read_line_no_echo() -> io::Result<String> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = io::stdin().as_raw_fd();
+    let mut term: libc::termios = unsafe { std::mem::zeroed() };
+    if unsafe { libc::tcgetattr(fd, &mut term) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let original = term;
+    term.c_lflag &= !(libc::ECHO as libc::tcflag_t);
+    if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &term) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut s = String::new();
+    let read = io::stdin().read_line(&mut s);
+
+    // 入力中に何があっても端末設定は必ず元へ戻す。
+    unsafe { libc::tcsetattr(fd, libc::TCSANOW, &original) };
+    eprintln!(); // エコーされない改行を補い、後続出力が同じ行に続かないようにする。
+
+    read?;
+    Ok(s)
+}
+
+/// 非 unix ではエコー抑制をサポートせず通常読みにフォールバックする。
+#[cfg(not(unix))]
+fn read_line_no_echo() -> io::Result<String> {
+    let mut s = String::new();
+    io::stdin().read_line(&mut s)?;
+    Ok(s)
+}

--- a/tests/e2e/locals.rs
+++ b/tests/e2e/locals.rs
@@ -1,0 +1,177 @@
+//! `dotfiles` のマシンローカル値（named value, §9 / S4 #458）の E2E。
+//!
+//! `locals` 宣言ユニットの配置ファイルへ `@@name@@` をストア値で注入する挙動を hermetic fixture
+//! で検証する: ①ストアに値あり → 置換 ②値なし＋非 TTY（assert_cmd は非 TTY）→ 警告のみ・継続・
+//! placeholder はリテラル維持 ③`secret set` がストアを 0600 で作成し以降の apply が置換 ④`doctor`
+//! が未設定/設定済みを診断 ⑤`sensitive ⊄ locals` を load 時に弾く。値は決して表示しない。
+
+use crate::dotfiles;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+/// locals 宣言の copy ユニット（dst=ディレクトリ、`user` に `@@` placeholder）を書き出す。
+fn write_locals_unit(work: &Path) {
+    let unit = work.join("configs/gituser");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/git\"\nlocals = [\"git.email\", \"git.name\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        unit.join("user"),
+        "[user]\n\temail = @@git.email@@\n\tname = @@git.name@@\n",
+    )
+    .unwrap();
+}
+
+/// HOME 配下のストア（`~/.config/dotfiles/local.toml`）に内容を書く。
+fn write_store(home: &Path, body: &str) {
+    let dir = home.join(".config/dotfiles");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("local.toml"), body).unwrap();
+}
+
+/// ①ストアに値があれば、配置ファイルの `@@name@@` がその値で置換される。
+#[test]
+fn apply_substitutes_locals_from_store() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_locals_unit(work.path());
+    write_store(home.path(), "[git]\nemail = \"me@x\"\nname = \"Me\"\n");
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(home.path().join(".config/git/user")).unwrap();
+    assert!(
+        out.contains("email = me@x"),
+        "ストア値が置換されるべき:\n{out}"
+    );
+    assert!(
+        out.contains("name = Me"),
+        "ストア値が置換されるべき:\n{out}"
+    );
+    assert!(
+        !out.contains("@@"),
+        "全 placeholder が解決され @@ が残らないべき:\n{out}"
+    );
+}
+
+/// ②値なし＋非 TTY: apply は成功（ブロックしない）し警告を出す。placeholder はリテラルで残る。
+#[test]
+fn apply_non_tty_warns_and_keeps_placeholder_literal() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_locals_unit(work.path()); // ストアは作らない。
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("未設定"))
+        .stderr(predicate::str::contains("git.email"));
+
+    let out = fs::read_to_string(home.path().join(".config/git/user")).unwrap();
+    assert!(
+        out.contains("@@git.email@@") && out.contains("@@git.name@@"),
+        "未解決 placeholder はリテラルのまま残るべき（空置換しない）:\n{out}"
+    );
+}
+
+/// ③`secret set` がストアを 0600 で作成し、続く apply が置換する。値は表示されない。
+#[cfg(unix)]
+#[test]
+fn secret_set_writes_store_0600_then_apply_substitutes() {
+    use std::os::unix::fs::PermissionsExt;
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_locals_unit(work.path());
+
+    dotfiles()
+        .args(["secret", "set", "git.email", "me@x"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git.email"))
+        .stdout(predicate::str::contains("me@x").not()); // 値は出さない。
+
+    let store = home.path().join(".config/dotfiles/local.toml");
+    let mode = fs::metadata(&store).unwrap().permissions().mode();
+    assert_eq!(mode & 0o777, 0o600, "ストアは 0600 であるべき");
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let out = fs::read_to_string(home.path().join(".config/git/user")).unwrap();
+    assert!(
+        out.contains("email = me@x"),
+        "secret set 値で置換されるべき:\n{out}"
+    );
+    // git.name は未設定なので placeholder のまま。
+    assert!(
+        out.contains("@@git.name@@"),
+        "未設定値は placeholder のまま:\n{out}"
+    );
+}
+
+/// ④`doctor` が未設定 locals を警告し、設定後は設定済みを報告する。
+#[test]
+fn doctor_reports_unset_then_set() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_locals_unit(work.path());
+
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("未設定"))
+        .stdout(predicate::str::contains("git.email"));
+
+    write_store(home.path(), "[git]\nemail = \"me@x\"\nname = \"Me\"\n");
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("すべて設定済み"));
+}
+
+/// ⑤`sensitive ⊄ locals` の manifest は load 時に弾く（typo の footgun を防ぐ）。
+#[test]
+fn apply_errors_on_sensitive_not_in_locals() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/bad");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/bad\"\nlocals = [\"git.email\"]\nsensitive = [\"git.token\"]\n",
+    )
+    .unwrap();
+    fs::write(unit.join("f"), "x\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("sensitive"));
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -14,6 +14,7 @@
 //! - [`generate`]: generate 層（S2/#456）— cmd 実行・deps gate・sibling 連結・list 表示
 //! - [`overlay`]: 合成軸（S3/#471）— overlay/strategy/when/preserve と load 時検証群
 //! - [`claude_settings`]: claude/settings 実 config（S3/#457）の結線確認
+//! - [`locals`]: マシンローカル値（S4/#458）— ストア注入・非 TTY 警告・secret set・doctor
 
 use assert_cmd::Command;
 
@@ -22,6 +23,7 @@ mod claude_settings;
 mod cli;
 mod generate;
 mod list;
+mod locals;
 mod overlay;
 
 /// 実バイナリ `dotfiles` を起動する Command を返す（全テスト共通）。


### PR DESCRIPTION
## 概要

S4 secrets（#458）。git user 等のマシン固有値を、単一の汎用ストアから**名前付きで注入**する機構へ再設計する（設計書 §9・改訂 PR #479）。env `DOTFILES_GIT_*` 注入は廃止。本スライスは **① named value（事前宣言した名前の穴埋め）** のみ対象（② 任意ローカル設定の拡張口は #467）。

## 受け入れ条件

- [x] manifest `locals` 属性を解釈（＋`sensitive`。**`sensitive ⊆ locals` を load 時検証**）
- [x] 単一ストア `~/.config/dotfiles/local.toml`（0600・dotfiles 非管理）の読み書き
- [x] 配置ファイルへ `@@name@@` 置換でストア値を注入（生成方式 `copy`/`generate` を問わず、`locals` 宣言 unit のみ対象）
- [x] apply: 未設定値を TTY なら対話取得（sensitive は非エコー）、非 TTY は警告のみで継続（ブロックしない）
- [x] `dotfiles secret set <name> <value>`（コマンド名は仮称・§14）
- [x] `env "DOTFILES_GIT_EMAIL/NAME"` 注入と `user.tmpl` の if 分岐を廃止
- [x] `dotfiles doctor`（雛形）が `locals` 未設定を警告
- [x] E2E: 値の有/無での注入と doctor 警告を検証

## 実装

### 機構（`src/`）

- **manifest**: `locals` / `sensitive` 属性。`validate()` で `sensitive ⊆ locals` を検証（typo で非エコー/ログ抑制が黙って効かない footgun を防ぐ）。
- **local_store**: 単一ストアの read/write。ファイル上はネスト TOML（`[git] email=".."`）、内部はドット区切りキーで相互変換。ファイル 0600・親 dir 0700。**値は決して表示しない**。
- **inject**: `locals` 宣言 unit の配置ファイルへ `@@name@@` を置換（バイト列・全 occurrence）。**未解決はリテラルのまま残す**（空置換せず doctor が拾える）。宣言の無い unit には走らない。
- **prompt**: TTY 判定（`IsTerminal`）と対話取得。sensitive は termios の `ECHO` を一時 off（unix。新規 crate 追加なし＝既存 workspace dep の `libc`）。
- **apply**: 配置後、`locals` 宣言 unit で値を解決（ストア → TTY 対話して 0600 で保存 → 非 TTY は警告のみで継続）し inject。`copy` / `compose` の `place` は配置ファイル群を返すよう変更。
- **main**: `secret set` / `doctor` サブコマンド。doctor は全 unit の locals を集約しストア照合で set/unset を診断（雛形・exit 0）。

### git 消費側の移行（bounded）

git 設定の全面移行は本スライスでは行わない（`alias` の `${DOTFILES}` 自己参照・`delta` の theme follower=S6/S7・hooks=§14 を巻き込むため）。**user identity だけを切り出し**、chezmoi の git config から git native `[include]`（§13 の「共有断片の組み立て」用途）で取り込む。値注入は include ではなく `@@name@@` 置換なので §9 と整合する。

- `configs/git/`（`manifest.toml` + `user`）に `locals=["git.email","git.name"]` を宣言。
- `home/dot_config/git/config.tmpl`: `includeTemplate user.tmpl` → native `[include] path = ~/.config/git/user`。
- `home/dot_config/git/configs/user.tmpl` 削除（env 注入廃止）。
- `home/dot_config/mise/create_config.toml`: `DOTFILES_GIT_*` 例コメントを `secret set` 案内へ更新。

## 検証

- `cargo test --workspace` … 208 passed（`tests/e2e/locals.rs` ＋ local_store/inject/manifest のユニット）。
- `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` … clean。
- `mise run check` … clean（taplo / chezmoi 含む）。
- 実 `configs/` smoke: `list` に `git → ~/.config/git [copy, locals=git.email+git.name]`、`doctor` 未設定→`secret set`→設定済み、ストア 0600、実 `configs/git/` の apply で email/name 置換、`chezmoi cat ~/.config/git/config` が native `[include]` をレンダリング・`DOTFILES_GIT` 0 件 を目視確認。

## 留保 / 後続

- TTY 対話 prompt の自動 E2E は困難（assert_cmd が非 TTY）→ 非 TTY 警告経路を E2E、TTY 経路は手動 smoke。
- git 設定の残り（alias/core/delta…）と hooks の移行は別スライス（S6/S7・§14）。
- create-only（mise）は #467。`secret` → `local` 改名は §14 で確定。

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
