### PR TITLE
docs: rustdoc を GitHub Pages で公開する

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Pages へのデプロイは同時実行させない（進行中のデプロイを打ち切らず、次の push は待たせる）。
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: cargo doc (workspace)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build rustdoc
+        run: cargo doc --workspace --no-deps --locked
+
+      # target/doc/ に集約クレートごとの index.html はできるがトップレベルの index.html はない。
+      # root package `dotfiles`（lib.rs のクレート doc から全 family module へ辿れる）を
+      # ランディングにリダイレクトする。
+      - name: Add landing page redirect
+        run: |
+          cat > target/doc/index.html <<'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0; url=dotfiles/index.html">
+              <link rel="canonical" href="dotfiles/index.html">
+              <title>dotfiles docs</title>
+            </head>
+            <body>
+              <p>Redirecting to <a href="dotfiles/index.html">dotfiles docs</a>…</p>
+            </body>
+          </html>
+          EOF
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Requires the `trash` CLI (bundled with macOS 15+). Both guards are intentionally
 
 All distributable commands live in the single root `dotfiles` package as multiple bins (a **Cargo workspace** at the repository root, whose only other members are the dev/maintenance tools under `tools/`). On `chezmoi apply`, a hook (`run_onchange_before_cargo-install`) installs them into `~/.cargo/bin` with one `cargo install --path .` (the tools under `tools/` are not installed). Off a clone you can do the same in one shot: `cargo install --git https://github.com/toshiki670/dotfiles`. The Rust toolchain and the lint tools are supplied by **mise** (`mise.toml`), so a fresh machine bootstraps as: `mise install` (rust) → `chezmoi apply` (cargo install).
 
+📖 [Rustdoc](https://toshiki670.github.io/dotfiles/) — API docs for every crate, rebuilt on every push to `main`.
+
 | Command | Description |
 | --- | --- |
 | `dotfiles` | dotfiles core; version entry point (`dotfiles --version`) plus `apply` (place `configs/` via per-directory `manifest.toml`; resolves & injects machine-local `locals` values), `list` (overview of every config's destination), `local set <name> <value>` (store a machine-local value in `~/.config/dotfiles/local.toml`), `color sample` (print an ANSI color table — 16 + 256 colors), and `doctor` (report unset `locals`) |


### PR DESCRIPTION
## Summary
- `cargo doc --workspace --no-deps` の成果物を `actions/upload-pages-artifact` + `actions/deploy-pages` でデプロイする `.github/workflows/docs.yml` を追加（`main` push で自動更新、`workflow_dispatch` も可）
- `target/doc/` にはトップレベル `index.html` が生成されないため、root package `dotfiles`（`lib.rs` のクレート doc から全 family module へ辿れる）へリダイレクトする `index.html` をビルド時に生成
- README.md の「Rust commands」節に公開 URL（https://toshiki670.github.io/dotfiles/）へのリンクを追加
- リポジトリの GitHub Pages を `build_type=workflow`（Source: GitHub Actions）で有効化済み

## Test plan
- [x] `cargo doc --workspace --no-deps --locked` がローカルで成功し、`dotfiles` / `dotfiles-lint` / `v-sync` 各クレートの doc が生成されることを確認
- [x] `mise run check` で README.md の lint（rumdl）が通ることを確認
- [ ] マージ後、Actions の `Docs` workflow が成功し `https://toshiki670.github.io/dotfiles/` からリダイレクト経由で最新の rustdoc を閲覧できることを確認

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)