### PR TITLE
feat(cursor): cursor のルールを configs/ へ移行する

### DIFF
--- a/configs/cursor/manifest.toml
+++ b/configs/cursor/manifest.toml
@@ -1,0 +1,10 @@
+# Cursor のルール（rules/git-no-commit-on-main.mdc）を ~/.cursor へ copy する。
+# 設計: docs/dotfiles-native-design.md §6
+#
+# dst=~/.cursor のディレクトリ単位 copy。配下は相対構造を保って再帰配置される:
+#   rules/git-no-commit-on-main.mdc → ~/.cursor/rules/git-no-commit-on-main.mdc
+# kind は省略時 "copy"。
+#
+# claude/rules/git-no-commit-on-main.md と内容が重複しているが、ルール本体の出所の一本化・
+# 各ツール形式（.md/.mdc）への展開方式は別スライスで検討する。本スライスは素朴 copy のみで完了させる。
+dst = "~/.cursor"

--- a/configs/cursor/rules/git-no-commit-on-main.mdc
+++ b/configs/cursor/rules/git-no-commit-on-main.mdc
@@ -1,0 +1,22 @@
+---
+description: Never commit on main; use a feature branch first (enforced for all git work)
+alwaysApply: true
+---
+
+# Git — do not commit on `main`
+
+`main`（およびリポジトリの default ブランチ）に**直接コミットしない**。ローカルだけでも禁止。後からブランチに移すのは手戻りであり、手順として認めない。
+
+## 必須フロー
+
+1. 変更の前またはコミットの直前に `git branch --show-current` で現在ブランチを確認する。
+2. いま `main`（または `master`、リモートの default と同一名）なら、**先に**作業ブランチを切る: `git checkout -b <type>/<short-description>`。
+3. そのブランチ上でだけ `git add` / `git commit` / `git push` を行う。PR が必要ならそのブランチから出す。
+
+## 例外
+
+ユーザーが**明示的に**「このコミットは main に直接」「hotfix を main に」などと指示した場合のみ、main へのコミットを許可する。黙示・省略は例外にしない。
+
+## エージェント向け
+
+`git commit` を実行する前に必ず上記を満たしていること。満たしていない場合はコミットせず、ブランチ作成から行う。


### PR DESCRIPTION
## Summary
- `home/dot_cursor/rules/git-no-commit-on-main.mdc` を `configs/cursor`(copy 層・ディレクトリ copy) へ移行し、`~/.cursor/rules/` へ配置する
- ルール本体の内容は変更なし(元ファイルとバイト一致)
- `claude/rules/git-no-commit-on-main.md` との内容重複・出所一本化/`.md`↔`.mdc` 展開方式の検討は #539 へ切り出し、本スライスでは素朴 copy のみで完了させる
- `home/dot_cursor/` 撤去は S9(#463) の一括撤去に乗せるため本 PR では行わない

Closes #533

## Test plan
- [x] `cargo test` (240 passed)
- [x] `mise run check`(taplo 含むlint一式) が通ることを確認
- [x] `cargo fmt --all --check`
- [x] `cargo run --bin dotfiles -- list` で `cursor → ~/.cursor [copy]` が出力されることを確認
- [x] `HOME=<scratch>` で `dotfiles apply` を実行し、`~/.cursor/rules/git-no-commit-on-main.mdc` が元ファイルとdiff無しで配置されることを確認(実ホームには非接触)