### PR TITLE
feat(dotfiles): ソース解決の二段構え（埋め込みフォールバック）[#462]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ version = "0.69.6"
 dependencies = [
  "assert_cmd",
  "clap",
+ "include_dir",
  "libc",
  "predicates",
  "rstest",
@@ -502,6 +503,25 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,15 @@ repository  = { workspace = true }
 version     = "0.69.6"
 
 [dependencies]
-clap       = { workspace = true }
-libc       = { workspace = true }
-serde      = { workspace = true }
-serde_json = { workspace = true }
-sha2       = { workspace = true }
-strum      = { workspace = true }
-tempfile   = { workspace = true }
-toml       = { workspace = true }
+clap        = { workspace = true }
+include_dir = { workspace = true }
+libc        = { workspace = true }
+serde       = { workspace = true }
+serde_json  = { workspace = true }
+sha2        = { workspace = true }
+strum       = { workspace = true }
+tempfile    = { workspace = true }
+toml        = { workspace = true }
 
 [lints]
 workspace = true
@@ -52,6 +53,7 @@ repository = "https://github.com/toshiki670/dotfiles"
 clap          = { version = "4", features = [ "derive" ] }
 clap_complete = "4"
 ignore        = "0.4"
+include_dir   = "0.7"
 libc          = "0.2"
 serde         = { version = "1", features = [ "derive" ] }
 serde_json    = "1"

--- a/src/list.rs
+++ b/src/list.rs
@@ -3,13 +3,16 @@
 //! 設計書 §11 の「分散方式の弱点（全体一覧が横断的）を補う」俯瞰ビュー。各単位を
 //! source 相対名でソートし、`名前 → dst [属性]` の形で出力する。配置は行わないため
 //! `home` は不要（dst は manifest の生表記 `~/...` をそのまま見せる方が読みやすい）。
+//!
+//! 見出しには `source` の実 path でなく解決元ラベル（`origin`・[`crate::source::Origin`]）を出す。
+//! 埋め込み時の `source` は temp dir で、実 path を生で見せても俯瞰の役に立たないため（§8）。
 
 use crate::discover::{self, MANIFEST};
 use crate::manifest::Manifest;
 use std::path::Path;
 
-/// `source`（= `configs/`）配下の設定単位を一覧表示する。
-pub fn run(source: &Path) -> Result<(), String> {
+/// `source` 配下の設定単位を一覧表示する。`origin` は見出しに出す解決元ラベル（§8）。
+pub fn run(source: &Path, origin: &str) -> Result<(), String> {
     let units = discover::collect(source)?;
     if units.is_empty() {
         println!(
@@ -27,7 +30,7 @@ pub fn run(source: &Path) -> Result<(), String> {
     rows.sort_by(|a, b| a.0.cmp(&b.0));
 
     let width = rows.iter().map(|(name, _)| name.len()).max().unwrap_or(0);
-    println!("dotfiles list（source: {}）", source.display());
+    println!("dotfiles list（source: {origin}）");
     for (name, manifest) in &rows {
         println!(
             "  {name:<width$}  → {dst}  [{attrs}]",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@
 //! `--version` / `--help` はバージョンの source of truth（タグ `v{version}`）を担う。
 //!
 //! `apply` / `list` サブコマンドは dotfiles ネイティブ化（Epic #453）の一部：
-//! 固定ソース `configs/` を走査し、`manifest.toml` に従って配置する。配置は **2軸**
+//! ソース（`configs/` の実体）を二段構えで解決し（作業ツリー検出 → 埋め込み・[`source`]、§8）、
+//! `manifest.toml` に従って配置する。配置は **2軸**
 //! （生成方式 `kind`=copy/generate × 合成 `strategy`=concat/json-shallow）＋条件付き overlay
 //! （`when` gate）で捉える（設計書 §5 / §5.5）。copy はツリー配置、generate / overlay 明示は
 //! ファイル合成（[`compose`]）を通り、トップレベル `when`（`deps` / `os`）はユニット単位 gate（[`gate`]）。配置の直前に
@@ -15,7 +16,7 @@
 
 use clap::{Parser, Subcommand};
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 mod apply;
 mod color;
@@ -33,6 +34,7 @@ mod onchange;
 mod prompt;
 mod resolve;
 mod secret;
+mod source;
 mod store;
 mod strategy;
 
@@ -47,11 +49,17 @@ mod strategy;
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
+
+    /// ソースルートを明示指定する（§8 の上級オプション。通常は作業ツリー検出 → 埋め込みで自動解決）。
+    ///
+    /// apply / list / doctor 横断で効く（`global`）。前面に出さない（`hide`）。
+    #[arg(long, global = true, hide = true, value_name = "DIR")]
+    source: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
 enum Commands {
-    /// 固定ソース `configs/` を走査し、copy / generate / overlay 合成で設定を配置する。
+    /// ソース（作業ツリー / 埋め込み・§8）を走査し、copy / generate / overlay 合成で設定を配置する。
     Apply,
     /// configs の manifest を集約し、配置先一覧を表示する。
     List,
@@ -85,9 +93,10 @@ enum SecretAction {
 
 fn main() {
     let cli = Cli::parse();
+    let source = cli.source.as_deref();
     let result = match cli.command {
-        Some(Commands::Apply) => run_apply(),
-        Some(Commands::List) => list::run(Path::new("configs")),
+        Some(Commands::Apply) => run_apply(source),
+        Some(Commands::List) => run_list(source),
         Some(Commands::Secret {
             action: SecretAction::Set { name, value },
         }) => run_secret_set(&name, &value),
@@ -97,7 +106,7 @@ fn main() {
             color::sample();
             Ok(())
         }
-        Some(Commands::Doctor) => run_doctor(),
+        Some(Commands::Doctor) => run_doctor(source),
         // サブコマンドなし: 従来どおりバージョンを表示する。
         None => {
             println!("dotfiles {}", env!("CARGO_PKG_VERSION"));
@@ -110,10 +119,19 @@ fn main() {
     }
 }
 
-/// `dotfiles apply`：CWD 相対の固定ソース `configs/` を、HOME を基点に配置する。
-fn run_apply() -> Result<(), String> {
+/// `dotfiles apply`：ソースを二段構えで解決し（§8）、HOME を基点に配置する。
+/// 解決元（作業ツリー / 埋め込み / `--source`）を 1 行目に示す。
+fn run_apply(source: Option<&Path>) -> Result<(), String> {
     let home = home_dir()?;
-    apply::run(Path::new("configs"), Path::new(&home))
+    let resolved = source::resolve(source)?;
+    println!("apply: source = {}", resolved.origin());
+    apply::run(resolved.root(), Path::new(&home))
+}
+
+/// `dotfiles list`：ソースを二段構えで解決し、配置先一覧を解決元の表示付きで出す。
+fn run_list(source: Option<&Path>) -> Result<(), String> {
+    let resolved = source::resolve(source)?;
+    list::run(resolved.root(), &resolved.origin().to_string())
 }
 
 /// `dotfiles secret set <name> <value>`：named value をストアへ保存する。
@@ -122,10 +140,11 @@ fn run_secret_set(name: &str, value: &str) -> Result<(), String> {
     secret::set(Path::new(&home), name, value)
 }
 
-/// `dotfiles doctor`：`configs/` の `locals` 宣言とストアを突き合わせ未設定を報告する。
-fn run_doctor() -> Result<(), String> {
+/// `dotfiles doctor`：ソースの `locals` 宣言とストアを突き合わせ未設定を報告する。
+fn run_doctor(source: Option<&Path>) -> Result<(), String> {
     let home = home_dir()?;
-    doctor::run(Path::new("configs"), Path::new(&home))
+    let resolved = source::resolve(source)?;
+    doctor::run(resolved.root(), Path::new(&home))
 }
 
 /// HOME を取得する（dst の `~` 展開・ストアパスの基点）。

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,182 @@
+//! ソースの二段構え（§8）: 配置エンジンが読む `configs/` の実体をどこから得るかを解決する。
+//!
+//! 解決優先順位（§8）は **`--source` 明示 ＞ 作業ツリー検出 ＞ 埋め込みフォールバック**。
+//!
+//! - **作業ツリー直読み**（dev / 移行期の主役）: 設定を編集して即 apply で検証できる。CWD から
+//!   上へ辿り、ユニット（`manifest.toml`）を持つ最初の `configs/` を使う。
+//! - **埋め込み**（配布の完成形）: `cargo install dotfiles` だけ（clone 無し）で自己完結させるため、
+//!   コンパイル時に `configs/` をバイナリへ焼き込み（[`include_dir`]）、解決時に temp dir へ展開する。
+//!
+//! 配置エンジン（[`crate::discover`] / [`crate::copy`] / [`crate::compose`] / [`crate::generate`] /
+//! [`crate::hooks`]）は全て実 path で `std::fs` を読む。埋め込みを temp dir へ実体化して**実 path**を
+//! 渡すことで、エンジンは「ソースが埋め込みか実 FS か」を知らずに済む（安定な core を揮発に依存させない）。
+
+use crate::discover;
+use include_dir::{Dir, include_dir};
+use std::fmt;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// コンパイル時に焼き込む `configs/`（埋め込みフォールバックの実体）。
+static EMBEDDED: Dir = include_dir!("$CARGO_MANIFEST_DIR/configs");
+
+/// 解決元（どの段で解決したか）。ユーザー向け表示（apply ヘッダ / list）に使う。
+pub enum Origin {
+    /// `--source` 明示（上級オプション）。
+    Explicit(PathBuf),
+    /// 作業ツリー検出（移行期の主役）。
+    WorkingTree(PathBuf),
+    /// 埋め込みフォールバック（clone 無しの配布）。
+    Embedded,
+}
+
+impl fmt::Display for Origin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Origin::Explicit(p) => write!(f, "--source ({})", p.display()),
+            Origin::WorkingTree(p) => write!(f, "作業ツリー ({})", p.display()),
+            Origin::Embedded => write!(f, "埋め込み"),
+        }
+    }
+}
+
+/// 解決済みソース。エンジンへ渡す実 path（[`Resolved::root`]）と解決元（[`Resolved::origin`]）を持つ。
+///
+/// `_temp` は埋め込み展開先の生存保証: [`TempDir`] は drop で中身を削除するため、apply / list /
+/// doctor が `root` を読み終えるまで `Resolved` を保持する必要がある（明示・作業ツリー時は `None`）。
+pub struct Resolved {
+    root: PathBuf,
+    origin: Origin,
+    _temp: Option<TempDir>,
+}
+
+impl Resolved {
+    /// エンジンへ渡すソースルートの実 path。
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// 解決元（表示用）。
+    pub fn origin(&self) -> &Origin {
+        &self.origin
+    }
+}
+
+/// ソースを二段構えで解決する（§8 の優先順位）。
+///
+/// 1. `explicit`（`--source`）あり → そのまま使う（dir でなければエラー）。
+/// 2. なし → 作業ツリー検出（[`detect_working_tree`]）。
+/// 3. 見つからねば → 埋め込みを temp dir へ展開して使う。
+pub fn resolve(explicit: Option<&Path>) -> Result<Resolved, String> {
+    if let Some(path) = explicit {
+        if !path.is_dir() {
+            return Err(format!(
+                "--source {} がディレクトリとして見つかりません",
+                path.display()
+            ));
+        }
+        return Ok(Resolved {
+            root: path.to_path_buf(),
+            origin: Origin::Explicit(path.to_path_buf()),
+            _temp: None,
+        });
+    }
+
+    if let Some(root) = detect_working_tree() {
+        return Ok(Resolved {
+            origin: Origin::WorkingTree(root.clone()),
+            root,
+            _temp: None,
+        });
+    }
+
+    extract_embedded()
+}
+
+/// CWD から祖先を上へ辿り、ユニットを持つ最初の `<ancestor>/configs` を作業ツリーとみなす。
+///
+/// 「ユニットを持つ」判定は [`discover::collect`] を再利用する（「ユニットとは `manifest.toml` を
+/// 持つ dir」の出所を一本化）。これにより、たまたま同名の空 `configs/` を誤検出せず埋め込みへ落ちる。
+fn detect_working_tree() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    for ancestor in cwd.ancestors() {
+        let candidate = ancestor.join("configs");
+        if candidate.is_dir() && has_units(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// `dir` がユニット（`manifest.toml` を持つ dir）を1つ以上含むか。走査エラーは「ソースでない」扱い。
+fn has_units(dir: &Path) -> bool {
+    discover::collect(dir)
+        .map(|u| !u.is_empty())
+        .unwrap_or(false)
+}
+
+/// 埋め込んだ `configs/` を temp dir へ展開し、その実 path を解決結果にする。
+fn extract_embedded() -> Result<Resolved, String> {
+    let temp = tempfile::Builder::new()
+        .prefix("dotfiles-configs-")
+        .tempdir()
+        .map_err(|e| format!("埋め込みソースの展開先 temp dir 作成に失敗: {e}"))?;
+    EMBEDDED
+        .extract(temp.path())
+        .map_err(|e| format!("埋め込みソースの展開に失敗: {e}"))?;
+    Ok(Resolved {
+        root: temp.path().to_path_buf(),
+        origin: Origin::Embedded,
+        _temp: Some(temp),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// `--source` 明示は dir 検証して Explicit を返す。
+    #[test]
+    fn explicit_source_uses_given_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = resolve(Some(dir.path())).unwrap();
+        assert_eq!(resolved.root(), dir.path());
+        assert!(matches!(resolved.origin(), Origin::Explicit(_)));
+    }
+
+    /// `--source` が dir でなければエラー。
+    #[test]
+    fn explicit_source_missing_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        assert!(resolve(Some(&missing)).is_err());
+    }
+
+    /// ユニットを持つ `configs/` だけを作業ツリーとして検出し、空 dir は弾く。
+    #[test]
+    fn has_units_requires_a_manifest() {
+        let root = tempfile::tempdir().unwrap();
+        let configs = root.path().join("configs");
+        fs::create_dir_all(configs.join("empty")).unwrap();
+        assert!(
+            !has_units(&configs),
+            "manifest 無しの configs はユニット無し"
+        );
+
+        let unit = configs.join("foo");
+        fs::create_dir_all(&unit).unwrap();
+        fs::write(unit.join("manifest.toml"), "dst = \"~/x\"\n").unwrap();
+        assert!(has_units(&configs), "manifest を持つ dir はユニット有り");
+    }
+
+    /// 埋め込みフォールバックは temp dir へ実体化し、ユニットを伴う実 path を返す。
+    #[test]
+    fn embedded_extracts_units_to_real_path() {
+        let resolved = extract_embedded().unwrap();
+        assert!(matches!(resolved.origin(), Origin::Embedded));
+        assert!(resolved.root().is_dir());
+        // 出荷 configs は必ずユニットを持つ（埋め込みが実体化された証跡）。
+        assert!(has_units(resolved.root()), "埋め込み展開先にユニットが無い");
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -21,6 +21,9 @@ use tempfile::TempDir;
 static EMBEDDED: Dir = include_dir!("$CARGO_MANIFEST_DIR/configs");
 
 /// 解決元（どの段で解決したか）。ユーザー向け表示（apply ヘッダ / list）に使う。
+///
+/// 表示ラベルは英語にする ― 周囲の技術ラベル（`copy` / `generate` / `overlay` 等）が英語で、
+/// そこへ日本語語句を混ぜると不揃いになるため（出力の体裁を 1 系統に揃える）。
 pub enum Origin {
     /// `--source` 明示（上級オプション）。
     Explicit(PathBuf),
@@ -34,8 +37,8 @@ impl fmt::Display for Origin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Origin::Explicit(p) => write!(f, "--source ({})", p.display()),
-            Origin::WorkingTree(p) => write!(f, "作業ツリー ({})", p.display()),
-            Origin::Embedded => write!(f, "埋め込み"),
+            Origin::WorkingTree(p) => write!(f, "working tree ({})", p.display()),
+            Origin::Embedded => write!(f, "embedded"),
         }
     }
 }

--- a/tests/e2e/apply_copy.rs
+++ b/tests/e2e/apply_copy.rs
@@ -4,7 +4,6 @@
 //! パーミッション属性の合成を検証する。
 
 use crate::dotfiles;
-use predicates::prelude::*;
 use rstest::rstest;
 use std::fs;
 
@@ -38,22 +37,9 @@ fn apply_defaults_to_copy_and_expands_tilde() {
     );
 }
 
-/// `configs/` が無い場所で apply するとエラー終了することを検証する。
-#[test]
-fn apply_errors_when_source_missing() {
-    let work = tempfile::tempdir().unwrap();
-    let home = tempfile::tempdir().unwrap();
-
-    dotfiles()
-        .arg("apply")
-        .current_dir(work.path())
-        .env("HOME", home.path())
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("が見つかりません"))
-        .stderr(predicate::str::contains("探索先:"))
-        .stderr(predicate::str::contains("リポジトリのルート"));
-}
+// 「`configs/` が無い場所で apply → エラー」は S8（#462）で挙動が変わった: 作業ツリーが
+// 無ければ埋め込みフォールバックで解決するため、もうエラーにならない。解決の二段切替は
+// [`crate::source`] が検証する（ソース欠落の旧契約はそこへ移った）。
 
 /// S1 受け入れ条件: サブディレクトリ再帰・複数ファイル・manifest の再帰委譲。
 /// 親単位は配下を再帰コピーするが、自前 manifest を持つサブツリー（child）は

--- a/tests/e2e/list.rs
+++ b/tests/e2e/list.rs
@@ -1,7 +1,6 @@
-//! `dotfiles list` の E2E — 名前順・属性ラベル・ソース欠落を検証する。
+//! `dotfiles list` の E2E — 名前順・属性ラベルを検証する。
 
 use crate::dotfiles;
-use predicates::prelude::*;
 use std::fs;
 
 /// `dotfiles list` が単位を名前順に並べ、dst と属性ラベルを表示することを検証する。
@@ -50,15 +49,6 @@ fn list_shows_units_sorted_with_attrs() {
     );
 }
 
-/// `configs/` が無い場所で list するとエラー終了することを検証する。
-#[test]
-fn list_errors_when_source_missing() {
-    let work = tempfile::tempdir().unwrap();
-
-    dotfiles()
-        .arg("list")
-        .current_dir(work.path())
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("が見つかりません"));
-}
+// 「`configs/` が無い場所で list → エラー」は S8（#462）で挙動が変わった: 作業ツリーが
+// 無ければ埋め込みフォールバックで解決し、出荷 configs を一覧する。解決の二段切替は
+// [`crate::source`] が検証する。

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -23,12 +23,13 @@
 //!
 //! - [`cli`]: `--help` / `--version` / 引数なし（契約）
 //! - [`apply_copy`]: copy 層（S0/S1）— kind 既定・tilde 展開・再帰委譲・パーミッション（契約）
-//! - [`list`]: 分散 manifest の名前順・属性ラベル・ソース欠落（契約）
+//! - [`list`]: 分散 manifest の名前順・属性ラベル（契約）
 //! - [`generate`]: generate 層（S2/#456）— cmd 実行・when.deps gate・sibling 連結・list 表示（契約）
 //! - [`overlay`]: 合成軸（S3/#471）— overlay/strategy/when/preserve と load 時検証群（契約）
 //! - [`secrets`]: マシンローカル値（S4/#458）— secret set / 注入 / doctor（契約）
 //! - [`hooks`]: onchange フック（S5/#459）— 架空コマンドでエンジンの汎用実行を検証（契約）
 //! - [`color`]: `color sample`（S6/#460）— ANSI 確認表の見出し・エスケープシーケンス（契約）
+//! - [`source`]: ソース二段構え（S8/#462）— 作業ツリー検出 / 埋め込み / `--source` の解決切替（契約＋実 configs）
 //! - [`real_configs`]: 出荷 configs の妥当性（実 configs 層）— 全ユニット走査で load/apply/list
 
 use assert_cmd::Command;
@@ -42,6 +43,7 @@ mod list;
 mod overlay;
 mod real_configs;
 mod secrets;
+mod source;
 
 /// 実バイナリ `dotfiles` を起動する Command を返す（全テスト共通）。
 pub(crate) fn dotfiles() -> Command {

--- a/tests/e2e/source.rs
+++ b/tests/e2e/source.rs
@@ -1,0 +1,112 @@
+//! ソース二段構え（S8/#462・設計書 §8）の解決切替を検証する E2E。
+//!
+//! 受け入れ条件「作業ツリー有/無での解決切替」を、`dotfiles apply` の 1 行目
+//! （`apply: source = {origin}`）と実際に配置されたユニットの両面で確かめる:
+//!
+//! - **作業ツリー検出**: CWD のサブディレクトリから上へ辿り、ユニットを持つ `configs/` を使う
+//!   （hermetic な架空 fixture `foo`）。
+//! - **`--source` 明示**: 検出に掛からない CWD でも、指定したソースが最優先で使われる（fixture `bar`）。
+//! - **埋め込みフォールバック**: 作業ツリーが無ければバイナリ埋め込みの出荷 configs で apply が
+//!   完結する（clone 無しの自己完結。実 configs 層なので空 PATH で dep gate / bare hook を無効化）。
+
+use crate::dotfiles;
+use predicates::prelude::*;
+use std::fs;
+
+/// `<root>/configs/<unit>` に最小の copy ユニット（`dst` ＋ 1 ファイル）を作る。
+fn write_unit(configs: &std::path::Path, unit: &str, dst: &str, file: &str) {
+    let dir = configs.join(unit);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("manifest.toml"), format!("dst = \"{dst}\"\n")).unwrap();
+    fs::write(dir.join(file), "x\n").unwrap();
+}
+
+/// 作業ツリー検出: CWD のサブディレクトリから上へ辿り、ユニットを持つ `configs/` を解決元にする。
+#[test]
+fn detects_working_tree_from_subdir() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_unit(
+        &work.path().join("configs"),
+        "foo",
+        "~/.config/foo",
+        "foo.conf",
+    );
+
+    // CWD をリポ相当 `work` のサブディレクトリにし、上方向検出（ancestors）が効くことを示す。
+    let sub = work.path().join("sub/deep");
+    fs::create_dir_all(&sub).unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(&sub)
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        // 解決元が作業ツリーであることを 1 行目で示す。
+        .stdout(predicate::str::contains("source = 作業ツリー"));
+
+    // 検出した作業ツリーの fixture（埋め込みでない）が配置された証跡。
+    assert!(
+        home.path().join(".config/foo/foo.conf").is_file(),
+        "作業ツリーの fixture が配置されていない",
+    );
+}
+
+/// `--source` 明示は最優先（検出に掛からない CWD でも、指定ソースが使われる）。
+#[test]
+fn explicit_source_takes_precedence() {
+    let explicit = tempfile::tempdir().unwrap(); // ここを `--source` のソースルートにする。
+    let cwd = tempfile::tempdir().unwrap(); // configs を持たない隔離 CWD。
+    let home = tempfile::tempdir().unwrap();
+    write_unit(explicit.path(), "bar", "~/.config/bar", "bar.conf");
+
+    dotfiles()
+        .arg("apply")
+        .arg("--source")
+        .arg(explicit.path())
+        .current_dir(cwd.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("source = --source"));
+
+    assert!(
+        home.path().join(".config/bar/bar.conf").is_file(),
+        "--source 指定のソースが配置されていない",
+    );
+}
+
+/// 埋め込みフォールバック: 作業ツリーが無ければ出荷 configs（埋め込み）で apply が完結する。
+///
+/// 隔離 CWD（configs 祖先なし）＋空 PATH で実行する。空 PATH は実 configs 層の決まり事
+/// （[`crate::real_configs`] と同じ）で、dep gate を決定的に外し bare hook を未インストール
+/// （skip）にして apply を決定的にする。
+#[test]
+fn falls_back_to_embedded_without_working_tree() {
+    let cwd = tempfile::tempdir().unwrap(); // configs を持たない隔離 CWD（祖先にも configs 無し）。
+    let home = tempfile::tempdir().unwrap();
+    let empty_path = tempfile::tempdir().unwrap();
+
+    let out = dotfiles()
+        .arg("apply")
+        .current_dir(cwd.path())
+        .env("HOME", home.path())
+        .env("PATH", empty_path.path())
+        .assert()
+        .success()
+        // 解決元が埋め込みであることを 1 行目で示す。
+        .stdout(predicate::str::contains("source = 埋め込み"))
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(out).unwrap();
+
+    // 出荷 configs が埋め込みから配置された証跡: ユニット配置行（`… → … (label)`）が 1 件以上。
+    // ツール名はハードコードしない（実 configs 層・data-driven）。
+    let placements = stdout.lines().filter(|l| l.contains(" → ")).count();
+    assert!(
+        placements > 0,
+        "埋め込みフォールバックでユニットが 1 つも配置されていない:\n{stdout}",
+    );
+}

--- a/tests/e2e/source.rs
+++ b/tests/e2e/source.rs
@@ -44,7 +44,7 @@ fn detects_working_tree_from_subdir() {
         .assert()
         .success()
         // 解決元が作業ツリーであることを 1 行目で示す。
-        .stdout(predicate::str::contains("source = 作業ツリー"));
+        .stdout(predicate::str::contains("source = working tree"));
 
     // 検出した作業ツリーの fixture（埋め込みでない）が配置された証跡。
     assert!(
@@ -96,7 +96,7 @@ fn falls_back_to_embedded_without_working_tree() {
         .assert()
         .success()
         // 解決元が埋め込みであることを 1 行目で示す。
-        .stdout(predicate::str::contains("source = 埋め込み"))
+        .stdout(predicate::str::contains("source = embedded"))
         .get_output()
         .stdout
         .clone();


### PR DESCRIPTION
## 概要

Epic #453（dotfiles ネイティブ化）の **S8: ソース解決の二段構え**（#462）。`apply` / `list` / `doctor` が読む `configs/` の実体を、CWD 相対の固定パスから設計書 §8 の二段構えへ切り替える。これで `cargo install dotfiles` 単体（clone 無し）でも設定込みの apply が完結する＝バイナリ方式の完成。

解決優先順位（§8）: **`--source` 明示 ＞ 作業ツリー検出 ＞ 埋め込みフォールバック**。

## 設計

配置エンジン（`discover` / `copy` / `compose` / `generate` / `hooks` / `onchange`）は全て実 path で `std::fs` を読む。ここに埋め込み（仮想 FS）の抽象を貫通させると安定な core がソース種別の詳細に依存するため、**埋め込みソースは解決時に temp dir へ展開して実 path をエンジンへ渡す**。ソース解決の分岐は新規 `src/source.rs` 一箇所に閉じ、エンジンは無改修。onchange は内容ハッシュなので展開先 temp path が変わってもハッシュは安定（状態は HOME 側に永続）。

## 変更点

- **依存**: `include_dir = "0.7"` を追加。`include_dir!("$CARGO_MANIFEST_DIR/configs")` で `configs/` をバイナリへ焼き込む。
- **`src/source.rs`（新規）**: `Origin`（Explicit / WorkingTree / Embedded）＋ `Resolved`（実 path ＋ temp 生存保証）＋ `resolve()`。作業ツリー検出は CWD の祖先を上へ辿り、ユニット（`manifest.toml`）を持つ最初の `configs/` を採る（リポ内サブディレクトリからも効く）。ユニット判定は `discover::collect` を再利用。
- **`main.rs`**: `--source <DIR>` を追加（`global` ＝ apply / list / doctor 横断・`hide` ＝ help 非表示）。各 arm で `source::resolve` を 1 回呼ぶ。
- **可視化**: `apply` は 1 行目に `apply: source = {origin}`、`list` は見出しに解決元ラベル（埋め込み時の temp path を生で見せない）。

## 挙動変更

作業ツリーが無い場所での `apply` / `list` は「ソース欠落エラー」でなく**埋め込みフォールバックで完結**する。旧「ソース欠落エラー」契約は `source.rs` の解決切替 E2E へ移し、`apply_copy` / `list` の当該テストを削除した。

## 受け入れ条件

- [x] include_dir で configs をバイナリに埋め込む
- [x] ソース解決を二段化（作業ツリー検出＋埋め込みフォールバック、環境判定）
- [x] 解決順序（作業ツリー検出 → 埋め込み。`--source` は上級オプションで前面に出さない）
- [x] 別マシン／clone 無しで apply が完結
- [x] E2E: 作業ツリー有/無での解決切替を検証（`tests/e2e/source.rs`）

## 検証

- `cargo test -p dotfiles`: 111 passed（新規 E2E 3 ＋ ユニット 4 を含む）
- `cargo clippy --all-targets -- -D warnings`: clean / `cargo fmt --all --check`: clean / `mise run check`: clean
- 手動: リポ外＋空 PATH で `apply` → `source = 埋め込み` で出荷 configs を配置。リポ root / `src/` サブディレクトリから → `source = 作業ツリー`。`apply --help` に `--source` は非表示。
- release バイナリ 1.5M（configs は 248K・§8 想定どおり増分は実用上無視できる）。

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
