### PR TITLE
feat(fish): _fzf_file / _fzf_history を configs/fish へ移行する

### DIFF
--- a/configs/fish/functions/_fzf_file.fish
+++ b/configs/fish/functions/_fzf_file.fish
@@ -1,0 +1,9 @@
+function _fzf_file
+    set -l selected (
+    find . -path '*/\.*' -prune -o -type f -print 2>/dev/null | fzf
+  )
+    if test -n "$selected"
+        commandline -i "$selected"
+    end
+    commandline -f repaint
+end

--- a/configs/fish/functions/_fzf_history.fish
+++ b/configs/fish/functions/_fzf_history.fish
@@ -1,0 +1,7 @@
+function _fzf_history
+    set -l line (history | fzf +s --tiebreak=index)
+    if test -n "$line"
+        commandline -r "$line"
+    end
+    commandline -f repaint
+end

--- a/configs/fish/manifest.toml
+++ b/configs/fish/manifest.toml
@@ -1,0 +1,13 @@
+# fish の自前 fzf 関数（native bin を持たないもの）を ~/.config/fish へ copy する。
+# 設計: docs/dotfiles-native-design.md §5・§6 / 決定経緯: Issue #530
+#
+# dst=~/.config/fish のディレクトリ単位 copy。配下は相対構造を保って再帰配置される:
+#   functions/_fzf_file.fish     → ~/.config/fish/functions/_fzf_file.fish
+#   functions/_fzf_history.fish  → ~/.config/fish/functions/_fzf_history.fish
+# kind は省略時 "copy"。いずれも 0644（fish が autoload で source するだけで実行ビット不要）。
+#
+# `_fzf_gh` / `_fzf_ghq_cd` / `_fzf_worktree_remove` は各ツール（fzf-picker）側へ帰属するため
+# ここには含めない。config.fish・conf.d/・themes/ は別スライス「fish 本体移行」の対象で、
+# 現時点では home/dot_config/fish 側（chezmoi）が配置を担い、この単位と併存する
+# （apply 未接続。#505 の home/dot_claude と同じ移行期方針）。
+dst = "~/.config/fish"


### PR DESCRIPTION
## Summary

- Issue #530 の決定（自前維持・Rust bin 化なし）に基づき、`_fzf_file` / `_fzf_history` を `configs/fish`（dst=`~/.config/fish`, copy）へ追加
- `config.fish` / `conf.d/` / `themes/` は別スライス「fish 本体移行」の対象で、今回のスコープ外
- `home/dot_config/fish` 側は chezmoi が現行配置を担うため残置し併存（apply 未接続。#505 の `home/dot_claude` と同じ移行期方針）

## Test plan

- [x] `cargo run -q --bin dotfiles -- list` で `fish → ~/.config/fish  [copy]` が出ることを確認
- [x] `mise run check`（lint 一式）
- [x] `cargo test --workspace`（254 passed）
- [x] `cargo fmt --all --check`

Closes #530

Epic: #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)