### PR TITLE
refactor(dotfiles): force-push guard を Claude PreToolUse に一本化 [#473]

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,12 @@ exec $SHELL -l
 
 On macOS, `chezmoi apply` runs a hook that symlinks Ghostty’s expected config path to `~/.config/ghostty/config`. If you use Ghostty, install it separately (see [Optional Tools](#optional-tools)). Ghostty works well as the terminal for a Fish-centric setup.
 
-## Git hooks (gitleaks, force-push guard)
+## Git hooks (gitleaks)
 
-Git is configured with a global `core.hooksPath = ~/.config/git/hooks`, so the managed hooks run for **every** repository on the host. A single dispatcher script (`dispatch`) is symlinked under every client-side hook name (`pre-commit`, `commit-msg`, `prepare-commit-msg`, `pre-push`, `post-checkout`, `post-merge`, `post-commit`, `pre-rebase`, `pre-merge-commit`, `post-rewrite`, `applypatch-msg`, `pre-applypatch`, `post-applypatch`) and dispatches on `basename "$0"` (`dispatch` itself is not a hook name, so Git never runs it directly). It does three things:
+Git is configured with a global `core.hooksPath = ~/.config/git/hooks`, so the managed hooks run for **every** repository on the host. A single dispatcher script (`dispatch`) is symlinked under every client-side hook name (`pre-commit`, `commit-msg`, `prepare-commit-msg`, `pre-push`, `post-checkout`, `post-merge`, `post-commit`, `pre-rebase`, `pre-merge-commit`, `post-rewrite`, `applypatch-msg`, `pre-applypatch`, `post-applypatch`) and dispatches on `basename "$0"` (`dispatch` itself is not a hook name, so Git never runs it directly). It does two things:
 
 1. **Secret scan (pre-commit only)** — runs `gitleaks git --staged` on the staged diff. If a likely secret is found, the commit is **blocked**; secret values are redacted in the output. False positives can be silenced with a `.gitleaks.toml` allowlist or an inline `gitleaks:allow` comment. If `gitleaks` is not installed, the scan is **skipped with a warning** (the commit is not blocked).
-2. **Force-push / non-fast-forward guard (pre-push only)** — **blocks** any push that rewrites already-published history (a non-fast-forward ref update — what `--force` / `--force-with-lease` pushes through). Fast-forwards, new branches, and branch deletions are allowed; a re-pointed tag counts as non-fast-forward and is blocked. Because pre-push cannot distinguish a force-push from a *forgot-to-pull* push, the message is dual-purpose (pull/rebase **or** stop and defer to a human). Shallow clones that cannot resolve ancestry are **not** blocked (left to Git's own non-ff rejection). A human can bypass with `git push --no-verify`; an automated agent must not.
-3. **Chaining (all hook types)** — because a global `core.hooksPath` makes Git stop looking at each repo's `.git/hooks`, the dispatcher explicitly invokes the repository-local `.git/hooks/<hook>` afterwards (if present and executable), forwarding arguments and stdin, so per-project hooks keep working.
+2. **Chaining (all hook types)** — because a global `core.hooksPath` makes Git stop looking at each repo's `.git/hooks`, the dispatcher explicitly invokes the repository-local `.git/hooks/<hook>` afterwards (if present and executable), forwarding arguments and stdin, so per-project hooks keep working.
 
 Bypass everything for a single commit with `git commit --no-verify`.
 
@@ -143,12 +142,12 @@ Bypass everything for a single commit with `git commit --no-verify`.
 
 `~/.claude/settings.json` is managed by a chezmoi `modify_` script (`home/dot_claude/modify_settings.json.tmpl`). It merges the live file so keys the app writes itself (`model`, `theme`, `effortLevel`, …) are preserved, while dotfiles-owned shared settings (`hooks`, `statusLine`, `language`, `voiceEnabled`) are always enforced. The `rtk` token-proxy hook is included only when `rtk` is on `PATH`.
 
-Deleting files is steered to `trash` (move to the macOS Trash, recoverable) by two layers:
+`PreToolUse` / `Bash` hooks provide two safety rails:
 
-- **Primary — a standing instruction** (`~/.claude/rules/use-trash-not-rm.md`, auto-loaded by Claude Code). It tells Claude to delete via `trash` rather than `rm`. Being intent-based, it has no false positives and also covers other irreversible deletions the hook can't (`xargs rm`, `find … -delete`, `unlink`). This is the main mechanism.
-- **Backstop — a `PreToolUse` / `Bash` hook** that **denies** any command invoking `rm` and tells Claude to use `trash` instead, catching the rare case where the instruction is forgotten. Its regex is deliberately **simple**: it matches `rm` at command position only — at the start, right after a separator (`a && rm b`, `foo; rm bar`), or inside `$(rm x)`. `git rm` and substrings (`charm`, `/var/rm-cache`) are not matched.
+- **`rm` guard** — denies commands invoking `rm` and tells Claude to use `trash` instead. This keeps file deletion recoverable by default.
+- **force-push guard** — denies `git push` commands that include `--force`, `-f`, `--force-with-lease`, or `--no-verify` so history rewrites and hook bypasses are blocked before execution.
 
-Requires the `trash` CLI (bundled with macOS 15+). Because the hook is only a backstop (the instruction does the real work and fires first), its regex is kept minimal rather than exhaustive — wrapper / absolute-path forms (`sudo rm`, `/bin/rm`, `command rm`, `xargs rm`) are intentionally **left to the instruction**, not the hook. One quirk to know: since the hook inspects the command string, a command that merely *contains* the text `rm` at command position (e.g. inside a `gh` / `git` argument) is over-blocked — pass such content through a file.
+Requires the `trash` CLI (bundled with macOS 15+). Both guards are intentionally string-based and simple: they are meant as practical pre-execution safety rails, not full shell parsers.
 
 ## Platform-Specific Notes
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,13 @@ exec $SHELL -l
 
 On macOS, `chezmoi apply` runs a hook that symlinks Ghostty’s expected config path to `~/.config/ghostty/config`. If you use Ghostty, install it separately (see [Optional Tools](#optional-tools)). Ghostty works well as the terminal for a Fish-centric setup.
 
-## Git hooks (gitleaks)
+## Git hooks (gitleaks, force-push guard)
 
-Git is configured with a global `core.hooksPath = ~/.config/git/hooks`, so the managed hooks run for **every** repository on the host. A single dispatcher script (`dispatch`) is symlinked under every client-side hook name (`pre-commit`, `commit-msg`, `prepare-commit-msg`, `pre-push`, `post-checkout`, `post-merge`, `post-commit`, `pre-rebase`, `pre-merge-commit`, `post-rewrite`, `applypatch-msg`, `pre-applypatch`, `post-applypatch`) and dispatches on `basename "$0"` (`dispatch` itself is not a hook name, so Git never runs it directly). It does two things:
+Git is configured with a global `core.hooksPath = ~/.config/git/hooks`, so the managed hooks run for **every** repository on the host. A single dispatcher script (`dispatch`) is symlinked under every client-side hook name (`pre-commit`, `commit-msg`, `prepare-commit-msg`, `pre-push`, `post-checkout`, `post-merge`, `post-commit`, `pre-rebase`, `pre-merge-commit`, `post-rewrite`, `applypatch-msg`, `pre-applypatch`, `post-applypatch`) and dispatches on `basename "$0"` (`dispatch` itself is not a hook name, so Git never runs it directly). It does three things:
 
 1. **Secret scan (pre-commit only)** — runs `gitleaks git --staged` on the staged diff. If a likely secret is found, the commit is **blocked**; secret values are redacted in the output. False positives can be silenced with a `.gitleaks.toml` allowlist or an inline `gitleaks:allow` comment. If `gitleaks` is not installed, the scan is **skipped with a warning** (the commit is not blocked).
-2. **Chaining (all hook types)** — because a global `core.hooksPath` makes Git stop looking at each repo's `.git/hooks`, the dispatcher explicitly invokes the repository-local `.git/hooks/<hook>` afterwards (if present and executable), forwarding arguments and stdin, so per-project hooks keep working.
+2. **Force-push / non-fast-forward guard (pre-push only)** — **blocks** any push that rewrites already-published history (a non-fast-forward ref update — what `--force` / `--force-with-lease` pushes through). Fast-forwards, new branches, and branch deletions are allowed; a re-pointed tag counts as non-fast-forward and is blocked. Because pre-push cannot distinguish a force-push from a *forgot-to-pull* push, the message is dual-purpose (pull/rebase **or** stop and defer to a human). Shallow clones that cannot resolve ancestry are **not** blocked (left to Git's own non-ff rejection). A human can bypass with `git push --no-verify`; an automated agent must not.
+3. **Chaining (all hook types)** — because a global `core.hooksPath` makes Git stop looking at each repo's `.git/hooks`, the dispatcher explicitly invokes the repository-local `.git/hooks/<hook>` afterwards (if present and executable), forwarding arguments and stdin, so per-project hooks keep working.
 
 Bypass everything for a single commit with `git commit --no-verify`.
 

--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -3,7 +3,9 @@
 # 温存しつつ、dotfiles 由来の共有設定（hooks/statusLine/language/voiceEnabled）を
 # 強制上書きする。chezmoi が既存ファイル内容を stdin で渡し、stdout を新しい内容として書き込む。
 #
-# 強制設定のうち PreToolUse/Bash には "rm→trash ガード" を含む。rm を deny し trash 利用を促す。
+# 強制設定のうち PreToolUse/Bash には2本のガードを含む。①"rm→trash ガード": rm を deny し
+# trash 利用を促す。②"force-push ガード": `git push` の --force/-f/--force-with-lease/--no-verify
+# を deny し履歴書き換えを止める（メッセージは環境非依存）。どちらも主役は行動側で本フックは保険。
 # 主役は意図ベースの指示（rules/use-trash-not-rm.md）で、本フックは「指示を忘れた時の保険」。
 # 保険なので regex は素朴に保つ: コマンド先頭/区切り直後・$() 内の rm のみ検知する。
 # sudo/絶対パス/command 経由・xargs rm 等は意図的に拾わない（指示側がカバー）。git rm や

--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -5,8 +5,8 @@
 #
 # 強制設定のうち PreToolUse/Bash には2本のガードを含む。①"rm→trash ガード": rm を deny し
 # trash 利用を促す。②"force-push ガード": `git push` の --force/-f/--force-with-lease/--no-verify
-# を deny し履歴書き換えを止める（メッセージは環境非依存）。どちらも主役は行動側で本フックは保険。
-# 主役は意図ベースの指示（rules/use-trash-not-rm.md）で、本フックは「指示を忘れた時の保険」。
+# を deny し履歴書き換えと検査バイパスを止める。どちらも主役は行動側で本フックは保険。
+# 主役は意図ベースの指示（rules/use-trash-not-rm.md など）で、本フックは「指示を忘れた時の保険」。
 # 保険なので regex は素朴に保つ: コマンド先頭/区切り直後・$() 内の rm のみ検知する。
 # sudo/絶対パス/command 経由・xargs rm 等は意図的に拾わない（指示側がカバー）。git rm や
 # rm 部分一致（charm 等）は非該当。rm を文字列に含むだけのコマンドも弾く点に注意（回避＝
@@ -58,7 +58,7 @@ forced_json="$(cat <<'JSON'
           },
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE 'git([[:space:]]|$)' && printf '%s' \"$cmd\" | grep -qE 'push' && printf '%s' \"$cmd\" | grep -qE '(--force|(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--no-verify)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Force-push is forbidden in this environment. Do NOT run git push with --force / -f / --force-with-lease, and do NOT use --no-verify to bypass the pre-push guard. This is not a simple mistake to route around: rewriting already-published history irreversibly destroys shared state (other developers fetches/derived work, review anchors, stacked-PR rebase discipline). To resolve conflicts or update a branch, merge the base (git merge origin/main) or run git pull --rebase, then push normally as a fast-forward. To remove code from the final state, make a normal delete commit, which is different from deleting commits from history. If history truly must be rewritten, STOP and surface the situation to the user; the decision to proceed belongs to the user alone. An automated agent must never force-push or bypass this guard, even when explicitly instructed.\"}}'; fi",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE 'git([[:space:]]|$)' && printf '%s' \"$cmd\" | grep -qE 'push' && printf '%s' \"$cmd\" | grep -qE '(--force|(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--no-verify)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Force-push is forbidden in this environment. Do NOT run git push with --force / -f / --force-with-lease, and do NOT use --no-verify. This is not a simple mistake to route around: rewriting already-published history irreversibly destroys shared state (other developers fetches/derived work, review anchors, stacked-PR rebase discipline). To resolve conflicts or update a branch, merge the base (git merge origin/main) or run git pull --rebase, then push normally as a fast-forward. To remove code from the final state, make a normal delete commit, which is different from deleting commits from history. If history truly must be rewritten, STOP and surface the situation to the user; the decision to proceed belongs to the user alone. An automated agent must never force-push or bypass this guard, even when explicitly instructed.\"}}'; fi",
             "statusMessage": "force-push guard"
           }
         ]

--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -53,6 +53,11 @@ forced_json="$(cat <<'JSON'
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE '(^|[;&|()])[[:space:]]*rm([[:space:]]|$)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Do not use rm. Use trash (moves to the macOS Trash) instead, e.g. `trash <file/dir>`. trash handles directories as-is; no -r/-f needed. Only ask the user before permanently deleting if it is truly required.\"}}'; fi",
             "statusMessage": "rm guard (trash)"
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE 'git([[:space:]]|$)' && printf '%s' \"$cmd\" | grep -qE 'push' && printf '%s' \"$cmd\" | grep -qE '(--force|(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--no-verify)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Force-push is forbidden in this environment. Do NOT run git push with --force / -f / --force-with-lease, and do NOT use --no-verify to bypass the pre-push guard. This is not a simple mistake to route around: rewriting already-published history irreversibly destroys shared state (other developers fetches/derived work, review anchors, stacked-PR rebase discipline). To resolve conflicts or update a branch, merge the base (git merge origin/main) or run git pull --rebase, then push normally as a fast-forward. To remove code from the final state, make a normal delete commit, which is different from deleting commits from history. If history truly must be rewritten, STOP and surface the situation to the user; the decision to proceed belongs to the user alone. An automated agent must never force-push or bypass this guard, even when explicitly instructed.\"}}'; fi",
+            "statusMessage": "force-push guard"
           }
         ]
       }

--- a/home/dot_config/git/hooks/executable_dispatch
+++ b/home/dot_config/git/hooks/executable_dispatch
@@ -9,7 +9,10 @@
 #
 # 役割:
 #   1. pre-commit のときだけ、ステージ済み差分を gitleaks で検査する。
-#   2. すべての hook 種別で、リポジトリ固有の .git/hooks/<hook名> があれば引数と
+#   2. pre-push のときだけ、非 fast-forward（force-push が通す履歴書き換え）をブロック
+#      する。force と「pull 忘れの通常 push」は pre-push では判別不能なので両義メッセージ
+#      を出す。万能バックストップ（Claude 以外の人手/スクリプトも捕捉）。
+#   3. すべての hook 種別で、リポジトリ固有の .git/hooks/<hook名> があれば引数と
 #      stdin をそのまま渡してチェイン実行する（グローバル hooksPath で握り潰され
 #      る repo ローカル hook を実質復活させる）。
 set -euo pipefail
@@ -34,7 +37,54 @@ if [ "$hook_name" = "pre-commit" ]; then
   fi
 fi
 
-# --- 2. リポジトリ固有 hook へのチェイン（全 hook 種別） ----------------------
+# --- 2. force-push / 非 fast-forward ガード（pre-push のみ） -------------------
+# git は pre-push の stdin に「<local ref> <local oid> <remote ref> <remote oid>」を 1 行
+# ずつ渡す。remote oid は接続して得たライブのリモート先端（古いローカル追跡 ref ではない）。
+# remote が local の祖先でなければ非 ff＝履歴書き換え（force が通すもの）でブロックする。
+# pre-push は --force フラグを受け取らないため「force」か「pull 忘れの通常 push」かは判別
+# 不能。両者とも非 ff でブロックが正しいので、メッセージを両義にして読み手に分岐させる。
+# stdin はここで消費するため、後段のチェイン（section 3）へ再供給できるようバッファする。
+push_stdin=""
+if [ "$hook_name" = "pre-push" ]; then
+  push_stdin="$(cat)"
+  nonff=0
+  while read -r _lref loid _rref roid; do
+    [ -z "${loid:-}" ] && continue
+    [ -z "${roid:-}" ] && continue
+    # local oid が全 0＝ブランチ削除、remote oid が全 0＝新規ブランチ。どちらも非 ff ではない。
+    [[ "$loid" =~ ^0+$ ]] && continue
+    [[ "$roid" =~ ^0+$ ]] && continue
+    if ! git merge-base --is-ancestor "$roid" "$loid" 2>/dev/null; then
+      nonff=1
+    fi
+  done <<<"$push_stdin"
+
+  if [ "$nonff" -eq 1 ]; then
+    cat >&2 <<'MSG'
+✖ pre-push 中止: 非 fast-forward（リモート先端を含まない）push を検出しました。
+
+[STOP — read before retrying]
+This push does NOT contain the current remote tip as an ancestor (non-fast-forward).
+Two situations land here — pick the one that applies:
+
+(1) You just forgot to pull (the remote moved ahead).
+    -> Integrate first: `git pull --rebase` (or merge origin/<branch>), then push normally.
+    -> Do NOT add --force to "make it go through."
+
+(2) You intended to rewrite already-published history (force-push).
+    -> Forbidden here. Not a "simple mistake" — it irreversibly destroys shared state
+       (others' fetches/derived work, review anchors, stacked-PR rebase discipline).
+    -> An automated agent must NEVER force-push, even when instructed. Stop and surface
+       the situation to the user; the decision to proceed is the user's alone.
+
+Do NOT bypass this guard with --no-verify; overriding it is a conscious human decision,
+never an automated one.
+MSG
+    exit 1
+  fi
+fi
+
+# --- 3. リポジトリ固有 hook へのチェイン（全 hook 種別） ----------------------
 # repo ローカル hook の場所を解決する。
 #   - `git rev-parse --git-path hooks` は core.hooksPath 設定下でグローバル dir
 #     （＝自分自身）を返すため使えない。
@@ -48,6 +98,11 @@ if [ -x "$local_hook" ]; then
   # 自分自身（このディスパッチャ）を指していたら無限再帰になるので除外する。
   self="$(realpath "${BASH_SOURCE[0]}")"
   if [ "$(realpath "$local_hook")" != "$self" ]; then
-    exec "$local_hook" "$@"
+    if [ "$hook_name" = "pre-push" ]; then
+      # section 2 で stdin を消費済みなので、バッファした ref 行を再供給する。
+      exec "$local_hook" "$@" <<<"$push_stdin"
+    else
+      exec "$local_hook" "$@"
+    fi
   fi
 fi

--- a/home/dot_config/git/hooks/executable_dispatch
+++ b/home/dot_config/git/hooks/executable_dispatch
@@ -9,10 +9,7 @@
 #
 # 役割:
 #   1. pre-commit のときだけ、ステージ済み差分を gitleaks で検査する。
-#   2. pre-push のときだけ、非 fast-forward（force-push が通す履歴書き換え）をブロック
-#      する。force と「pull 忘れの通常 push」は pre-push では判別不能なので両義メッセージ
-#      を出す。万能バックストップ（Claude 以外の人手/スクリプトも捕捉）。
-#   3. すべての hook 種別で、リポジトリ固有の .git/hooks/<hook名> があれば引数と
+#   2. すべての hook 種別で、リポジトリ固有の .git/hooks/<hook名> があれば引数と
 #      stdin をそのまま渡してチェイン実行する（グローバル hooksPath で握り潰され
 #      る repo ローカル hook を実質復活させる）。
 set -euo pipefail
@@ -37,69 +34,7 @@ if [ "$hook_name" = "pre-commit" ]; then
   fi
 fi
 
-# --- 2. force-push / 非 fast-forward ガード（pre-push のみ） -------------------
-# git は pre-push の stdin に「<local ref> <local oid> <remote ref> <remote oid>」を 1 行
-# ずつ渡す。remote oid は接続して得たライブのリモート先端（古いローカル追跡 ref ではない）。
-# remote が local の祖先でなければ非 ff＝履歴書き換え（force が通すもの）でブロックする。
-# pre-push は --force フラグを受け取らないため「force」か「pull 忘れの通常 push」かは判別
-# 不能。両者とも非 ff でブロックが正しいので、メッセージを両義にして読み手に分岐させる。
-# stdin はここで消費するため、後段のチェイン（section 3）へ再供給できるようバッファする。
-push_stdin=""
-if [ "$hook_name" = "pre-push" ]; then
-  push_stdin="$(cat)"
-  nonff=0
-  # shallow clone は祖先を完全に辿れず is-ancestor がエラーになり得る。後段で「解決不能」を
-  # 非 ff と誤判定して正当な ff push を誤ブロックしないよう、shallow か一度だけ判定しておく。
-  is_shallow=false
-  [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ] && is_shallow=true
-  while read -r _lref loid _rref roid; do
-    [ -z "${loid:-}" ] && continue
-    [ -z "${roid:-}" ] && continue
-    # local oid が全 0＝ブランチ削除、remote oid が全 0＝新規ブランチ。どちらも非 ff ではない。
-    [[ "$loid" =~ ^0+$ ]] && continue
-    [[ "$roid" =~ ^0+$ ]] && continue
-    # is-ancestor: 0=祖先(ff) / 1=祖先でない(非ff確定) / それ以外=解決不能(エラー)。
-    # set -e 下で終了コードを失わないよう rc を先に 0 にして || で捕捉する。
-    rc=0
-    git merge-base --is-ancestor "$roid" "$loid" 2>/dev/null || rc=$?
-    if [ "$rc" -eq 0 ]; then
-      : # remote 先端は local の祖先＝fast-forward。許可。
-    elif [ "$rc" -eq 1 ]; then
-      nonff=1 # 祖先でないと確定＝非 ff（force が通す履歴書き換え）。
-    elif [ "$is_shallow" = true ]; then
-      : # shallow で祖先を解決できない。誤ブロックを避け許可し、git 本来の非 ff 判定に委ねる。
-    else
-      # full repo で remote oid が解決不能＝local から到達不能＝非 ff 確定（祖先なら手元に在るはず）。
-      nonff=1
-    fi
-  done <<<"$push_stdin"
-
-  if [ "$nonff" -eq 1 ]; then
-    cat >&2 <<'MSG'
-✖ pre-push 中止: 非 fast-forward（リモート先端を含まない）push を検出しました。
-
-[STOP — read before retrying]
-This push does NOT contain the current remote tip as an ancestor (non-fast-forward).
-Two situations land here — pick the one that applies:
-
-(1) You just forgot to pull (the remote moved ahead).
-    -> Integrate first: `git pull --rebase` (or merge origin/<branch>), then push normally.
-    -> Do NOT add --force to "make it go through."
-
-(2) You intended to rewrite already-published history (force-push).
-    -> Forbidden here. Not a "simple mistake" — it irreversibly destroys shared state
-       (others' fetches/derived work, review anchors, stacked-PR rebase discipline).
-    -> An automated agent must NEVER force-push, even when instructed. Stop and surface
-       the situation to the user; the decision to proceed is the user's alone.
-
-Do NOT bypass this guard with --no-verify; overriding it is a conscious human decision,
-never an automated one.
-MSG
-    exit 1
-  fi
-fi
-
-# --- 3. リポジトリ固有 hook へのチェイン（全 hook 種別） ----------------------
+# --- 2. リポジトリ固有 hook へのチェイン（全 hook 種別） ----------------------
 # repo ローカル hook の場所を解決する。
 #   - `git rev-parse --git-path hooks` は core.hooksPath 設定下でグローバル dir
 #     （＝自分自身）を返すため使えない。
@@ -113,11 +48,6 @@ if [ -x "$local_hook" ]; then
   # 自分自身（このディスパッチャ）を指していたら無限再帰になるので除外する。
   self="$(realpath "${BASH_SOURCE[0]}")"
   if [ "$(realpath "$local_hook")" != "$self" ]; then
-    if [ "$hook_name" = "pre-push" ]; then
-      # section 2 で stdin を消費済みなので、バッファした ref 行を再供給する。
-      exec "$local_hook" "$@" <<<"$push_stdin"
-    else
-      exec "$local_hook" "$@"
-    fi
+    exec "$local_hook" "$@"
   fi
 fi

--- a/home/dot_config/git/hooks/executable_dispatch
+++ b/home/dot_config/git/hooks/executable_dispatch
@@ -48,13 +48,28 @@ push_stdin=""
 if [ "$hook_name" = "pre-push" ]; then
   push_stdin="$(cat)"
   nonff=0
+  # shallow clone は祖先を完全に辿れず is-ancestor がエラーになり得る。後段で「解決不能」を
+  # 非 ff と誤判定して正当な ff push を誤ブロックしないよう、shallow か一度だけ判定しておく。
+  is_shallow=false
+  [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ] && is_shallow=true
   while read -r _lref loid _rref roid; do
     [ -z "${loid:-}" ] && continue
     [ -z "${roid:-}" ] && continue
     # local oid が全 0＝ブランチ削除、remote oid が全 0＝新規ブランチ。どちらも非 ff ではない。
     [[ "$loid" =~ ^0+$ ]] && continue
     [[ "$roid" =~ ^0+$ ]] && continue
-    if ! git merge-base --is-ancestor "$roid" "$loid" 2>/dev/null; then
+    # is-ancestor: 0=祖先(ff) / 1=祖先でない(非ff確定) / それ以外=解決不能(エラー)。
+    # set -e 下で終了コードを失わないよう rc を先に 0 にして || で捕捉する。
+    rc=0
+    git merge-base --is-ancestor "$roid" "$loid" 2>/dev/null || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      : # remote 先端は local の祖先＝fast-forward。許可。
+    elif [ "$rc" -eq 1 ]; then
+      nonff=1 # 祖先でないと確定＝非 ff（force が通す履歴書き換え）。
+    elif [ "$is_shallow" = true ]; then
+      : # shallow で祖先を解決できない。誤ブロックを避け許可し、git 本来の非 ff 判定に委ねる。
+    else
+      # full repo で remote oid が解決不能＝local から到達不能＝非 ff 確定（祖先なら手元に在るはず）。
       nonff=1
     fi
   done <<<"$push_stdin"


### PR DESCRIPTION
## 背景

#473 のガード方針を見直し、運用コストの高かった Git hook 側の複雑な判定を外して、Claude の `PreToolUse` 設定に責務を集約する。

## 変更方針

- **採用**: Claude `PreToolUse` (`Bash`) で `git push` の `--force` / `-f` / `--force-with-lease` / `--no-verify` を deny
- **見送り**: グローバル `pre-push` hook の non-fast-forward 判定と両義メッセージ
- **意図**: まずは実行直前の明示的なコマンド検知で確実に止め、PreToolUse で防げないケースが出たらその時点で hook を再検討する

## 実装

- `home/dot_claude/modify_settings.json.tmpl`
  - force-push guard の説明と deny メッセージを `PreToolUse` 一本化の方針に更新
- `home/dot_config/git/hooks/executable_dispatch`
  - 追加していた `pre-push` 非 fast-forward ガードを削除
  - gitleaks + repo-local hook chain の最小責務へ戻す
- `README.md`
  - Git hooks 節から force-push guard の説明を削除
  - Claude Code 節で `PreToolUse` の safety rail（`rm` / force-push）として明記

## 検証

- `bash -n home/dot_config/git/hooks/executable_dispatch`
- `bash -n home/dot_claude/modify_settings.json.tmpl`
- `mise run check`

Refs #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)