### PR TITLE
chore: release v0.69.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.69.10] - 2026-07-02
+### Features
+- Hook の実行頻度 frequency を追加(onchange/always) ([#555](https://github.com/toshiki670/dotfiles/pull/555)) ([`7a4b357`](https://github.com/toshiki670/dotfiles/commit/7a4b35705d45e5fbdd7bd4120ead76f89bb8a979))
+### Fixes
+- Force-push guard を native settings へ移植する ([#553](https://github.com/toshiki670/dotfiles/pull/553)) ([`2874c56`](https://github.com/toshiki670/dotfiles/commit/2874c56c20b85a61412de1411c0ac90b0edb7523))
+
+
 ## [0.69.9] - 2026-07-01
 ### Features
 - Starship 設定を configs/ へ移行し $schema を網参照化 [#532] ([#536](https://github.com/toshiki670/dotfiles/pull/536)) ([`a6a11b1`](https://github.com/toshiki670/dotfiles/commit/a6a11b1a6c378e62d5b36189a6f2b118608a8c65))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.69.9"
+version = "0.69.10"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.69.9"
+version     = "0.69.10"
 
 [dependencies]
 clap          = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `dotfiles`: 0.69.9 -> 0.69.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.69.10] - 2026-07-02

### Features
- Hook の実行頻度 frequency を追加(onchange/always) ([#555](https://github.com/toshiki670/dotfiles/pull/555)) ([`7a4b357`](https://github.com/toshiki670/dotfiles/commit/7a4b35705d45e5fbdd7bd4120ead76f89bb8a979))
### Fixes
- Force-push guard を native settings へ移植する ([#553](https://github.com/toshiki670/dotfiles/pull/553)) ([`2874c56`](https://github.com/toshiki670/dotfiles/commit/2874c56c20b85a61412de1411c0ac90b0edb7523))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).