### PR TITLE
fix(claude): force-push guard を native settings へ移植する

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Bypass everything for a single commit with `git commit --no-verify`.
 
 ## Claude Code
 
-`~/.claude/settings.json` is managed by a chezmoi `modify_` script (`home/dot_claude/modify_settings.json.tmpl`). It merges the live file so keys the app writes itself (`model`, `theme`, `effortLevel`, …) are preserved, while dotfiles-owned shared settings (`hooks`, `statusLine`, `language`, `voiceEnabled`) are always enforced. The `rtk` token-proxy hook is included only when `rtk` is on `PATH`.
+`~/.claude/settings.json` is placed by `dotfiles apply` (`configs/claude/settings/`: base `settings.json` plus a conditional `rtk.json` overlay when `rtk` is on `PATH`, `strategy = "json-shallow"` with `preserve = true`). It merges the live file so keys the app writes itself (`model`, `theme`, `effortLevel`, …) are preserved, while dotfiles-owned shared settings (`hooks`, `statusLine`, `language`, `voiceEnabled`) are always enforced. A chezmoi `modify_` script (`home/dot_claude/modify_settings.json.tmpl`) still manages the same file during the chezmoi→dotfiles migration (`chezmoi apply` runs first, `dotfiles apply` runs after and wins); it is removed once the migration finishes (#463). **Until then, any hooks change must be ported to both `configs/claude/settings/{settings,rtk}.json` and `home/dot_claude/modify_settings.json.tmpl`** — porting only one side lets a guard silently vanish on the other (#549).
 
 `PreToolUse` / `Bash` hooks provide two safety rails:
 

--- a/configs/claude/settings/manifest.toml
+++ b/configs/claude/settings/manifest.toml
@@ -15,6 +15,11 @@
 # 注: json-shallow は `hooks` を object ごと差し替えるため、rtk.json は rm→trash ガードを含む
 # hooks 全体を持つ（base と一部重複する）。これは「rtk hook だけ条件付き」を deep merge 無しで
 # 表現する設計上のコスト。rm ガードを変えるときは settings.json と rtk.json の両方を直すこと。
+#
+# 移行期限定の注意（S9 #463 完了まで）: `home/dot_claude/modify_settings.json.tmpl` が同じ
+# ~/.claude/settings.json を chezmoi 側からも管理している（併存は設計上の不変条件・§12.1、
+# `home/` は個別削除しない）。hooks の追加・変更はこの native 側だけでなく modify_settings.json.tmpl
+# にも移植すること。片方だけ直すと、移植し忘れた側でガードが消える（#549 で実際に発生）。
 dst      = "~/.claude/settings.json"
 strategy = "json-shallow"
 # 既存 dst を土台に温存（旧 modify_ の `$local + $forced`）。非管理キーは全保持。

--- a/configs/claude/settings/rtk.json
+++ b/configs/claude/settings/rtk.json
@@ -23,6 +23,11 @@
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE '(^|[;&|()])[[:space:]]*rm([[:space:]]|$)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Do not use rm. Use trash (moves to the macOS Trash) instead, e.g. `trash <file/dir>`. trash handles directories as-is; no -r/-f needed. Only ask the user before permanently deleting if it is truly required.\"}}'; fi",
             "statusMessage": "rm guard (trash)"
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE 'git([[:space:]]|$)' && printf '%s' \"$cmd\" | grep -qE 'push' && printf '%s' \"$cmd\" | grep -qE '(--force|(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--no-verify)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Force-push is forbidden in this environment. Do NOT run git push with --force / -f / --force-with-lease, and do NOT use --no-verify. This is not a simple mistake to route around: rewriting already-published history irreversibly destroys shared state (other developers fetches/derived work, review anchors, stacked-PR rebase discipline). To resolve conflicts or update a branch, merge the base (git merge origin/main) or run git pull --rebase, then push normally as a fast-forward. To remove code from the final state, make a normal delete commit, which is different from deleting commits from history. If history truly must be rewritten, STOP and surface the situation to the user; the decision to proceed belongs to the user alone. An automated agent must never force-push or bypass this guard, even when explicitly instructed.\"}}'; fi",
+            "statusMessage": "force-push guard"
           }
         ]
       }

--- a/configs/claude/settings/settings.json
+++ b/configs/claude/settings/settings.json
@@ -26,6 +26,11 @@
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE '(^|[;&|()])[[:space:]]*rm([[:space:]]|$)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Do not use rm. Use trash (moves to the macOS Trash) instead, e.g. `trash <file/dir>`. trash handles directories as-is; no -r/-f needed. Only ask the user before permanently deleting if it is truly required.\"}}'; fi",
             "statusMessage": "rm guard (trash)"
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if printf '%s' \"$cmd\" | grep -qE 'git([[:space:]]|$)' && printf '%s' \"$cmd\" | grep -qE 'push' && printf '%s' \"$cmd\" | grep -qE '(--force|(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--no-verify)'; then printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Force-push is forbidden in this environment. Do NOT run git push with --force / -f / --force-with-lease, and do NOT use --no-verify. This is not a simple mistake to route around: rewriting already-published history irreversibly destroys shared state (other developers fetches/derived work, review anchors, stacked-PR rebase discipline). To resolve conflicts or update a branch, merge the base (git merge origin/main) or run git pull --rebase, then push normally as a fast-forward. To remove code from the final state, make a normal delete commit, which is different from deleting commits from history. If history truly must be rewritten, STOP and surface the situation to the user; the decision to proceed belongs to the user alone. An automated agent must never force-push or bypass this guard, even when explicitly instructed.\"}}'; fi",
+            "statusMessage": "force-push guard"
           }
         ]
       }


### PR DESCRIPTION
## 概要

force-push guard を native 側（`configs/claude/settings/`）へ移植し、issue #549 の残タスクを片付ける。

## #549 チェックリストへの対応

- [x] **force-push guard を settings.json / rtk.json へ移植** — json-shallow は `hooks` をトップレベルキー単位で丸ごと差し替える（deep merge しない、`src/core/apply/strategy.rs` の `json_shallow` 参照）ため、両ファイルに追加した。片方だけだと rtk 有無で guard の有無が変わってしまう。
- [x] **chezmoi 側と native 側の同期漏れを防ぐ仕組みを検討** — 設計書 §12.1 の不変条件により、移行期間中は `home/` を個別に変更・削除できない（S9 #463 で一括撤去）。また #488 の方針でエンジンのテストに実ツール名を持ち込むのも避けたい。そのため `home/` には触れず、native 側の `manifest.toml` コメントと README.md「Claude Code」節を実態（chezmoi/native 併存・後勝ちで native が勝つ）に更新し、hooks 変更時は両方に移植する必要があることを明記した。
- [x] **応急処置として本機で chezmoi apply するか判断** — 不要と判断した。設計書の二段適用モデル（`chezmoi apply` → `dotfiles apply`、後勝ち）どおり、本機で `cargo run --bin dotfiles -- apply` を実行済みで、`~/.claude/settings.json` に rm guard・force-push guard の両方が反映されていることを確認済み（native apply が最後に勝つため、これが最終状態）。

## 変更内容

- `configs/claude/settings/settings.json` / `rtk.json`: force-push guard hook を追加（`home/dot_claude/modify_settings.json.tmpl` と同一のコマンド・reason文言）。
- `configs/claude/settings/manifest.toml`: hooks を変更する際は chezmoi 側（`modify_settings.json.tmpl`）にも移植する必要がある旨のコメントを追加。
- `README.md`: `~/.claude/settings.json` が chezmoi 側だけでなく native 側 `dotfiles apply` にも管理されており、後勝ちで native が勝つ実態、および移行期間中は両方への移植が必要な旨を追記。

## Test plan

- [x] `mise run check`（taplo / rumdl 含む lint）
- [x] `cargo test --test e2e`（57 passed）
- [x] 本機で `dotfiles apply` を実行し `~/.claude/settings.json` に両ガードが反映されていることを確認

Closes #549
