### PR TITLE
docs(dotfiles): apply ヘルプ文を実態（copy / generate / overlay 合成）に更新 [#507]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// 固定ソース `configs/` を走査し設定を配置する（copy 層）。
+    /// 固定ソース `configs/` を走査し、copy / generate / overlay 合成で設定を配置する。
     Apply,
     /// configs の manifest を集約し、配置先一覧を表示する。
     List,


### PR DESCRIPTION
## 概要

`apply` サブコマンドのヘルプ文「（copy 層）」が実態（copy + compose）と古かったのを修正する。Closes #507。

## 背景

`apply` は `src/apply.rs:70` の `uses_compose` 分岐で copy と compose（generate / overlay）の**両経路**を回す。しかし `src/main.rs:54` のサブコマンド説明は `（copy 層）` のままで、同 `main.rs` のモジュール doc（両経路を正しく記述）と食い違っていた。

## 変更

```diff
-    /// 固定ソース `configs/` を走査し設定を配置する（copy 層）。
+    /// 固定ソース `configs/` を走査し、copy / generate / overlay 合成で設定を配置する。
```

語彙は `placement_label`（`copy` / `generate` / `overlay`）に揃えた。

## 確認

- `cargo build -p dotfiles` 成功
- `dotfiles --help` の `apply` 行が更新後の文言で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
