### PR TITLE
refactor(dotfiles): Kind / Strategy の表示文字列を Display に集約し複製を解消 [#506]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strum",
  "tempfile",
  "toml",
 ]
@@ -838,6 +839,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ libc       = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 sha2       = { workspace = true }
+strum      = { workspace = true }
 tempfile   = { workspace = true }
 toml       = { workspace = true }
 
@@ -55,6 +56,7 @@ libc          = "0.2"
 serde         = { version = "1", features = [ "derive" ] }
 serde_json    = "1"
 sha2          = "0.10"
+strum         = { version = "0.27", features = [ "derive" ] }
 tempfile      = "3"
 toml          = "0.8"
 # E2E（dev-dependencies）

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -12,7 +12,7 @@
 //! 本モジュールはオーケストレーションと、両経路が共有する小道具（`~` 展開・パーミッション適用）を持つ。
 
 use crate::discover::{self, MANIFEST, Unit};
-use crate::manifest::{Kind, Manifest, Strategy};
+use crate::manifest::{Kind, Manifest};
 use crate::onchange::State as HookState;
 use crate::store::Store;
 use crate::{compose, copy, gate, hooks, prompt, resolve};
@@ -86,18 +86,15 @@ fn uses_compose(manifest: &Manifest) -> bool {
 }
 
 /// 表示用の配置ラベル（apply の 1 行出力）。overlay 明示は strategy を併記する。
-fn placement_label(manifest: &Manifest) -> &'static str {
+/// 表示名は [`Kind`] / [`crate::manifest::Strategy`] の `Display` に集約する（list の属性と同じ出所）。
+fn placement_label(manifest: &Manifest) -> String {
     if !manifest.overlay.is_empty() {
         return match manifest.strategy {
-            Some(Strategy::JsonShallow) => "overlay/json-shallow",
-            Some(Strategy::Concat) => "overlay/concat",
-            None => "overlay",
+            Some(strategy) => format!("overlay/{strategy}"),
+            None => "overlay".to_string(),
         };
     }
-    match manifest.kind {
-        Kind::Copy => "copy",
-        Kind::Generate => "generate",
-    }
+    manifest.kind.to_string()
 }
 
 /// 配置済みファイルへ manifest のパーミッションを適用する（Unix のみ）。

--- a/src/list.rs
+++ b/src/list.rs
@@ -5,7 +5,7 @@
 //! `home` は不要（dst は manifest の生表記 `~/...` をそのまま見せる方が読みやすい）。
 
 use crate::discover::{self, MANIFEST};
-use crate::manifest::{Kind, Manifest, Strategy};
+use crate::manifest::Manifest;
 use std::path::Path;
 
 /// `source`（= `configs/`）配下の設定単位を一覧表示する。
@@ -41,21 +41,10 @@ pub fn run(source: &Path) -> Result<(), String> {
 /// 1 単位の属性ラベル（2軸モデル, §7）。
 /// kind ＋ strategy ＋ overlay 数 ＋ preserve ＋ private / executable ＋ when.deps / when.os ＋ hooks。
 fn attrs(manifest: &Manifest) -> String {
-    let mut parts = vec![
-        match manifest.kind {
-            Kind::Copy => "copy",
-            Kind::Generate => "generate",
-        }
-        .to_string(),
-    ];
+    // 表示名は Kind / Strategy の Display に集約する（apply のラベルと同じ出所）。
+    let mut parts = vec![manifest.kind.to_string()];
     if let Some(strategy) = manifest.strategy {
-        parts.push(
-            match strategy {
-                Strategy::Concat => "concat",
-                Strategy::JsonShallow => "json-shallow",
-            }
-            .to_string(),
-        );
+        parts.push(strategy.to_string());
     }
     if !manifest.overlay.is_empty() {
         parts.push(format!("overlay={}", manifest.overlay.len()));

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -18,6 +18,7 @@
 //! theme は後続（color）スライスで追加する。
 
 use serde::Deserialize;
+use std::fmt;
 use std::path::Path;
 
 /// 1 つの設定単位（`manifest.toml` を持つディレクトリ）の配置仕様。
@@ -94,6 +95,17 @@ pub enum Kind {
     Generate,
 }
 
+/// 表示名の唯一の出所。apply のラベル・list の属性が共有する。文字列は serde の `rename_all`
+/// （受理する TOML トークン）と一致させる（一致は tests の round-trip が保証する）。
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Copy => "copy",
+            Self::Generate => "generate",
+        })
+    }
+}
+
 /// 合成戦略（複数断片を1 dst=ファイルへ重ねる方法, §5.5）。
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -102,6 +114,17 @@ pub enum Strategy {
     Concat,
     /// JSON のトップレベル shallow merge（後勝ち）。deep merge はしない。
     JsonShallow,
+}
+
+/// 表示名の唯一の出所。apply のラベル・list の属性・validate のエラー文が共有する。文字列は
+/// serde の `rename_all`（受理する TOML トークン）と一致させる（一致は tests の round-trip が保証する）。
+impl fmt::Display for Strategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Concat => "concat",
+            Self::JsonShallow => "json-shallow",
+        })
+    }
 }
 
 /// 1 つの overlay（条件付き断片, §5.5）。`when` を満たす時だけ合成に参加する。
@@ -182,12 +205,17 @@ impl Manifest {
     ///   コマンドそのものをデータとして宣言する（binary は実行するだけ）。
     fn validate(&self) -> Result<(), String> {
         if !self.overlay.is_empty() && self.strategy.is_none() {
-            return Err(
-                "overlay を明示する場合は strategy（concat / json-shallow）が必要です".to_string(),
-            );
+            return Err(format!(
+                "overlay を明示する場合は strategy（{} / {}）が必要です",
+                Strategy::Concat,
+                Strategy::JsonShallow,
+            ));
         }
         if self.preserve && self.strategy != Some(Strategy::JsonShallow) {
-            return Err("preserve = true は strategy = \"json-shallow\" 専用です".to_string());
+            return Err(format!(
+                "preserve = true は strategy = \"{}\" 専用です",
+                Strategy::JsonShallow
+            ));
         }
         if self.preserve && self.overlay.is_empty() && self.kind != Kind::Generate {
             return Err(
@@ -260,6 +288,31 @@ mod tests {
         let manifest: Manifest = toml::from_str(toml_src).map_err(|e| e.to_string())?;
         manifest.validate()?;
         Ok(manifest)
+    }
+
+    #[test]
+    fn kind_display_round_trips_through_serde() {
+        // Display（表示名の出所）が serde の受理トークンと一致することを固定する。ズレると
+        // apply / list の表示が manifest に書ける値からズレる。
+        for kind in [Kind::Copy, Kind::Generate] {
+            let parsed = parse(&format!("dst = \"~/x\"\nkind = \"{kind}\"\n")).unwrap();
+            assert_eq!(
+                parsed.kind, kind,
+                "Display と serde 表現がズレている: {kind}"
+            );
+        }
+    }
+
+    #[test]
+    fn strategy_display_round_trips_through_serde() {
+        for strategy in [Strategy::Concat, Strategy::JsonShallow] {
+            let parsed = parse(&format!("dst = \"~/x\"\nstrategy = \"{strategy}\"\n")).unwrap();
+            assert_eq!(
+                parsed.strategy,
+                Some(strategy),
+                "Display と serde 表現がズレている: {strategy}"
+            );
+        }
     }
 
     #[test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -87,10 +87,8 @@ pub struct Manifest {
 }
 
 /// 生成方式（断片の実体化方法）。copy / generate。`merge` は kind ではなく `strategy`（§5.5）。
-///
-/// 表示名（apply のラベル・list の属性）は変種名を唯一の出所として導出する: `Display`
-/// （strum `serialize_all`）と serde `rename_all` が同じ `lowercase` 規則で変換するため、
-/// 変種を足すと両方へ同時に反映される。両規則が揃っていることは tests の round-trip が保証する。
+/// 表示名（`Display`）と受理する TOML トークン（serde）を一致させるため `serialize_all` と
+/// `rename_all` は同じ規則で揃える（ズレは tests の round-trip が検出する）。
 #[derive(Debug, Deserialize, Default, PartialEq, Eq, Display)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
@@ -101,9 +99,7 @@ pub enum Kind {
 }
 
 /// 合成戦略（複数断片を1 dst=ファイルへ重ねる方法, §5.5）。
-///
-/// 表示名（apply のラベル・list の属性・validate のエラー文）は [`Kind`] と同様、変種名を唯一の
-/// 出所として `Display`（strum `serialize_all`）と serde `rename_all` が同じ `kebab-case` 規則で導出する。
+/// 表示名と TOML トークンを揃える規則は [`Kind`] と同じ（`serialize_all` / `rename_all` を `kebab-case` に）。
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Display)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -18,8 +18,8 @@
 //! theme は後続（color）スライスで追加する。
 
 use serde::Deserialize;
-use std::fmt;
 use std::path::Path;
+use strum::Display;
 
 /// 1 つの設定単位（`manifest.toml` を持つディレクトリ）の配置仕様。
 ///
@@ -87,44 +87,31 @@ pub struct Manifest {
 }
 
 /// 生成方式（断片の実体化方法）。copy / generate。`merge` は kind ではなく `strategy`（§5.5）。
-#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
+///
+/// 表示名（apply のラベル・list の属性）は変種名を唯一の出所として導出する: `Display`
+/// （strum `serialize_all`）と serde `rename_all` が同じ `lowercase` 規則で変換するため、
+/// 変種を足すと両方へ同時に反映される。両規則が揃っていることは tests の round-trip が保証する。
+#[derive(Debug, Deserialize, Default, PartialEq, Eq, Display)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum Kind {
     #[default]
     Copy,
     Generate,
 }
 
-/// 表示名の唯一の出所。apply のラベル・list の属性が共有する。文字列は serde の `rename_all`
-/// （受理する TOML トークン）と一致させる（一致は tests の round-trip が保証する）。
-impl fmt::Display for Kind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Copy => "copy",
-            Self::Generate => "generate",
-        })
-    }
-}
-
 /// 合成戦略（複数断片を1 dst=ファイルへ重ねる方法, §5.5）。
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+///
+/// 表示名（apply のラベル・list の属性・validate のエラー文）は [`Kind`] と同様、変種名を唯一の
+/// 出所として `Display`（strum `serialize_all`）と serde `rename_all` が同じ `kebab-case` 規則で導出する。
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Display)]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum Strategy {
     /// テキスト連結（後ろへ連結）。境目に改行を 1 つ補う。
     Concat,
     /// JSON のトップレベル shallow merge（後勝ち）。deep merge はしない。
     JsonShallow,
-}
-
-/// 表示名の唯一の出所。apply のラベル・list の属性・validate のエラー文が共有する。文字列は
-/// serde の `rename_all`（受理する TOML トークン）と一致させる（一致は tests の round-trip が保証する）。
-impl fmt::Display for Strategy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Concat => "concat",
-            Self::JsonShallow => "json-shallow",
-        })
-    }
 }
 
 /// 1 つの overlay（条件付き断片, §5.5）。`when` を満たす時だけ合成に参加する。


### PR DESCRIPTION
## 背景

`Kind` / `Strategy` の表示文字列（`copy` / `generate` / `concat` / `json-shallow`）が複数箇所に手書きで複製されていた（#506）。戦略 / 種別を 1 つ足すと、コンパイラが網羅性を強制する `match` に加えて、表示リテラルを複数系統で手直しする必要があった（複製であって導出でない）。

## 変更

- `Kind` / `Strategy` に **strum の `#[derive(Display)]` ＋ `serialize_all`** を付け、表示名を一点へ収束。`Display`（strum `serialize_all`）も serde `rename_all` も**同じ変換規則（`lowercase` / `kebab-case`）で変種名から導出**されるため、表示名の出所が変種名 1 点に収束する（リテラルの再掲が消え、変種追加で両系統へ同時反映）。
- `apply` の `placement_label`、`list` の `attrs`、`manifest` の `validate` エラー文がその `Display` を参照する。
- `Display` と serde 表現（受理する TOML トークン）の規則が揃っていることを round-trip テスト 2 本で固定（issue の「serde 表現の整合も一箇所に集約」をガードで担保）。
- `compose` の `match Strategy` は表示でなく戦略のセマンティック分岐なので対象外（コンパイラが網羅性を強制）。

## 影響

挙動非変更のリファクタリング。表示文字列はバイト等価で、E2E 含む全テスト（106）・clippy・rustdoc・fmt・taplo 通過。strum を root crate の依存に追加（`features = ["derive"]`、v0.27）。

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
