### PR TITLE
chore: remove cargo-install removed_crates after host rollout (#503)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Verify dev/maintenance-only tools were NOT installed
         run: |
           # tools/ 配下は repo 内部の開発・保守ツール（非 install）。~/.cargo/bin に入らない。
-          # v-sync は #485 で配布終了（保守ツール化）。removed_crates が旧バイナリも掃除する。
+          # v-sync は #485 で配布終了（保守ツール化）。
           for bin in dotfiles-lint v-sync; do
             if [ -e "$HOME/.cargo/bin/$bin" ]; then
               echo "error: $bin must not be installed to ~/.cargo/bin" >&2

--- a/home/.chezmoiscripts/run_onchange_before_cargo-install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_cargo-install.sh.tmpl
@@ -16,9 +16,7 @@
 #
 # `--force` is required on existing hosts: binaries such as `clip` were previously
 # owned by their own per-crate packages in ~/.cargo/.crates.toml; --force overwrites
-# them and transfers ownership to the root `dotfiles` package (binary names are kept,
-# so no removed_crates cleanup is needed for them — only for v-sync, whose binary is
-# no longer installed; see removed_crates below).
+# them and transfers ownership to the root `dotfiles` package.
 #
 # This is a run_*before* hook (not after) on purpose: fish completion templates
 # such as dot_config/fish/completions/clip.fish.tmpl gate generation on
@@ -60,18 +58,6 @@ else
   echo "cargo-install: neither mise nor cargo found; skipping (run 'mise install' then re-apply)." >&2
   exit 0
 fi
-
-# 配布をやめた／改名した旧コマンドを cargo uninstall で掃除する。バイナリを直接削除
-# すると cargo の登録簿（~/.cargo/.crates.toml）と不整合になるため、必ず cargo
-# uninstall を使う。未登録（既に掃除済み / 未インストール）なら黙って無視する。
-# 撤去（全ホスト浸透後にエントリを外す）の追跡は #503。
-removed_crates=(
-  "color"  # crates/color → dotfiles color sample に統合 (#460)
-  "v-sync" # crates/v-sync → tools/v-sync（保守ツール化・配布終了） (#485)
-)
-for crate in "${removed_crates[@]}"; do
-  run_cargo uninstall "$crate" &>/dev/null || true
-done
 
 echo "cargo-install: installing distributable dotfiles commands from $repo_root"
 run_cargo install --path "$repo_root" --target-dir "$target_dir" --locked --force


### PR DESCRIPTION
## Summary
- Remove the one-time `removed_crates` block (`color` / `v-sync` `cargo uninstall`) from the cargo-install hook now that all hosts have rolled through the cleanup.
- AN-117: old binaries already removed via prior `chezmoi apply`.
- AN-6: dotfiles binaries were never installed.
- Drop the related `removed_crates` mention in the Rust CI workflow comment.

Closes #503

## Test plan
- [x] Verified AN-117 has no `color` / `v-sync` in `~/.cargo/bin` or cargo registry
- [x] Confirmed AN-6 never had dotfiles binaries installed
- [ ] CI passes


Made with [Cursor](https://cursor.com)