### PR TITLE
feat(starship): starship 設定を configs/ へ移行し $schema を網参照化 [#532]

### DIFF
--- a/configs/starship/manifest.toml
+++ b/configs/starship/manifest.toml
@@ -1,0 +1,22 @@
+# starship の設定（starship.toml）を ~/.config 直下へ配置する（copy 層 / 設計書 §5・§6）。
+# 旧 chezmoi（home/dot_config/starship.toml.tmpl）の置き換え。
+#
+# dst=~/.config（ディレクトリ）。配下の starship.toml を相対構造のまま copy し
+# ~/.config/starship.toml に置く。kind は省略時 "copy"。copy は dst を prune しないので、
+# ~/.config 配下の他ツール設定（chezmoi 管理分を含む）には触れない。
+#
+# $schema: starship.toml 先頭の `$schema` は starship 公式のスキーマ URL
+# （https://starship.rs/config-schema.json）を指す。エディタ / taplo はこの URL を取得して
+# 設定を検証するため、スキーマ本体を repo にも ~/.config にも vendoring しない。旧 chezmoi は
+# 同梱の starship-config-schema.json を ~/.config へ deploy しローカル参照していたが、こちらは
+# ネットワーク参照に寄せて 170KB の同梱物を持たない（taplo のスキーマ検証はネットワーク到達性に
+# 依存する）。
+#
+# merge-ready 連携: [custom.merge_ready] 節は merge-ready-prompt を呼ぶプロンプトモジュール。
+# 旧 tmpl は `{{ if lookPath "merge-ready" }}` で節ごと出し分けていたが、starship の custom
+# module は `when`（shell コマンド・終了 0 で表示）を持つので、節は常時置きつつ
+# `when = "command -v merge-ready-prompt"` で自己 gate する。merge-ready 不在マシンでは
+# starship 自身が節を非表示にするため、出し分けと挙動は等価で、配置は単純 copy に保てる
+# （条件分岐を engine の overlay へ持ち込まず、表示可否という starship 固有の意図を starship の
+# 設定そのものに宿す）。
+dst = "~/.config"

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -1,0 +1,264 @@
+"$schema" = "https://starship.rs/config-schema.json"
+
+[aws]
+format = '[$symbol($profile )(\($region\) )(\[$duration\] )]($style)'
+symbol = " "
+
+[buf]
+format = '[$symbol($version )]($style)'
+symbol = " "
+
+[bun]
+symbol = " "
+
+[c]
+symbol = " "
+
+[cpp]
+symbol = " "
+
+[cmake]
+symbol = " "
+
+[cmd_duration]
+format = '[ $duration]($style) '
+
+[conda]
+symbol = " "
+
+[crystal]
+symbol = " "
+
+[dart]
+symbol = " "
+
+[deno]
+symbol = " "
+
+[directory]
+read_only         = " 󰌾"
+repo_root_format  = '[$before_root_path]($before_repo_root_style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) '
+repo_root_style   = 'bold blue'
+style             = 'bold cyan'
+truncate_to_repo  = true
+truncation_length = 0
+
+[docker_context]
+format = '[$symbol$context ]($style)'
+symbol = " "
+
+[elixir]
+symbol = " "
+
+[elm]
+symbol = " "
+
+[fennel]
+symbol = " "
+
+[fortran]
+symbol = " "
+
+[fossil_branch]
+symbol = " "
+
+[gcloud]
+format = '[$symbol$account(@$domain)(\($region\))]($style) '
+symbol = " "
+
+[git_branch]
+format = '[$symbol$branch(:$remote_branch) ]($style)'
+symbol = " "
+
+[git_commit]
+tag_symbol = '  '
+
+[git_state]
+am           = "am"
+am_or_rebase = "am/rebase"
+bisect       = "bisect"
+cherry_pick  = "cherry-pick"
+merge        = "merge"
+rebase       = "rebase"
+revert       = "revert"
+
+[git_metrics]
+disabled = false
+
+[git_status]
+ahead    = '[⇡${count}](green)'
+behind   = '⇣${count}'
+diverged = '⇡${ahead_count}⇣${behind_count}'
+format   = '([$all_status$ahead_behind ]($style))'
+modified = '!${count}'
+stashed  = ''
+
+[golang]
+format = '[$symbol($version )]($style)'
+symbol = " "
+
+[gradle]
+format = '[$symbol($version )]($style)'
+symbol = " "
+
+[guix_shell]
+symbol = " "
+
+[haskell]
+symbol = " "
+
+[haxe]
+symbol = " "
+
+[hg_branch]
+symbol = " "
+
+[hostname]
+ssh_symbol = " "
+
+[java]
+format = '[${symbol}(${version} )]($style)'
+symbol = " "
+
+[julia]
+symbol = " "
+
+[kotlin]
+format = '[$symbol($version )]($style)'
+symbol = " "
+
+[lua]
+symbol = " "
+
+[memory_usage]
+disabled  = false
+format    = '[$symbol${ram_pct}( | ${swap_pct}) ]($style)'
+symbol    = "󰍛 "
+threshold = 75
+
+[meson]
+symbol = "󰔷 "
+
+[mise]
+# disabled         = false
+format           = '[$symbol($health )]($style)'
+healthy_symbol   = ''
+symbol           = "󰭼 "
+unhealthy_symbol = 'bad'
+
+[nim]
+symbol = "󰆥 "
+
+[nix_shell]
+symbol = " "
+
+[nodejs]
+format = '[$symbol($version) ]($style)'
+symbol = "󰎙 "
+
+[ocaml]
+symbol = " "
+
+[os.symbols]
+AOSC             = " "
+AlmaLinux        = " "
+Alpaquita        = " "
+Alpine           = " "
+Amazon           = " "
+Android          = " "
+Arch             = " "
+Artix            = " "
+CachyOS          = " "
+CentOS           = " "
+Debian           = " "
+DragonFly        = " "
+Elementary       = " "
+Emscripten       = " "
+EndeavourOS      = " "
+Fedora           = " "
+FreeBSD          = " "
+Garuda           = "󰛓 "
+Gentoo           = " "
+HardenedBSD      = "󰞌 "
+Illumos          = "󰈸 "
+Ios              = "󰀷 "
+Kali             = " "
+Linux            = " "
+Mabox            = " "
+Macos            = " "
+Manjaro          = " "
+Mariner          = " "
+MidnightBSD      = " "
+Mint             = " "
+NetBSD           = " "
+NixOS            = " "
+Nobara           = " "
+OpenBSD          = "󰈺 "
+OracleLinux      = "󰌷 "
+Pop              = " "
+Raspbian         = " "
+RedHatEnterprise = " "
+Redhat           = " "
+Redox            = "󰀘 "
+RockyLinux       = " "
+SUSE             = " "
+Solus            = "󰠳 "
+Ubuntu           = " "
+Unknown          = " "
+Void             = " "
+Windows          = "󰍲 "
+Zorin            = " "
+openSUSE         = " "
+
+[package]
+format = '[$symbol$version ]($style)'
+symbol = "󰏗 "
+
+[perl]
+symbol = " "
+
+[php]
+symbol = " "
+
+[pijul_channel]
+symbol = " "
+
+[pixi]
+symbol = "󰏗 "
+
+[python]
+format = '[${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'
+symbol = " "
+
+[rlang]
+symbol = "󰟔 "
+
+[ruby]
+format = '[$symbol($version )]($style)'
+symbol = " "
+
+[rust]
+format = '[$symbol($version )]($style)'
+symbol = "󱘗 "
+
+[scala]
+symbol = " "
+
+[status]
+symbol = " "
+
+[swift]
+symbol = " "
+
+[xmake]
+symbol = " "
+
+[zig]
+symbol = " "
+
+[custom.merge_ready]
+command      = "merge-ready-prompt"
+format       = "($output )"
+require_repo = true
+shell        = [ "/bin/zsh" ]
+when         = "command -v merge-ready-prompt"


### PR DESCRIPTION
## 概要

Epic #453 の縦スライス。starship 設定を chezmoi (`home/dot_config/starship.toml.tmpl`) から dotfiles-native の `configs/` へ移行する。

Closes #532

## 変更内容

`configs/starship/` を新設（`dst=~/.config` の copy）:

- `manifest.toml`
- `starship.toml`（設定本体。先頭 `$schema` は starship 公式 URL を指す）

`home/` 側（chezmoi）は**据え置き**。撤去は S9（#463）の一括撤去に乗せる。

## 設計判断

### merge-ready 条件節 → starship 自己 gate（overlay でなく copy）

テンプレート分岐は `{{ if lookPath "merge-ready" }}` の **1 か所のみ**で、`[custom.merge_ready]`（`merge-ready-prompt` を呼ぶプロンプトモジュール）の出し分けだった。これを engine の overlay で再現する代わりに starship 自身の `when`（shell コマンド・終了 0 で表示）へ寄せた:

```toml
when = "command -v merge-ready-prompt"
```

merge-ready 不在マシンでは starship が節を非表示にするため**出し分けと挙動は等価**。表示可否という starship 固有の意図を starship の設定そのものに宿し、配置は単純 copy に保てる。

### `$schema` を vendored ローカル → ネットワーク参照

旧来は `starship-config-schema.json`（170KB）を同梱し `./starship-config-schema.json` でローカル参照していた（Nix sandbox が HTTPS 取得不可だった名残）。Nix 撤去で制約が消えたため、starship 公式 URL へ切替え、同梱 schema を repo からも `~/.config` からも撤去:

```toml
"$schema" = "https://starship.rs/config-schema.json"
```

- 公式 URL は schema 自身の `$schema.default` 値で、内容は vendored コピーと完全一致（170838 B）。
- taplo がこの URL を取得・検証することを実証（正常 config は pass、未知キーは `Additional properties are not allowed` で fail）。
- トレードオフ: taplo の `$schema` 検証がネットワーク到達性に依存する。

## 検証

- `cargo test --test e2e` → **57 passed**（`real_configs::*` 含む＝全 manifest load + apply 配置 + list 集約）
- `mise run check`（taplo fmt/lint 等）→ **exit 0**、`starship.toml` はリモート schema で lint 通過
- `cargo fmt --all --check` → 差分なし
- temp HOME へ `dotfiles apply` → `apply: starship → ~/.config (copy)`、`starship.toml` のみ配置（schema 非配置）を確認

## 受け入れ条件

- [x] `configs/starship` を新設し apply で配置
- [x] テンプレート変数の有無を確認（lookPath merge-ready の 1 か所 → starship native `when` へ寄せ copy 単純化）
- [ ] `home/dot_config/starship.toml.tmpl` / schema 撤去（**S9 #463 一括撤去に委譲**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
