### PR TITLE
feat(merge-ready): merge-ready.toml を configs/ へ移行する

### DIFF
--- a/configs/merge-ready/manifest.toml
+++ b/configs/merge-ready/manifest.toml
@@ -1,0 +1,12 @@
+# merge-ready 本体設定（merge-ready.toml）を ~/.config へ copy する。
+# 設計: docs/dotfiles-native-design.md §6.1（gh の想定どおりの配置）
+#
+# dst=~/.config のディレクトリ単位 copy。配下の merge-ready.toml を相対構造のまま copy し
+# ~/.config/merge-ready.toml に置く。kind は省略時 "copy"。copy は dst を prune しないので、
+# ~/.config 配下の他ツール設定には触れない。
+#
+# completion/（fish 補完の generate 層）はサブ manifest を持つので、この copy からは委譲され
+# 除外される（§6.3 ルール1。gh/config と gh/completion と同じ関係）。
+#
+# 旧 chezmoi（home/dot_config/merge-ready.toml）の置き換え。撤去は S9（#463）で行う。
+dst = "~/.config"

--- a/configs/merge-ready/merge-ready.toml
+++ b/configs/merge-ready/merge-ready.toml
@@ -1,0 +1,56 @@
+[merge_ready]
+format = "[$symbol $label( $pr_ids)](bold green)"
+symbol = "󰄬"
+
+[no_pull_request]
+format = "[$symbol $label](cyan)"
+label  = "Create PR"
+symbol = "󰎔"
+
+[conflict]
+format = "[$symbol $label( $pr_ids)](bold red)"
+symbol = ""
+
+[update_branch]
+format = "[$symbol $label( $pr_ids)](yellow)"
+symbol = "󰚰"
+
+[sync_unknown]
+format = "[$symbol $label( $pr_ids)](yellow)"
+symbol = ""
+
+[ci_fail]
+format = "[$symbol $label( $pr_ids)](bold red)"
+symbol = ""
+
+[ci_action]
+format = "[$symbol $label( $pr_ids)](yellow)"
+symbol = "󰀦"
+
+[ci_pending]
+format = "[$symbol $label( $pr_ids)](cyan)"
+symbol = ""
+
+[changes_requested]
+format = "[$symbol $label( $pr_ids)](yellow)"
+symbol = "󰀦"
+
+[review_required]
+format = "[$symbol $label( $pr_ids)](cyan)"
+symbol = ""
+
+[draft]
+format = "[$symbol $label( $pr_ids)](dimmed)"
+symbol = ""
+
+[status_calculating]
+format = "[$symbol $label( $pr_ids)](dimmed)"
+symbol = ""
+
+[blocked_unknown]
+format = "[$symbol $label( $pr_ids)](yellow)"
+symbol = ""
+
+[error]
+format = "[$symbol $message](bold red)"
+symbol = ""


### PR DESCRIPTION
## Summary
- `configs/merge-ready/` に本体設定（`merge-ready.toml`）を copy 層（`dst = "~/.config"`）で配置する manifest を追加。設計書 §6.1 で既に想定されていた配置そのまま（gh の #568 と同型）。
- completion（fish 補完・generate 層）は既存の `configs/merge-ready/completion/` のまま、config（copy 層）とは kind が異なるため別単位として分離（委譲ルールで自動除外）。
- `home/dot_config/merge-ready.toml` の撤去は受け入れ条件どおり S9（#463）へ据え置き、本 PR では `home/` に触れない。

## Test plan
- [x] `cargo test`（workspace 252件 green）
- [x] `mise run check`
- [x] `dotfiles list` に `merge-ready` が `[copy]` で表示されることを確認
- [x] 一時 HOME への実 `dotfiles apply` で `~/.config/merge-ready.toml` の内容がバイト一致することを確認

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)