### PR TITLE
feat(cli): completions を top-level --completions フラグ化し Tab 候補から隠す [#526]

### DIFF
--- a/configs/clip/completion/manifest.toml
+++ b/configs/clip/completion/manifest.toml
@@ -1,8 +1,9 @@
 # clip（src/clip）の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
-# `clip completions fish` の出力を dst のファイルへ書き出す。
+# `clip --completions fish` の出力を dst のファイルへ書き出す（completions は top-level option。
+# サブコマンドにしないことで `clip <Tab>` の候補に出さない）。
 # when.deps = clip が PATH に無ければ生成をスキップ（ユニット gate, §5.5）。chezmoi apply 初回など
 # clip 未 install の段階では生成されない。
-cmd  = [ "clip", "completions", "fish" ]
+cmd  = [ "clip", "--completions", "fish" ]
 dst  = "~/.config/fish/completions/clip.fish"
 kind = "generate"
 when = { deps = [ "clip" ] }

--- a/configs/dotfiles/completion/manifest.toml
+++ b/configs/dotfiles/completion/manifest.toml
@@ -1,0 +1,9 @@
+# dotfiles core（src/core）の fish 補完を生成・配置する（generate 層 / 設計書 §5・§7）。
+# `dotfiles --completions fish` の出力を dst のファイルへ書き出す（completions は top-level option。
+# サブコマンドにしないことで `dotfiles <Tab>` の候補に出さない）。
+# when.deps = dotfiles が PATH に無ければ生成をスキップ（ユニット gate, §5.5）。chezmoi apply 初回など
+# dotfiles 未 install の段階では生成されない。
+cmd  = [ "dotfiles", "--completions", "fish" ]
+dst  = "~/.config/fish/completions/dotfiles.fish"
+kind = "generate"
+when = { deps = [ "dotfiles" ] }

--- a/home/dot_config/fish/completions/clip.fish.tmpl
+++ b/home/dot_config/fish/completions/clip.fish.tmpl
@@ -1,3 +1,3 @@
 {{ if lookPath "clip" -}}
-{{ output "clip" "completions" "fish" }}
+{{ output "clip" "--completions" "fish" }}
 {{- end }}

--- a/src/clip/cli.rs
+++ b/src/clip/cli.rs
@@ -16,8 +16,12 @@ use super::{obj, path, text};
     about = "Copy a file to the clipboard (obj / text / path; macOS)"
 )]
 struct Cli {
+    /// Print a shell completion script to stdout and exit.
+    #[arg(long, value_name = "SHELL")]
+    completions: Option<Shell>,
+
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -37,23 +41,26 @@ enum Commands {
         /// コピー対象のファイル。
         file: String,
     },
-    /// Print a shell completion script to stdout.
-    Completions {
-        /// 対象シェル（bash / fish / zsh / …）。
-        shell: Shell,
-    },
 }
 
 /// CLI を解析し、サブコマンドへディスパッチする。
 pub fn run() -> ExitCode {
     let cli = Cli::parse();
+
+    // `--completions <shell>`: 補完スクリプトを stdout へ出して終了する。サブコマンドではなく
+    // top-level option にすることで `clip <Tab>` の候補に出さない（fish は `-` 始まりのみ option を出す）。
+    if let Some(shell) = cli.completions {
+        let mut cmd = Cli::command();
+        clap_complete::generate(shell, &mut cmd, "clip", &mut io::stdout());
+        return ExitCode::SUCCESS;
+    }
+
     match cli.command {
-        Commands::Obj { file } => obj::run(&file),
-        Commands::Text { file } => text::run(&file),
-        Commands::Path { file } => path::run(&file),
-        Commands::Completions { shell } => {
-            let mut cmd = Cli::command();
-            clap_complete::generate(shell, &mut cmd, "clip", &mut io::stdout());
+        Some(Commands::Obj { file }) => obj::run(&file),
+        Some(Commands::Text { file }) => text::run(&file),
+        Some(Commands::Path { file }) => path::run(&file),
+        None => {
+            let _ = Cli::command().print_help();
             ExitCode::SUCCESS
         }
     }

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -3,8 +3,10 @@
 //! [`run`] が `src/bin/dotfiles.rs` の数行シムから呼ばれる入口。各サブコマンドの実体は
 //! core 配下の対応モジュール（[`super::apply`] / [`super::list`] / [`super::local`] …）にある。
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use std::ffi::OsString;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use super::{apply, color, doctor, list, local, profile, source};
@@ -18,6 +20,13 @@ use super::{apply, color, doctor, list, local, profile, source};
     long_about = "toshiki670/dotfiles 本体（core）。設定の管理・配置を担う。\nサブコマンドを指定しない場合はバージョンを表示する。"
 )]
 struct Cli {
+    /// Print a shell completion script to stdout and exit.
+    ///
+    /// top-level option にすることで `dotfiles <Tab>` の候補に出さない（fish は `-` 始まりのみ
+    /// option を候補にする）。`global` は付けない（サブコマンドへ伝播させない）。
+    #[arg(long, value_name = "SHELL")]
+    completions: Option<Shell>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 
@@ -74,6 +83,13 @@ enum LocalAction {
 /// `dotfiles` の入口。引数を解釈し、サブコマンドへディスパッチする。
 pub fn run() {
     let cli = Cli::parse();
+
+    // `--completions <shell>`: 補完スクリプトを stdout へ出して終了する。
+    if let Some(shell) = cli.completions {
+        generate(shell, &mut Cli::command(), "dotfiles", &mut io::stdout());
+        return;
+    }
+
     let source = cli.source.as_deref();
     let result = match cli.command {
         Some(Commands::Apply) => run_apply(source),

--- a/tests/clip/cli.rs
+++ b/tests/clip/cli.rs
@@ -25,12 +25,12 @@ fn version_flag_prints_name_and_version(#[case] flag: &str) {
 }
 
 #[test]
-fn no_subcommand_fails_with_usage() {
+fn no_subcommand_prints_help() {
+    // command が Option になり、サブコマンド無しは help を表示して正常終了する。
     clip()
         .assert()
-        .failure()
-        .code(2)
-        .stderr(predicate::str::contains("Usage").or(predicate::str::contains("subcommand")));
+        .success()
+        .stdout(predicate::str::contains("Usage"));
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn subcommand_without_file_fails(#[case] sub: &str) {
 #[test]
 fn completions_fish_prints_script() {
     clip()
-        .args(["completions", "fish"])
+        .args(["--completions", "fish"])
         .assert()
         .success()
         .stdout(predicate::str::contains("complete"))

--- a/tests/clip/mod.rs
+++ b/tests/clip/mod.rs
@@ -5,8 +5,8 @@
 //!
 //! # 検証内容（対象別ファイル）
 //!
-//! - `cli`:  `--help`/`--version`、サブコマンド無し/未知サブコマンド/ファイル引数欠落で
-//!   exit code 2、`completions fish` が補完スクリプトを出力（OS 非依存）
+//! - `cli`:  `--help`/`--version`、未知サブコマンド/ファイル引数欠落で exit code 2、
+//!   サブコマンド無しは help 表示、`--completions fish` が補完スクリプトを出力（OS 非依存）
 //! - `obj`:  macOS で osascript を `set the clipboard to POSIX file …` で呼ぶ／非 macOS で失敗
 //! - `text`: macOS で pbcopy にファイルの中身をそのまま渡す／非 macOS で失敗
 //! - `path`: macOS で絶対パスを pbcopy へ渡し stdout にも出力する／非 macOS で失敗

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -31,3 +31,14 @@ fn no_args_prints_version() {
         .stdout(predicate::str::contains("dotfiles"))
         .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
+
+#[test]
+fn completions_fish_prints_script() {
+    // `--completions <shell>` は top-level option（サブコマンドではない）。補完スクリプトを出力する。
+    dotfiles()
+        .args(["--completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete"))
+        .stdout(predicate::str::contains("dotfiles"));
+}


### PR DESCRIPTION
## Summary

- `clip` / `dotfiles` core の補完生成エントリを `completions <shell>` サブコマンドから top-level `--completions <shell>` option へ変更。fish は `-` 始まりのトークンでしか option を候補に出さないため、`<bin> <Tab>` から `completions` が消える。
- native engine の generate manifest を追従（`configs/clip/completion/manifest.toml` の `cmd` 更新、`configs/dotfiles/completion/manifest.toml` を新設）。
- 旧サブコマンドを呼んでいた chezmoi テンプレート `home/dot_config/fish/completions/clip.fish.tmpl` を `--completions` へ更新（未更新だと新バイナリで破綻）。
- 影響テストを追従（clip CLI / dotfiles core CLI に completions の E2E）。

Closes #526

## 受け入れ条件の確認

- `clip --completions fish` / `dotfiles --completions fish` が補完スクリプトを stdout 出力。
- 生成 fish 補完で `completions` がサブコマンド候補（`-a "..."`）から消え、`-l completions`（`-` 入力時のみ）の option になった。
- スコープは Fish のみ。妥協点として `<bin> -<Tab>` に `--completions` が出るのは許容（fish.rs が option の `hide` を無視するため）。

## Test plan

- [x] `cargo test`（132 passed）
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`（clean）
- [x] `mise run check`（exit 0）
- [x] `clip --completions fish` / `dotfiles --completions fish` の stdout を目視確認
- [x] `clip --completions fish` の出力に `completions` のサブコマンド候補が含まれないことを確認

Made with [Cursor](https://cursor.com)