### PR TITLE
feat(gh): gh の config.yml を configs/ へ移行する

### DIFF
--- a/configs/gh/config/config.yml
+++ b/configs/gh/config/config.yml
@@ -1,0 +1,27 @@
+# The current version of the config schema
+version: 1
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: ssh
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor: nvim
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# Preference for editor-based interactive prompting. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prefer_editor_prompt: disabled
+# A pager program to send command output to, e.g. "less". If blank, will refer to environment. Set the value to "cat" to disable the pager.
+pager: delta --side-by-side
+# Aliases allow you to create nicknames for gh commands
+# aliases:
+#     co: pr checkout
+# The path to a unix socket through which to send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+http_unix_socket:
+# What web browser gh should use when opening URLs. If blank, will refer to environment.
+browser:
+# Whether to display labels using their RGB hex color codes in terminals that support truecolor. Supported values: enabled, disabled
+color_labels: disabled
+# Whether customizable, 4-bit accessible colors should be used. Supported values: enabled, disabled
+accessible_colors: disabled
+# Whether an accessible prompter should be used. Supported values: enabled, disabled
+accessible_prompter: disabled
+# Whether to use a animated spinner as a progress indicator. If disabled, a textual progress indicator is used instead. Supported values: enabled, disabled
+spinner: enabled

--- a/configs/gh/config/manifest.toml
+++ b/configs/gh/config/manifest.toml
@@ -1,0 +1,8 @@
+# gh 本体設定（config.yml）を ~/.config/gh へ copy する（設計書 §6.1 の想定どおりの配置）。
+#
+# git_protocol / editor / prompt / pager 等、gh 自身が読む設定一式。旧 chezmoi
+# （home/dot_config/gh/config.yml）の置き換え。completion（fish 補完の generate 層）は
+# 同じ configs/gh 配下でも kind が異なる別単位（configs/gh/completion）として分離済み。
+#
+# kind は省略時 "copy"。home/dot_config/gh/config.yml の撤去は S9（#463）で行う。
+dst = "~/.config/gh"


### PR DESCRIPTION
## Summary
- `configs/gh/config/` を新設し、gh 本体設定（`config.yml`: git_protocol/editor/prompt/pager 等）を copy 層で `~/.config/gh` へ配置する。設計書 §6.1 で既に想定されていた配置そのまま。
- completion（fish 補完・generate 層）は既存の `configs/gh/completion/` のまま、config（copy 層）とは kind が異なるため別単位として分離。
- `home/dot_config/gh/config.yml` の撤去は受け入れ条件どおり S9（#463）へ据え置き、本 PR では `home/` に触れない。

## Test plan
- [x] `cargo test --workspace`（266件 green）
- [x] `cargo fmt --all --check`
- [x] `mise run check`
- [x] 一時 HOME への実 `dotfiles apply` で `~/.config/gh/config.yml` の内容一致を確認
- [x] `dotfiles list` に `gh/config` が `[copy]` で表示されることを確認

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)