### PR TITLE
feat(dotfiles): マシンローカル値 named value 機構を実装 [S4 #458]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ version = "0.69.4"
 dependencies = [
  "assert_cmd",
  "clap",
+ "libc",
  "predicates",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap       = { workspace = true }
 libc       = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
+tempfile   = { workspace = true }
 toml       = { workspace = true }
 
 [lints]
@@ -26,7 +27,6 @@ workspace = true
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 rstest     = { workspace = true }
-tempfile   = { workspace = true }
 
 [[test]]
 name = "e2e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version     = "0.69.4"
 
 [dependencies]
 clap       = { workspace = true }
+libc       = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 toml       = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The CLI commands form a **Cargo workspace** at the repository root. The root pac
 
 | Command | Crate | Description |
 | --- | --- | --- |
-| `dotfiles` | (root) | dotfiles core; version entry point (`dotfiles --version`) plus `apply` (place `configs/` via per-directory `manifest.toml`, copy layer) and `list` (overview of every config's destination) |
+| `dotfiles` | (root) | dotfiles core; version entry point (`dotfiles --version`) plus `apply` (place `configs/` via per-directory `manifest.toml`; resolves & injects machine-local `locals` values), `list` (overview of every config's destination), `secret set <name> <value>` (store a machine-local value in `~/.config/dotfiles/local.toml`), and `doctor` (report unset `locals`) |
 | `color` | `crates/color` | Print an ANSI color table (16 + 256 colors) |
 | `git-upstream` | `crates/git-upstream` | Merge `upstream/master` / initialize the upstream remote |
 | `gcm` | `crates/gcm` | AI-powered git commit with Conventional Commits (`claude -p`) |

--- a/configs/git/config
+++ b/configs/git/config
@@ -1,0 +1,15 @@
+# Dotfiles' git config（dotfiles ネイティブ化・設計書 §13）。
+#
+# 旧 chezmoi は config.tmpl の includeTemplate で 8 部品をビルド時に inline 連結していた。
+# dotfiles では部品を configs/ へバラのまま配置し、ここで git native [include] で実行時に束ねる
+# （「ファイル合成 → git native [include]（copy へ降格）」§13）。include の相対パスは本ファイルの
+# あるディレクトリ（~/.config/git）基準で解決される。順序は同名キー後勝ちに効くため旧構成を踏襲。
+[include]
+	path = configs/alias
+	path = configs/core
+	path = configs/delta
+	path = configs/fast_forward
+	path = configs/ghq
+	path = configs/push
+	path = configs/user
+	path = configs/vimdiff

--- a/configs/git/configs/alias
+++ b/configs/git/configs/alias
@@ -1,0 +1,23 @@
+[alias]
+  # Alias Management ===================================
+  alias = !"cat \"$HOME/.config/git/configs/alias\" | grep -v '^\\[' | sed 's/^  //'"
+
+  # Diff (PR base, side-by-side) =======================
+  diff-base = diff-base-helper
+  d-base = diff-base
+
+  d-s = -c delta.side-by-side=true diff
+  ds-s = -c delta.side-by-side=true diff --staged
+  diff-base-s = diff-base-helper -c delta.side-by-side=true
+  d-base-s = diff-base-s
+
+  diff-base-helper = !"f() { git fetch && git \"$@\" diff $(gh pr view --json baseRefOid --jq '.baseRefOid')...HEAD; }; f"
+
+  # Branch & Switch ===================================
+  main = !git switch main && git pull
+  master = !git switch master && git pull
+
+  # GitHub PR Workflow =================================
+  merged = !"[ \"$(gh pr view --json state --jq '.state')\" = \"MERGED\" ]"
+  base = !"gh pr view --json baseRefName --jq '.baseRefName'"
+  done = !"git merged && current=$(git branch --show-current) && base=$(git base) && [ -n \"$base\" ] && git switch \"$base\" && git pull && git branch -d \"$current\" && git fetch --prune"

--- a/configs/git/configs/core
+++ b/configs/git/configs/core
@@ -1,0 +1,5 @@
+# Core options
+
+[core]
+  editor = nvim
+  hooksPath = ~/.config/git/hooks

--- a/configs/git/configs/delta
+++ b/configs/git/configs/delta
@@ -1,0 +1,30 @@
+# Delta (git-delta) configuration
+
+[core]
+  pager = delta
+
+[interactive]
+  diffFilter = delta --color-only
+
+[delta]
+  navigate = true    # use n and N to move between diff sections
+  hyperlinks = true
+  line-numbers = true
+  side-by-side = false
+
+# Theme variants chosen at runtime via the DELTA_FEATURES env var, which fish
+# keeps in sync with the terminal's light/dark appearance (see fish
+# conf.d/50-delta.fish). light = One Half Light, dark = Ayu.
+[delta "theme-light"]
+  light = true
+  syntax-theme = OneHalfLight
+
+[delta "theme-dark"]
+  dark = true
+  syntax-theme = ayu-dark
+
+[merge]
+  conflictstyle = diff3
+
+[diff]
+  colorMoved = dimmed-zebra

--- a/configs/git/configs/fast_forward
+++ b/configs/git/configs/fast_forward
@@ -1,0 +1,7 @@
+# Fast forward's settings
+# To keep the branch clean
+
+[merge]
+	ff = false
+[pull]
+	ff = only

--- a/configs/git/configs/ghq
+++ b/configs/git/configs/ghq
@@ -1,0 +1,2 @@
+[ghq]
+	root = ~/Repos

--- a/configs/git/configs/push
+++ b/configs/git/configs/push
@@ -1,0 +1,4 @@
+# Config for Push
+
+[push]
+	autoSetupRemote = true

--- a/configs/git/configs/user
+++ b/configs/git/configs/user
@@ -1,0 +1,7 @@
+# For github account
+# email / name はマシンローカル値（named value）。dotfiles apply 時にストア
+# （~/.config/dotfiles/local.toml）から @@…@@ が注入される（設計書 §9・manifest の locals）。
+# 旧 chezmoi の env "DOTFILES_GIT_EMAIL/NAME" 注入＋if 分岐を置き換える。
+[user]
+	email = @@git.email@@
+	name = @@git.name@@

--- a/configs/git/configs/vimdiff
+++ b/configs/git/configs/vimdiff
@@ -1,0 +1,11 @@
+[diff]
+  tool = nvimdiff
+
+[merge]
+  tool = nvimdiff
+
+[difftool "nvimdiff"]
+  cmd = "nvim -R -d -c \"wincmd l\" -d \"$LOCAL\" \"$REMOTE\""
+
+[mergetool "nvimdiff"]
+  cmd = "nvim -d -c \"4wincmd w | wincmd J\" \"$LOCAL\" \"$BASE\" \"$REMOTE\"  \"$MERGED\""

--- a/configs/git/manifest.toml
+++ b/configs/git/manifest.toml
@@ -1,0 +1,15 @@
+# git config を dotfiles ネイティブで配置する（copy 層 ＋ named value 注入。設計書 §9・§13）。
+#
+# 旧 chezmoi（home/dot_config/git/）の置き換え。dst 配下へツリーをそのまま copy する:
+#   config            … git native [include] で配下 configs/<part> を束ねる薄い親（§13）
+#   configs/<part>    … alias / core / delta / fast_forward / ghq / push / user / vimdiff
+#
+# user 部品は email/name をマシンローカル値（named value）として持ち、配置時に `@@git.email@@` /
+# `@@git.name@@` がストア（~/.config/dotfiles/local.toml）から注入される（§9）。旧 env
+# "DOTFILES_GIT_EMAIL/NAME" 注入＋user.tmpl の if 分岐を廃し、宣言的な locals に一本化する。
+# email/name は commit に載るため非 sensitive（sensitive は宣言しない）。
+#
+# 注: git hooks（旧 symlink_ 13本）と ignore は本スライス対象外（hooks は §14 で配置方式を保留）。
+# copy は dst を prune しないため、chezmoi が配置する ~/.config/git/{hooks,ignore} は無傷で残る。
+dst    = "~/.config/git"
+locals = [ "git.email", "git.name" ]

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -4,16 +4,21 @@
 //! ①**ユニット gate（`deps` / `os`）を最初に評価し false なら短絡**（[`crate::gate`]、dst を
 //! 一切触らず skip）。生き残った単位は dst 種別で配置経路が分かれる ―
 //! dst=ディレクトリの copy は [`crate::copy`]（ツリー配置）、dst=ファイルの generate /
-//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve=既存 dst を土台に敷く合成）。本モジュールは
-//! オーケストレーションと、両経路が共有する小道具（`~` 展開・パーミッション適用）を持つ。
+//! overlay 明示は [`crate::compose`]（②宣言順 overlay ③preserve=既存 dst を土台に敷く合成）。
+//! 配置の直前に `locals`（named value）を解決し（[`crate::resolve`]）、配置ファイルの `@@name@@` を
+//! 注入する（§9）。本モジュールはオーケストレーションと、両経路が共有する小道具（`~` 展開・
+//! パーミッション適用）を持つ。
 
 use crate::discover::{self, MANIFEST, Unit};
 use crate::manifest::{Kind, Manifest, Strategy};
-use crate::{compose, copy, gate};
+use crate::store::Store;
+use crate::{compose, copy, gate, prompt, resolve};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// `source`（= `configs/`）配下を走査し、各 manifest の配置を実行する。
-/// `home` は dst の `~` 展開先。
+/// `home` は dst の `~` 展開先。`locals` の取得・注入に使う named value ストアは
+/// 開始時に1回ロードし（[`Store`]）、各単位の対話取得（TTY）で逐次更新する。
 pub fn run(source: &Path, home: &Path) -> Result<(), String> {
     let units = discover::collect(source)?;
     if units.is_empty() {
@@ -24,14 +29,15 @@ pub fn run(source: &Path, home: &Path) -> Result<(), String> {
         return Ok(());
     }
 
+    let mut store = Store::load(home)?;
     for unit in &units {
-        apply_unit(unit, home)?;
+        apply_unit(unit, home, &mut store)?;
     }
     Ok(())
 }
 
 /// 1 単位を評価順（§5.5）に従って配置し、結果を 1 行で表示する。
-fn apply_unit(unit: &Unit, home: &Path) -> Result<(), String> {
+fn apply_unit(unit: &Unit, home: &Path, store: &mut Store) -> Result<(), String> {
     let manifest = Manifest::load(&unit.dir.join(MANIFEST))?;
     let dst = expand_home(&manifest.dst, home);
     let name = unit.rel.to_string_lossy();
@@ -42,11 +48,19 @@ fn apply_unit(unit: &Unit, home: &Path) -> Result<(), String> {
         return Ok(());
     }
 
+    // `locals` 宣言があれば配置前に解決する（TTY=対話 / 非TTY=警告のみ）。宣言が無ければ空マップ
+    // ＝注入経路を素通りし、無関係ファイルの `@@…@@` を巻き込まない（§9.1）。
+    let locals = if manifest.locals.is_empty() {
+        BTreeMap::new()
+    } else {
+        resolve::fill(&manifest, store, prompt::is_tty())?
+    };
+
     let label = placement_label(&manifest);
     if uses_compose(&manifest) {
-        compose::place(&unit.dir, &dst, &manifest)?;
+        compose::place(&unit.dir, &dst, &manifest, &locals)?;
     } else {
-        copy::place(&unit.dir, &dst, &manifest)?;
+        copy::place(&unit.dir, &dst, &manifest, &locals)?;
     }
     println!("apply: {name} → {} ({label})", manifest.dst);
     Ok(())

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -2,18 +2,27 @@
 //!
 //! copy のツリー配置（dst=ディレクトリ）と異なり、generate と overlay 明示はここを通る。
 //! 評価順の不変条件（§5.5）を実装する: ②overlay は宣言順に `when` 評価し満たす断片だけ採用、
-//! ③`preserve = true` の既存 dst は最下層（土台）として断片の下に敷く。
+//! ③`preserve = true` の既存 dst は最下層（土台）として断片の下に敷く。合成後の出力には
+//! `locals` の `@@name@@` 注入を通す（§9。空マップなら素通り）。
 //! 不変条件①（ユニット gate 先・false で短絡）は [`crate::apply`] が前段で担う。
 
 use crate::apply::set_mode;
 use crate::manifest::{Manifest, Overlay, Strategy};
-use crate::{gate, generate, strategy};
+use crate::{gate, generate, resolve, strategy};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// 1 単位（`dir`）を overlay 合成で `dst`（ファイル）へ生成・配置する。
-pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
+/// 合成結果へ解決済み `locals` を注入してから書き出す（空なら注入なし）。
+pub fn place(
+    dir: &Path,
+    dst: &Path,
+    manifest: &Manifest,
+    locals: &BTreeMap<String, String>,
+) -> Result<(), String> {
     let frags = resolve_fragments(dir, manifest)?;
     let bytes = combine(manifest, dst, &frags)?;
+    let bytes = resolve::inject(&bytes, locals);
 
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -4,15 +4,24 @@
 //! 配下の実ファイルを相対構造を保ったまま copy する。`manifest.toml` 自体と、別 manifest を
 //! 持つサブツリー（委譲先の責務）は除外する。パーミッションは manifest の
 //! `private` / `executable` 属性に従う（§7、適用は [`crate::apply::set_mode`]）。
+//! `locals`（named value）が解決されている単位では、各ファイルへ `@@name@@` 注入を通す（§9）。
 
 use crate::apply::set_mode;
 use crate::discover::{self, MANIFEST};
 use crate::manifest::Manifest;
+use crate::resolve;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// 1 単位（`dir`）を copy で `dst`（ディレクトリ）へ配置する。
-pub fn place(dir: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
-    copy_tree(dir, dir, dst, manifest)
+/// `locals` は解決済みの named value（空なら注入なし＝従来の純コピー）。
+pub fn place(
+    dir: &Path,
+    dst: &Path,
+    manifest: &Manifest,
+    locals: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    copy_tree(dir, dir, dst, manifest, locals)
 }
 
 /// `src_root` 配下の実ファイルを、相対構造を保ったまま `dst_root` へコピーする。
@@ -22,6 +31,7 @@ fn copy_tree(
     src_root: &Path,
     dst_root: &Path,
     manifest: &Manifest,
+    locals: &BTreeMap<String, String>,
 ) -> Result<(), String> {
     for entry in discover::read_dir(current)? {
         let path = entry.path();
@@ -30,25 +40,39 @@ fn copy_tree(
             if path.join(MANIFEST).is_file() {
                 continue;
             }
-            copy_tree(&path, src_root, dst_root, manifest)?;
+            copy_tree(&path, src_root, dst_root, manifest, locals)?;
         } else if entry.file_name() != MANIFEST {
             let rel = path
                 .strip_prefix(src_root)
                 .map_err(|e| format!("{}: 相対パス算出失敗: {e}", path.display()))?;
-            copy_file(&path, &dst_root.join(rel), manifest)?;
+            copy_file(&path, &dst_root.join(rel), manifest, locals)?;
         }
     }
     Ok(())
 }
 
-/// 親ディレクトリを作りつつ 1 ファイルをコピーし、manifest のパーミッションを与える。
-fn copy_file(src: &Path, dst: &Path, manifest: &Manifest) -> Result<(), String> {
+/// 親ディレクトリを作りつつ 1 ファイルを配置し、manifest のパーミッションを与える。
+/// `locals` が空なら高速な `fs::copy`、非空なら read→注入→write で `@@name@@` を埋める。
+fn copy_file(
+    src: &Path,
+    dst: &Path,
+    manifest: &Manifest,
+    locals: &BTreeMap<String, String>,
+) -> Result<(), String> {
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
     }
-    std::fs::copy(src, dst)
-        .map_err(|e| format!("{} → {}: コピー失敗: {e}", src.display(), dst.display()))?;
+    if locals.is_empty() {
+        std::fs::copy(src, dst)
+            .map_err(|e| format!("{} → {}: コピー失敗: {e}", src.display(), dst.display()))?;
+    } else {
+        let bytes =
+            std::fs::read(src).map_err(|e| format!("{}: 読み込み失敗: {e}", src.display()))?;
+        let injected = resolve::inject(&bytes, locals);
+        std::fs::write(dst, &injected)
+            .map_err(|e| format!("{}: 書き込み失敗: {e}", dst.display()))?;
+    }
     set_mode(dst, manifest)?;
     Ok(())
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,37 @@
+//! `dotfiles doctor`（雛形・§9.5・§11）: `locals` 宣言がストアに揃っているかを診断する。
+//!
+//! 全単位の `manifest.toml`（[`crate::discover`]）から `locals` を集め、ストア（[`crate::store`]）に
+//! 値が無い名前を報告する。ツール別ロジックは持たず「宣言名がストアに在るか」を見るだけ（§9.5。
+//! git の `git config --includes` 解決スコープに依存しない）。雛形のため依存バイナリ等の他診断は
+//! 後続スライス。未設定があっても**ブロックしない**（exit 0・情報提供）。
+
+use crate::discover::{self, MANIFEST};
+use crate::manifest::Manifest;
+use crate::store::Store;
+use std::path::Path;
+
+/// `source` 配下の `locals` 宣言とストアを突き合わせ、未設定を stderr に報告する。
+pub fn run(source: &Path, home: &Path) -> Result<(), String> {
+    let units = discover::collect(source)?;
+    let store = Store::load(home)?;
+
+    let mut missing = Vec::new();
+    for unit in &units {
+        let manifest = Manifest::load(&unit.dir.join(MANIFEST))?;
+        for name in &manifest.locals {
+            if store.get(name).is_none() {
+                missing.push((unit.rel.to_string_lossy().into_owned(), name.clone()));
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        println!("doctor: locals は全て設定済み");
+        return Ok(());
+    }
+    eprintln!("doctor: 未設定の locals が {} 件あります:", missing.len());
+    for (unit, name) in &missing {
+        eprintln!("  - {name}（{unit}）: `dotfiles secret set {name} <value>` で設定");
+    }
+    Ok(())
+}

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -1,0 +1,87 @@
+//! placeholder 置換（§9.1-4）: 配置ファイル中の `@@name@@` を named value で埋める。
+//!
+//! `locals` を宣言した単位の materialize 後バイト列に対し、**解決済みの名前→値**だけを置換する
+//! （生成方式 copy / generate を問わず形式非依存）。条件分岐・関数を持つ汎用テンプレートは導入
+//! しない（named placeholder の単純置換のみ）。未解決名（ストアに値が無い）は `values` に入らない
+//! ため `@@name@@` が literal のまま残り、doctor が検出・再 apply で解消する（§9.1 非 TTY 劣化）。
+
+use std::collections::BTreeMap;
+
+/// `@@<name>@@` を `values` の対応値で置換する。`values` に無い名前は触らない（literal 残し）。
+///
+/// 置換対象は呼び出し側（apply）が解決した「locals 宣言かつ値あり」の集合のみ。`values` が空なら
+/// 入力をそのまま返す（注入対象でない単位は呼び出し側が空マップを渡す＝巻き込み防止）。
+pub fn substitute(bytes: &[u8], values: &BTreeMap<String, String>) -> Vec<u8> {
+    if values.is_empty() {
+        return bytes.to_vec();
+    }
+    // バイト列に対し UTF-8 を仮定せず置換するため、各 placeholder のバイトパターンで replace する。
+    // 設定ファイルはテキストだが、形式非依存を保つためバイト走査で実装する。
+    let mut out = bytes.to_vec();
+    for (name, value) in values {
+        let needle = format!("@@{name}@@");
+        out = replace_bytes(&out, needle.as_bytes(), value.as_bytes());
+    }
+    out
+}
+
+/// `haystack` 中の `needle` をすべて `replacement` に置換する（バイト単位）。
+fn replace_bytes(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> {
+    if needle.is_empty() {
+        return haystack.to_vec();
+    }
+    let mut out = Vec::with_capacity(haystack.len());
+    let mut i = 0;
+    while i < haystack.len() {
+        if haystack[i..].starts_with(needle) {
+            out.extend_from_slice(replacement);
+            i += needle.len();
+        } else {
+            out.push(haystack[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn substitutes_declared_names() {
+        let src = b"[user]\n  email = @@git.email@@\n  name = @@git.name@@\n";
+        let out = substitute(src, &map(&[("git.email", "me@x"), ("git.name", "Toshiki")]));
+        assert_eq!(out, b"[user]\n  email = me@x\n  name = Toshiki\n".to_vec(),);
+    }
+
+    #[test]
+    fn leaves_unresolved_placeholder_literal() {
+        // 値が無い名前（values に入らない）は @@…@@ のまま残す（非 TTY 劣化・doctor が検出）。
+        let src = b"email = @@git.email@@\n";
+        let out = substitute(src, &map(&[]));
+        assert_eq!(out, src.to_vec());
+    }
+
+    #[test]
+    fn does_not_touch_undeclared_placeholders() {
+        // 宣言外の @@other@@ は置換しない（values に無い）。
+        let src = b"a = @@git.email@@\nb = @@other@@\n";
+        let out = substitute(src, &map(&[("git.email", "v")]));
+        assert_eq!(out, b"a = v\nb = @@other@@\n".to_vec());
+    }
+
+    #[test]
+    fn replaces_multiple_occurrences() {
+        let src = b"@@k@@-@@k@@";
+        let out = substitute(src, &map(&[("k", "x")]));
+        assert_eq!(out, b"x-x".to_vec());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,20 +7,28 @@
 //! 固定ソース `configs/` を走査し、`manifest.toml` に従って配置する。配置は **2軸**
 //! （生成方式 `kind`=copy/generate × 合成 `strategy`=concat/json-shallow）＋条件付き overlay
 //! （`when` gate）で捉える（設計書 §5 / §5.5）。copy はツリー配置、generate / overlay 明示は
-//! ファイル合成（[`compose`]）を通り、`deps` / `os` はユニット単位 gate（[`gate`]）。
-//! `apply` は配置、`list` は分散 manifest を集約した配置先一覧を担う。
+//! ファイル合成（[`compose`]）を通り、`deps` / `os` はユニット単位 gate（[`gate`]）。配置の直前に
+//! `locals`（named value）を解決・注入する（[`resolve`] / [`inject`] / [`store`] / [`prompt`]、§9）。
+//! `apply` は配置、`list` は配置先一覧、`secret set` は named value 設定、`doctor` は診断（雛形）。
 
 use clap::{Parser, Subcommand};
+use std::ffi::OsString;
 use std::path::Path;
 
 mod apply;
 mod compose;
 mod copy;
 mod discover;
+mod doctor;
 mod gate;
 mod generate;
+mod inject;
 mod list;
 mod manifest;
+mod prompt;
+mod resolve;
+mod secret;
+mod store;
 mod strategy;
 
 /// toshiki670/dotfiles 本体（core）。
@@ -42,30 +50,62 @@ enum Commands {
     Apply,
     /// configs の manifest を集約し、配置先一覧を表示する。
     List,
+    /// マシンローカル値（named value）をストアへ設定する（§9）。
+    Secret {
+        #[command(subcommand)]
+        action: SecretAction,
+    },
+    /// 依存・`locals` 未設定などを診断する（雛形・§9）。
+    Doctor,
+}
+
+/// `secret` のサブコマンド。コマンド名 `secret` は仮称（非秘匿値も扱う。§14 で最終命名）。
+#[derive(Subcommand)]
+enum SecretAction {
+    /// 名前→値をストア（`~/.config/dotfiles/local.toml`）へ設定する。
+    Set { name: String, value: String },
 }
 
 fn main() {
     let cli = Cli::parse();
-    match cli.command {
-        Some(Commands::Apply) => {
-            if let Err(e) = run_apply() {
-                eprintln!("dotfiles apply: {e}");
-                std::process::exit(1);
-            }
-        }
-        Some(Commands::List) => {
-            if let Err(e) = list::run(Path::new("configs")) {
-                eprintln!("dotfiles list: {e}");
-                std::process::exit(1);
-            }
-        }
+    let result = match cli.command {
+        Some(Commands::Apply) => run_apply(),
+        Some(Commands::List) => list::run(Path::new("configs")),
+        Some(Commands::Secret {
+            action: SecretAction::Set { name, value },
+        }) => run_secret_set(&name, &value),
+        Some(Commands::Doctor) => run_doctor(),
         // サブコマンドなし: 従来どおりバージョンを表示する。
-        None => println!("dotfiles {}", env!("CARGO_PKG_VERSION")),
+        None => {
+            println!("dotfiles {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+    };
+    if let Err(e) = result {
+        eprintln!("dotfiles: {e}");
+        std::process::exit(1);
     }
 }
 
 /// `dotfiles apply`：CWD 相対の固定ソース `configs/` を、HOME を基点に配置する。
 fn run_apply() -> Result<(), String> {
-    let home = std::env::var_os("HOME").ok_or_else(|| "HOME が未設定".to_string())?;
+    let home = home_dir()?;
     apply::run(Path::new("configs"), Path::new(&home))
+}
+
+/// `dotfiles secret set <name> <value>`：named value をストアへ保存する。
+fn run_secret_set(name: &str, value: &str) -> Result<(), String> {
+    let home = home_dir()?;
+    secret::set(Path::new(&home), name, value)
+}
+
+/// `dotfiles doctor`：`configs/` の `locals` 宣言とストアを突き合わせ未設定を報告する。
+fn run_doctor() -> Result<(), String> {
+    let home = home_dir()?;
+    doctor::run(Path::new("configs"), Path::new(&home))
+}
+
+/// HOME を取得する（dst の `~` 展開・ストアパスの基点）。
+fn home_dir() -> Result<OsString, String> {
+    std::env::var_os("HOME").ok_or_else(|| "HOME が未設定".to_string())
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -9,7 +9,8 @@
 //!   `when`（`dep` / `os`）。既存 dst の温存はユニット属性 `preserve = true`（§5.5）。
 //!
 //! `deps` / `os` はユニット単位 gate（＝ ユニット全体に係る `when` の退化形, §5.5）。
-//! theme / hooks / secrets は後続スライスで追加する。
+//! `locals` / `sensitive` はマシンローカル値（named value）の宣言（§9, S4）。theme / hooks は
+//! 後続スライスで追加する。
 
 use serde::Deserialize;
 use std::path::Path;
@@ -55,6 +56,17 @@ pub struct Manifest {
     /// 各 overlay は `src` / `cmd` のどちらか ＋ `when?` を持つ。
     #[serde(default)]
     pub overlay: Vec<Overlay>,
+    /// マシンローカル値（named value）の宣言（§9）。ここで宣言した名前 `n` に対し、この単位の
+    /// 配置ファイル中の `@@n@@` をストア（`~/.config/dotfiles/local.toml`）の値で置換する。
+    /// 置換は `locals` を宣言した単位のファイルにだけ走る（無関係ファイルの `@@…@@` を巻き込まない）。
+    /// 例: `locals = ["git.email", "git.name"]`。
+    #[serde(default)]
+    pub locals: Vec<String>,
+    /// `locals` のうち秘匿値（対話取得時にエコー/ログを抑制する）。git の email/name は commit に
+    /// 載るため**非 sensitive**。`sensitive ⊆ locals` を load 時に検証する（§9.1）— typo で名前が
+    /// `locals` とズレると非エコー抑制が黙って効かず秘匿値が漏れる footgun を防ぐ。
+    #[serde(default)]
+    pub sensitive: Vec<String>,
 }
 
 /// 生成方式（断片の実体化方法）。copy / generate。`merge` は kind ではなく `strategy`（§5.5）。
@@ -130,6 +142,9 @@ impl Manifest {
     ///   構成を load 時に弾く（土台だけ再直列化する退化形に意味は無い）。
     /// - **各 overlay は `src` / `cmd` のうちちょうど 1 つ**（生成方式は択一）。2 つは一方が
     ///   黙って無視される typo、0 個は断片を実体化できない。
+    /// - **`sensitive ⊆ locals`**（§9.1）。`sensitive` に `locals` 未宣言の名前があると、その名は
+    ///   非エコー/ログ抑制の対象にならず（resolve は `locals` を走査するため）秘匿値が黙って漏れる。
+    ///   typo を配置前に弾く。
     fn validate(&self) -> Result<(), String> {
         if !self.overlay.is_empty() && self.strategy.is_none() {
             return Err(
@@ -156,6 +171,11 @@ impl Manifest {
                     "overlay[{i}] は src / cmd のうちちょうど 1 つを持つ必要があります（現在 {kinds} 個）"
                 ));
             }
+        }
+        if let Some(orphan) = self.sensitive.iter().find(|s| !self.locals.contains(s)) {
+            return Err(format!(
+                "sensitive `{orphan}` が locals に宣言されていません（sensitive ⊆ locals）"
+            ));
         }
         Ok(())
     }
@@ -271,6 +291,31 @@ mod tests {
         assert!(
             err.contains("ちょうど 1 つ"),
             "0 個が検知されていない: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_sensitive_subset_of_locals() {
+        // sensitive ⊆ locals は正規形（§9.1）。email/name は非 sensitive のまま宣言できる。
+        assert!(
+            parse(
+                "dst = \"~/x\"\nlocals = [\"git.email\", \"git.name\", \"github.token\"]\n\
+                 sensitive = [\"github.token\"]\n",
+            )
+            .is_ok()
+        );
+        // sensitive 省略（全て非秘匿）も可。
+        assert!(parse("dst = \"~/x\"\nlocals = [\"git.email\", \"git.name\"]\n").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_sensitive_not_in_locals() {
+        // locals に無い名を sensitive に書く typo → 非エコー抑制が効かず漏れる footgun。
+        let err = parse("dst = \"~/x\"\nlocals = [\"git.email\"]\nsensitive = [\"githb.token\"]\n")
+            .unwrap_err();
+        assert!(
+            err.contains("sensitive") && err.contains("githb.token"),
+            "sensitive ⊄ locals が弾かれていない: {err}"
         );
     }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -12,7 +12,9 @@ pub fn is_tty() -> bool {
 }
 
 /// `label`（値の名前）を提示して1行入力を受け取る。`sensitive` のときは端末エコーを抑制する。
-/// プロンプトは stderr へ出し、前後の空白・改行を trim して返す。
+/// プロンプトは stderr へ出し、**末尾の行終端（`\n` / `\r\n`）のみ除去**して返す。前後の空白は
+/// 保持する（値は verbatim ＝ `secret set <name> <value>` と同じ扱い）。full trim をしないのは、
+/// 前後空白が有意な sensitive 値（パスフレーズ等）を黙って壊さないため。
 pub fn ask(label: &str, sensitive: bool) -> Result<String, String> {
     let mut err = io::stderr();
     let _ = write!(err, "{label} を入力してください: ");
@@ -23,7 +25,18 @@ pub fn ask(label: &str, sensitive: bool) -> Result<String, String> {
     } else {
         read_line()?
     };
-    Ok(line.trim().to_string())
+    Ok(strip_line_ending(line))
+}
+
+/// 末尾の1つの行終端（`\n`、または `\r\n`）だけを取り除く。それ以外の空白・文字は保持する。
+fn strip_line_ending(mut line: String) -> String {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+    line
 }
 
 /// 標準入力から1行読む。
@@ -91,5 +104,21 @@ impl Drop for EchoGuard {
         unsafe {
             libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.original);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_line_ending;
+
+    #[test]
+    fn strips_only_trailing_line_ending() {
+        // 末尾の改行のみ除去（LF / CRLF）。
+        assert_eq!(strip_line_ending("value\n".to_string()), "value");
+        assert_eq!(strip_line_ending("value\r\n".to_string()), "value");
+        // 前後の空白・内部空白は保持（verbatim ＝ secret set と同じ）。
+        assert_eq!(strip_line_ending("  pa ss  \n".to_string()), "  pa ss  ");
+        // 改行が無ければそのまま（EOF で終端されたケース）。
+        assert_eq!(strip_line_ending("value".to_string()), "value");
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,95 @@
+//! 対話入力（§9.3 取得）: TTY 判定と1行入力。sensitive な値は端末エコーを落として読む。
+//!
+//! apply はローカル値の取得経路を **TTY=対話 / 非TTY=警告のみ**に分ける（[`crate::resolve`]）。
+//! 本モジュールはその TTY 側を担う。プロンプトは stdout を汚さないよう stderr へ出す。非エコーは
+//! termios の `ECHO` を一時的に落とし、RAII ガードで必ず復元する（Unix。非 Unix は通常入力）。
+
+use std::io::{self, BufRead, IsTerminal, Write};
+
+/// 標準入力が TTY か。apply の取得経路（対話 / 警告のみ）を分岐するのに使う（§9）。
+pub fn is_tty() -> bool {
+    io::stdin().is_terminal()
+}
+
+/// `label`（値の名前）を提示して1行入力を受け取る。`sensitive` のときは端末エコーを抑制する。
+/// プロンプトは stderr へ出し、前後の空白・改行を trim して返す。
+pub fn ask(label: &str, sensitive: bool) -> Result<String, String> {
+    let mut err = io::stderr();
+    let _ = write!(err, "{label} を入力してください: ");
+    let _ = err.flush();
+
+    let line = if sensitive {
+        read_line_no_echo()?
+    } else {
+        read_line()?
+    };
+    Ok(line.trim().to_string())
+}
+
+/// 標準入力から1行読む。
+fn read_line() -> Result<String, String> {
+    let mut line = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .map_err(|e| format!("入力の読み取りに失敗: {e}"))?;
+    Ok(line)
+}
+
+/// 端末エコーを落として1行読む（秘匿値用）。読み終えたら端末設定を必ず復元する（Unix）。
+#[cfg(unix)]
+fn read_line_no_echo() -> Result<String, String> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = io::stdin().as_raw_fd();
+    let guard = EchoGuard::disable(fd)?;
+    let line = read_line();
+    drop(guard); // 端末設定を復元してから改行を出す。
+    // エコーを落としている間は Enter の改行も表示されないため、ここで1つ補う。
+    let _ = writeln!(io::stderr());
+    line
+}
+
+/// 非 Unix ではエコー抑制の termios が無いため通常入力にフォールバックする。
+#[cfg(not(unix))]
+fn read_line_no_echo() -> Result<String, String> {
+    read_line()
+}
+
+/// termios の `ECHO` を一時的に落とし、`Drop` で元に戻す RAII ガード（Unix）。
+/// エラーで早期 return しても、確保済みのガードが drop されれば端末は復元される。
+#[cfg(unix)]
+struct EchoGuard {
+    fd: i32,
+    original: libc::termios,
+}
+
+#[cfg(unix)]
+impl EchoGuard {
+    /// `fd`（端末）の現在属性を保存し、`ECHO` を落とした属性を設定する。
+    fn disable(fd: i32) -> Result<Self, String> {
+        // SAFETY: term は tcgetattr で完全に初期化してから読む。fd は stdin（端末）。
+        unsafe {
+            let mut term: libc::termios = std::mem::zeroed();
+            if libc::tcgetattr(fd, &mut term) != 0 {
+                return Err("端末属性の取得に失敗（tcgetattr）".to_string());
+            }
+            let original = term; // libc::termios は Copy。復元用に保存。
+            term.c_lflag &= !libc::ECHO;
+            if libc::tcsetattr(fd, libc::TCSAFLUSH, &term) != 0 {
+                return Err("端末属性の設定に失敗（tcsetattr）".to_string());
+            }
+            Ok(Self { fd, original })
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for EchoGuard {
+    fn drop(&mut self) {
+        // SAFETY: 取得済みの original を書き戻すのみ。失敗時も他に取れる手当ては無い。
+        unsafe {
+            libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.original);
+        }
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,83 @@
+//! apply 時のローカル値解決（§9.3 取得）: 単位の `locals` をストアと突き合わせ、未設定値を
+//! TTY なら対話取得（sensitive は非エコー）、非 TTY なら警告のみで継続する（**ブロックしない**）。
+//!
+//! ここで解決できた「名前→値」だけを [`crate::inject`] が placeholder 置換に使う。未解決の名前は
+//! マップに入らないため、配置ファイルでは `@@name@@` が literal のまま残り doctor が検出する（§9.1）。
+
+use crate::manifest::Manifest;
+use crate::store::Store;
+use crate::{inject, prompt};
+use std::collections::BTreeMap;
+
+/// 単位の `locals` を解決し、注入用の「名前→値」マップ（解決できた名前のみ）を返す。
+///
+/// - ストアに既にあれば採用。
+/// - 無く `interactive`（TTY）なら [`prompt::ask`]（sensitive は非エコー）で取得しストアへ 0600 で書く。
+/// - 無く非 TTY なら警告（stderr）のみで継続し、その名前はマップに含めない（literal 残し）。
+///
+/// `manifest.locals` が空なら空マップ（注入対象でない単位）。空マップは [`inject::substitute`] が
+/// 素通しするため、`locals` を宣言しない単位のファイルは一切走査されない。
+pub fn fill(
+    manifest: &Manifest,
+    store: &mut Store,
+    interactive: bool,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut resolved = BTreeMap::new();
+    for name in &manifest.locals {
+        if let Some(value) = store.get(name) {
+            resolved.insert(name.clone(), value.to_string());
+            continue;
+        }
+        if interactive {
+            let value = prompt::ask(name, manifest.sensitive.contains(name))?;
+            store.set(name, &value);
+            store.save()?;
+            resolved.insert(name.clone(), value);
+        } else {
+            eprintln!(
+                "apply: locals `{name}` 未設定（`dotfiles secret set {name} <value>` で設定）"
+            );
+        }
+    }
+    Ok(resolved)
+}
+
+/// バイト列へ解決済みローカル値を注入する薄いラッパ（[`inject::substitute`] の再公開）。
+/// copy / compose の両配置経路が同じ注入を通すための単一窓口。
+pub fn inject(bytes: &[u8], values: &BTreeMap<String, String>) -> Vec<u8> {
+    inject::substitute(bytes, values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// テキストから Manifest をパースする（検証込み）。
+    fn manifest(src: &str) -> Manifest {
+        toml::from_str(src).unwrap()
+    }
+
+    #[test]
+    fn non_interactive_uses_store_values_and_warns_missing() {
+        let home = tempfile::tempdir().unwrap();
+        let mut store = Store::load(home.path()).unwrap();
+        store.set("git.email", "me@example.com");
+
+        let m = manifest("dst = \"~/x\"\nlocals = [\"git.email\", \"git.name\"]\n");
+        // 非 TTY: git.email はストアから解決、git.name は未設定で警告のみ（マップに入らない）。
+        let resolved = fill(&m, &mut store, false).unwrap();
+        assert_eq!(
+            resolved.get("git.email").map(String::as_str),
+            Some("me@example.com")
+        );
+        assert_eq!(resolved.get("git.name"), None);
+    }
+
+    #[test]
+    fn empty_locals_yields_empty_map() {
+        let home = tempfile::tempdir().unwrap();
+        let mut store = Store::load(home.path()).unwrap();
+        let m = manifest("dst = \"~/x\"\n");
+        assert!(fill(&m, &mut store, false).unwrap().is_empty());
+    }
+}

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,20 @@
+//! `dotfiles secret set`（§9・§11）: named value をストアへ設定する明示経路。
+//!
+//! ストアの読み書きは [`crate::store`]。コマンド名 `secret` は仮称（email/name 等の非秘匿値も
+//! 扱うため概念とズレる。§14 で最終命名）。値は argv に載るためシェル履歴/ps に残る点は呼び出し側
+//! の選択であり、対話取得の非エコー（[`crate::prompt`]）は apply の TTY 経路が担う別物。
+
+use crate::store::Store;
+use std::path::Path;
+
+/// `name`→`value` をストアへ設定し 0600 で保存する。
+pub fn set(home: &Path, name: &str, value: &str) -> Result<(), String> {
+    let mut store = Store::load(home)?;
+    store.set(name, value);
+    store.save()?;
+    println!(
+        "secret set: {name} を保存しました（{}）",
+        Store::path(home).display()
+    );
+    Ok(())
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -43,9 +43,11 @@ impl Store {
         self.values.insert(name.to_string(), value.to_string());
     }
 
-    /// ストアを 0600 で書き出す（親ディレクトリを作成）。秘匿値を含むため、作成時点から
-    /// 所有者のみのモードで開き（新規ファイルの 0644 露出窓を作らない）、既存ファイルにも
-    /// 念のため 0600 を再設定する。
+    /// ストアを **原子的に** 0600 で書き出す（親ディレクトリを作成）。同一ディレクトリへ
+    /// 一時ファイルを 0600 で作成し、fsync してから rename で置き換える。rename は既存の
+    /// `local.toml`（live ファイル）を切り詰めないため、書き込み途中のクラッシュ/kill でも
+    /// 既存値は無傷で残る（空/部分書き込みにならない）。一時ファイルの後始末は `tempfile` が
+    /// Drop で行う（明示削除なし）。
     pub fn save(&self) -> Result<(), String> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)
@@ -57,30 +59,26 @@ impl Store {
     }
 }
 
-/// 所有者のみ（0600）で書き出す（Unix）。create-mode 0600 で開いて作成窓を塞ぎ、
-/// 既存ファイルにも 0600 を再設定する。
-#[cfg(unix)]
+/// 所有者のみ（0600）で原子的に書き出す。同一ディレクトリの一時ファイル（`tempfile` が Unix では
+/// 0600 で作成）へ書き、fsync 後に rename で `path` を置き換える。失敗時は一時ファイルが Drop で
+/// 消える（本書き込みは未反映）。秘匿値の露出窓と、live ファイルの truncate を両方避ける。
 fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
     use std::io::Write;
-    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)
+        .map_err(|e| format!("{}: 一時ファイル作成失敗: {e}", dir.display()))?;
+    tmp.write_all(bytes)
         .map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))?;
-    file.write_all(bytes)
-        .map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))?;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| format!("{}: パーミッション設定失敗: {e}", path.display()))
-}
-
-/// 非 Unix ではパーミッションモデルが異なるため通常の書き込み。
-#[cfg(not(unix))]
-fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
-    std::fs::write(path, bytes).map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))
+    tmp.as_file()
+        .sync_all()
+        .map_err(|e| format!("{}: fsync 失敗: {e}", path.display()))?;
+    tmp.persist(path)
+        .map_err(|e| format!("{}: 原子的置換失敗: {}", path.display(), e.error))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -124,5 +122,30 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600, "ストアは 0600 で書かれる");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn overwriting_existing_store_keeps_owner_only() {
+        // 原子的置換（rename）でも、既存ファイルの上書き後に 0600 と最新値が保たれる。
+        use std::os::unix::fs::PermissionsExt;
+        let home = tempfile::tempdir().unwrap();
+
+        let mut first = Store::load(home.path()).unwrap();
+        first.set("git.email", "old@example.com");
+        first.save().unwrap();
+
+        let mut second = Store::load(home.path()).unwrap();
+        second.set("git.email", "new@example.com");
+        second.save().unwrap();
+
+        let path = Store::path(home.path());
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "上書き後も 0600 を保つ");
+        assert_eq!(
+            Store::load(home.path()).unwrap().get("git.email"),
+            Some("new@example.com"),
+            "最新値で置き換わる",
+        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,128 @@
+//! named value ストア（§9.1）: マシンローカル値の単一ストア `~/.config/dotfiles/local.toml`。
+//!
+//! 名前→値を全ツール横断で集約する **dotfiles 非管理**ファイル（repo には値を一切置かない）。
+//! `locals` を宣言した単位の placeholder（`@@name@@`）注入（[`crate::resolve`]）と doctor 診断
+//! （[`crate::doctor`]）がここを参照する。秘匿値を含むためファイルは 0600 で書き、ドット入り
+//! キー（`git.email`）は toml が自動でクォートするので round-trip する（フラットな名前→値マップ）。
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// `~/.config/dotfiles/local.toml` の名前→値マップ。
+pub struct Store {
+    path: PathBuf,
+    values: BTreeMap<String, String>,
+}
+
+impl Store {
+    /// ストアファイルのパス（`<home>/.config/dotfiles/local.toml`）。
+    pub fn path(home: &Path) -> PathBuf {
+        home.join(".config/dotfiles/local.toml")
+    }
+
+    /// ストアを読み込む。ファイルが無ければ空（apply 初回・未設定状態）として扱う。
+    pub fn load(home: &Path) -> Result<Self, String> {
+        let path = Self::path(home);
+        let values = match std::fs::read_to_string(&path) {
+            Ok(text) => {
+                toml::from_str(&text).map_err(|e| format!("{}: パース失敗: {e}", path.display()))?
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
+            Err(e) => return Err(format!("{}: 読み込み失敗: {e}", path.display())),
+        };
+        Ok(Self { path, values })
+    }
+
+    /// 名前に対応する値（無ければ None）。
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.values.get(name).map(String::as_str)
+    }
+
+    /// 名前→値を設定する（メモリ上。永続化は [`Store::save`]）。
+    pub fn set(&mut self, name: &str, value: &str) {
+        self.values.insert(name.to_string(), value.to_string());
+    }
+
+    /// ストアを 0600 で書き出す（親ディレクトリを作成）。秘匿値を含むため、作成時点から
+    /// 所有者のみのモードで開き（新規ファイルの 0644 露出窓を作らない）、既存ファイルにも
+    /// 念のため 0600 を再設定する。
+    pub fn save(&self) -> Result<(), String> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("{}: ディレクトリ作成失敗: {e}", parent.display()))?;
+        }
+        let text = toml::to_string(&self.values)
+            .map_err(|e| format!("{}: 直列化失敗: {e}", self.path.display()))?;
+        write_private(&self.path, text.as_bytes())
+    }
+}
+
+/// 所有者のみ（0600）で書き出す（Unix）。create-mode 0600 で開いて作成窓を塞ぎ、
+/// 既存ファイルにも 0600 を再設定する。
+#[cfg(unix)]
+fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))?;
+    file.write_all(bytes)
+        .map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| format!("{}: パーミッション設定失敗: {e}", path.display()))
+}
+
+/// 非 Unix ではパーミッションモデルが異なるため通常の書き込み。
+#[cfg(not(unix))]
+fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    std::fs::write(path, bytes).map_err(|e| format!("{}: 書き込み失敗: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_loads_empty() {
+        let home = tempfile::tempdir().unwrap();
+        let store = Store::load(home.path()).unwrap();
+        assert_eq!(store.get("git.email"), None);
+    }
+
+    #[test]
+    fn set_save_load_round_trips_dotted_keys() {
+        // ドット入りキー（git.email）が save→load で round-trip することを確認（toml の
+        // 自動クォート依存。フラットなマップとして round-trip する）。
+        let home = tempfile::tempdir().unwrap();
+        let mut store = Store::load(home.path()).unwrap();
+        store.set("git.email", "me@example.com");
+        store.set("git.name", "Toshiki");
+        store.save().unwrap();
+
+        let reloaded = Store::load(home.path()).unwrap();
+        assert_eq!(reloaded.get("git.email"), Some("me@example.com"));
+        assert_eq!(reloaded.get("git.name"), Some("Toshiki"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn saved_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = tempfile::tempdir().unwrap();
+        let mut store = Store::load(home.path()).unwrap();
+        store.set("github.token", "ghp_secret");
+        store.save().unwrap();
+
+        let mode = std::fs::metadata(Store::path(home.path()))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "ストアは 0600 で書かれる");
+    }
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -14,6 +14,7 @@
 //! - [`generate`]: generate 層（S2/#456）— cmd 実行・deps gate・sibling 連結・list 表示
 //! - [`overlay`]: 合成軸（S3/#471）— overlay/strategy/when/preserve と load 時検証群
 //! - [`claude_settings`]: claude/settings 実 config（S3/#457）の結線確認
+//! - [`secrets`]: マシンローカル値（S4/#458）— secret set / 注入 / doctor / 実 git 結線
 
 use assert_cmd::Command;
 
@@ -23,6 +24,7 @@ mod cli;
 mod generate;
 mod list;
 mod overlay;
+mod secrets;
 
 /// 実バイナリ `dotfiles` を起動する Command を返す（全テスト共通）。
 pub(crate) fn dotfiles() -> Command {

--- a/tests/e2e/secrets.rs
+++ b/tests/e2e/secrets.rs
@@ -1,0 +1,198 @@
+//! マシンローカル値（named value）機構の E2E（S4 / #458）。
+//!
+//! `dotfiles secret set` でストアへ設定 →`apply` で `@@name@@` 注入、未設定時の非 TTY 警告と
+//! placeholder 残し、`doctor` の未設定警告、実 config（configs/git）の user 注入を検証する。
+//! sensitive の非エコー対話（TTY）は pty 依存で自動化困難なため手動検証（PR 説明参照）。
+//!
+//! 注: `assert_cmd` の `.assert()` は `Command::output()` 経由で子の stdin を継承しない（= 非 TTY）。
+//! よって apply は常に非対話経路（警告のみ）を通り、テストがプロンプトでハングしない。
+
+use crate::dotfiles;
+use predicates::prelude::*;
+use std::fs;
+
+/// locals を宣言した単位へ、事前 `secret set` した値が apply で `@@name@@` 置換されることを検証。
+#[test]
+fn secret_set_then_apply_injects_local_value() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo\"\nlocals = [\"demo.token\"]\n",
+    )
+    .unwrap();
+    fs::write(unit.join("conf"), "token = @@demo.token@@\n").unwrap();
+
+    // 同じ HOME（= 同じストア）で secret set → apply。
+    dotfiles()
+        .args(["secret", "set", "demo.token", "s3cr3t"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let placed = home.path().join(".config/demo/conf");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "token = s3cr3t\n",
+        "ストア値が @@name@@ へ注入されていない",
+    );
+}
+
+/// 値未設定 ＋ 非 TTY では、警告のみで継続し（ブロックしない）placeholder が literal で残る。
+#[test]
+fn apply_without_value_warns_and_leaves_placeholder() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo\"\nlocals = [\"demo.token\"]\n",
+    )
+    .unwrap();
+    fs::write(unit.join("conf"), "token = @@demo.token@@\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success() // 非 TTY は警告のみで継続（ブロックしない）。
+        .stderr(predicate::str::contains("未設定"))
+        .stderr(predicate::str::contains("demo.token"));
+
+    let placed = home.path().join(".config/demo/conf");
+    assert_eq!(
+        fs::read_to_string(&placed).unwrap(),
+        "token = @@demo.token@@\n",
+        "未解決の placeholder は literal で残るべき",
+    );
+}
+
+/// `secret set` がストアを 0600 で作り、値を保持することを検証。
+#[cfg(unix)]
+#[test]
+fn secret_set_writes_owner_only_store() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = tempfile::tempdir().unwrap();
+    dotfiles()
+        .args(["secret", "set", "demo.token", "val"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let store = home.path().join(".config/dotfiles/local.toml");
+    let mode = fs::metadata(&store).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "ストアは 0600（所有者のみ）で書かれる");
+    assert!(
+        fs::read_to_string(&store).unwrap().contains("val"),
+        "ストアに値が保存されていない",
+    );
+}
+
+/// `doctor` が未設定 locals を警告し、`secret set` 後は「設定済み」になることを検証。
+#[test]
+fn doctor_warns_unset_then_clears_after_set() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/demo\"\nlocals = [\"demo.token\"]\n",
+    )
+    .unwrap();
+
+    // 未設定 → stderr に未設定名を報告（exit 0・ブロックしない雛形）。
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("demo.token"));
+
+    // 設定後 → 全て設定済み。
+    dotfiles()
+        .args(["secret", "set", "demo.token", "v"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("全て設定済み"));
+}
+
+/// load 時検証 `sensitive ⊆ locals` がバイナリ経由でも apply を失敗させることを検証。
+#[test]
+fn apply_rejects_sensitive_not_in_locals() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/bad");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "dst = \"~/.config/bad\"\nlocals = [\"a\"]\nsensitive = [\"b\"]\n",
+    )
+    .unwrap();
+    fs::write(unit.join("f"), "x\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("sensitive"));
+}
+
+/// 実 config: configs/git の user.email/user.name が apply 時にストア値で注入される。
+#[test]
+fn apply_injects_real_git_user() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let home = tempfile::tempdir().unwrap();
+
+    dotfiles()
+        .args(["secret", "set", "git.email", "me@example.com"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+    dotfiles()
+        .args(["secret", "set", "git.name", "Toshiki"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+    dotfiles()
+        .arg("apply")
+        .current_dir(repo_root)
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let user = fs::read_to_string(home.path().join(".config/git/configs/user")).unwrap();
+    assert!(
+        user.contains("email = me@example.com") && user.contains("name = Toshiki"),
+        "git user へストア値が注入されていない:\n{user}",
+    );
+    assert!(
+        !user.contains("@@git."),
+        "未置換の placeholder が残っている:\n{user}",
+    );
+}


### PR DESCRIPTION
## 届く価値

git user 等のマシンローカル値が、単一の汎用ストア（dotfiles 非管理）から**名前付きで注入**され、未設定は `dotfiles doctor` が警告する。env 注入（`DOTFILES_GIT_*`）は廃止。設計書 §9 / PR #479 の再設計を実装する S4 スライス。

Closes #458

## 受け入れ条件の対応

- [x] manifest `locals`/`sensitive` を解釈（**`sensitive ⊆ locals` を load 時検証** = typo footgun 防止）
- [x] 単一ストア `~/.config/dotfiles/local.toml`（0600・dotfiles 非管理）の読み書き（`store.rs`）
- [x] 配置ファイルへ `@@name@@` 置換でストア値を注入（copy / generate 問わず、`locals` 宣言 unit のみ）
- [x] apply: 未設定値を **TTY 対話取得**（sensitive 非エコー）/ **非 TTY 警告のみで継続**（ブロックしない）
- [x] `dotfiles secret set <name> <value>`
- [x] `env "DOTFILES_GIT_EMAIL/NAME"` 注入と `user.tmpl` if 分岐を**廃止**（configs/git の named value 版＋later-wins）
- [x] `dotfiles doctor`（雛形）が `locals` 未設定を警告
- [x] E2E: 値の有/無での注入と doctor 警告を検証

## 設計判断（本セッションで合意）

- **git 移行は方式A（native `[include]`）**: 8部品を `~/.config/git/configs/<part>` へ copy 配置し、`~/.config/git/config` は git の `[include]` で束ねる（設計書 §13「ファイル合成 → git native include（copy へ降格）」に忠実）。`user` 部品が `@@git.email@@` / `@@git.name@@` を担う。alias の `${DOTFILES}` 自己参照は配置先 `~/.config/git/configs/alias` へ修正。
- **home/ は一切触らない**: 設計書 §12.1（移行中は home/ 不変＝ chezmoi へのロールバック保証の根拠。物理撤去は S9 #463）を正とした。Issue の「user.tmpl の if 分岐を廃止」文面は PR #483〔home/ 削除を S9 へ統一〕に追いついていない stale と判断。「廃止」は configs/git 側に env 分岐を作らず、`dotfiles apply` の later-wins で chezmoi 版を上書きして実現する。
- **scope 外（後続）**: git hooks（symlink_ 13本・§14 で配置方式保留）と ignore は移行しない。copy は dst を prune しないため `~/.config/git/{hooks,ignore}` は chezmoi 配置のまま無傷。

## 実装（role 別ファイル）

新規: `store.rs`（ストア）/ `inject.rs`（`@@name@@` 置換）/ `prompt.rs`（TTY 判定・termios 非エコー）/ `resolve.rs`（apply 時の取得・解決）/ `secret.rs`（secret set）/ `doctor.rs`（診断雛形）。
改修: `manifest.rs`（locals/sensitive＋検証）/ `apply.rs`・`copy.rs`・`compose.rs`（解決値の注入結線）/ `main.rs`（Secret/Doctor サブコマンド）/ `Cargo.toml`（libc）。

## 検証

- `cargo test --workspace`: 210 passed（新 E2E `tests/e2e/secrets.rs` 含む）
- `cargo fmt --all --check` / `mise run check` / `cargo clippy --workspace --all-targets`: クリーン
- 手動: 一時 HOME で `secret set git.email/git.name` → `apply` → `git var GIT_AUTHOR_IDENT` が `Toshiki <me@example.com>`（native `[include]` の実行時解決＋注入を確認）

### 未自動化（手動検証で担保）

- **sensitive の TTY 非エコー対話**は pty 依存で assert_cmd では再現困難なため自動 E2E から除外。実端末で synthetic な sensitive local を使い、入力がエコーされないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)