### PR TITLE
feat(bash): bash profiles を configs/ へ移行し native source で合成 [#534]

### DIFF
--- a/configs/bash/.bash_profile
+++ b/configs/bash/.bash_profile
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+# shellcheck disable=SC1091
+. "$HOME/.config/bash/common.sh"
+. "$HOME/.config/bash/interactive.sh"
+. "$HOME/.config/bash/login.sh"

--- a/configs/bash/.bashenv
+++ b/configs/bash/.bashenv
@@ -1,0 +1,3 @@
+# shellcheck shell=bash
+# shellcheck disable=SC1091
+. "$HOME/.config/bash/common.sh"

--- a/configs/bash/.bashrc
+++ b/configs/bash/.bashrc
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+# shellcheck disable=SC1091
+. "$HOME/.config/bash/common.sh"
+. "$HOME/.config/bash/interactive.sh"
+. "$HOME/.config/bash/nonlogin.sh"

--- a/configs/bash/manifest.toml
+++ b/configs/bash/manifest.toml
@@ -1,0 +1,10 @@
+# ~/.bash_profile / ~/.bashenv / ~/.bashrc を配置する（copy 層 / 設計書 §5・§6）。
+# 旧 chezmoi（home/dot_bash_profile.tmpl 等、`include` によるビルド時連結）の置き換え。
+#
+# 主シェルは fish で bash の役割は最小。共有断片（common.sh 等）は configs/bash/lib/
+# （別 manifest, dst=~/.config/bash）に1か所だけ持ち、ここの3ファイルは合成順を宣言する
+# 薄い委譲層 ── git config の native [include]（configs/git/manifest.toml 参照）と同じ発想で
+# bash 自身の `source` に合成を委ねる（engine の concat overlay は使わない）。
+#
+# configs/bash/lib/ はサブ manifest を持つため対象外（設計書 §6.3 ルール1）。
+dst = "~/"

--- a/configs/bash/manifest.toml
+++ b/configs/bash/manifest.toml
@@ -1,10 +1,12 @@
 # ~/.bash_profile / ~/.bashenv / ~/.bashrc を配置する（copy 層 / 設計書 §5・§6）。
 # 旧 chezmoi（home/dot_bash_profile.tmpl 等、`include` によるビルド時連結）の置き換え。
 #
-# 主シェルは fish で bash の役割は最小。共有断片（common.sh 等）は configs/bash/lib/
+# 主シェルは fish で bash の役割は最小。共有断片（common.sh 等）は configs/bash/scripts/
 # （別 manifest, dst=~/.config/bash）に1か所だけ持ち、ここの3ファイルは合成順を宣言する
 # 薄い委譲層 ── git config の native [include]（configs/git/manifest.toml 参照）と同じ発想で
 # bash 自身の `source` に合成を委ねる（engine の concat overlay は使わない）。
 #
-# configs/bash/lib/ はサブ manifest を持つため対象外（設計書 §6.3 ルール1）。
+# configs/bash/scripts/ はサブ manifest を持つため対象外（設計書 §6.3 ルール1）。
+# ディレクトリ名は lib でなく scripts（`.gitignore` の Python テンプレート由来の非アンカー
+# `lib/` パターンと衝突し、git add で静かに無視されるため）。
 dst = "~/"

--- a/configs/bash/scripts/common.sh
+++ b/configs/bash/scripts/common.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+export HISTCONTROL=ignoredups
+
+# mise config
+eval "$(mise activate bash)"
+
+# Homebrew PATH configuration (macOS only)
+if [[ "$OSTYPE" == "darwin"* ]] && [[ -d "/opt/homebrew/bin" ]]; then
+  export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+fi
+
+# Obsidian (macOS only)
+if [[ "$OSTYPE" == "darwin"* ]] && [[ -d "/Applications/Obsidian.app/Contents/MacOS" ]]; then
+  export PATH="$PATH:/Applications/Obsidian.app/Contents/MacOS"
+fi
+
+# browser-use
+for _browser_use_dir in "$HOME/.browser-use/bin" "$HOME/.browser-use-env/bin"; do
+  [[ -d "$_browser_use_dir" ]] && export PATH="$PATH:$_browser_use_dir"
+done
+unset _browser_use_dir

--- a/configs/bash/scripts/interactive.sh
+++ b/configs/bash/scripts/interactive.sh
@@ -1,0 +1,2 @@
+# shellcheck shell=bash
+PS1="\[\e[0;36m\]\u@\H \W\[\e[0m\]\$ "

--- a/configs/bash/scripts/login.sh
+++ b/configs/bash/scripts/login.sh
@@ -1,0 +1,2 @@
+# shellcheck shell=bash
+# Login shell specific settings

--- a/configs/bash/scripts/manifest.toml
+++ b/configs/bash/scripts/manifest.toml
@@ -1,0 +1,4 @@
+# bash 断片（common/interactive/login/nonlogin）を配置する（copy 層）。
+# ~/.bash_profile 等（configs/bash/manifest.toml）が起動時に source する実体。
+# 旧 bash/*.sh（chezmoi include の連結元）をそのまま移設。
+dst = "~/.config/bash"

--- a/configs/bash/scripts/nonlogin.sh
+++ b/configs/bash/scripts/nonlogin.sh
@@ -1,0 +1,2 @@
+# shellcheck shell=bash
+# Non-login interactive shell specific settings


### PR DESCRIPTION
## 概要

Epic #453 の縦スライス。bash profiles（`home/dot_bash_profile.tmpl` / `dot_bashenv.tmpl` / `dot_bashrc.tmpl`）を chezmoi から dotfiles-native の `configs/` へ移行する。

Closes #534

## 変更内容

`configs/bash/` を新設:

- `configs/bash/manifest.toml`（`dst=~/`）+ `.bash_profile` / `.bashenv` / `.bashrc`
  - 各ファイルは `~/.config/bash/*.sh` を `source` するだけの薄い委譲層
- `configs/bash/scripts/manifest.toml`（`dst=~/.config/bash`）+ `common.sh` / `interactive.sh` / `login.sh` / `nonlogin.sh`
  - 旧 `bash/*.sh`（chezmoi `include` の連結元）をそのまま移設した実体

旧3ファイルは chezmoi の `{{ include }}` によるビルド時連結のみで Go template の変数・条件分岐は無し（4つの `bash/*.sh` も確認済み）。この engine の copy は `src` を manifest と同じディレクトリ内にしか解決できず（断片を複数箇所へ複製すると SSOT が壊れる）、断片を共有する3ファイルを1か所にまとめるため、git config が git 自身の native `[include]`（`configs/git/manifest.toml`）で合成をツールへ委ねているのと同じ発想で、bash 自身の `source` に合成を委ねた。

`source` 行は shellcheck `SC1091`（動的パスを追えない旨の info）に当たるため `# shellcheck disable=SC1091` を付与（実機で shellcheck/shfmt とも exit 0 を確認済み）。

共有断片のディレクトリ名は当初 `lib/` にしたが、`.gitignore` の Python テンプレート由来の非アンカー `lib/` パターンと衝突し `git add` で静かに無視されていたため `scripts/` へ改名（2つ目のコミット）。

## 受け入れ条件

- [x] `configs/bash` を新設し apply で配置
- [x] テンプレート変数の有無を確認（無し → copy へ単純化）
- [ ] `home/dot_bash*` 撤去（**S9 #463 一括撤去に委譲**）

## 検証

- `cargo test --workspace` → 254 passed（`real_configs::*` 含む＝全 manifest load + apply 配置 + list 集約）
- `cargo run -p dotfiles-lint -- check` → exit 0
- `cargo fmt --all --check` → 差分なし
- 一時 HOME へ `dotfiles apply --source configs` → `apply: bash → ~/ (copy)` / `apply: bash/scripts → ~/.config/bash (copy)`、`~/.bash_profile` 等の実体を確認
- `bash --login` / `BASH_ENV=~/.bashenv bash -c` / 通常 `bash -c` の3経路で `source` を実行し `HISTCONTROL=ignoredups`（`.bashrc` では `PS1` も）反映を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)