### PR TITLE
feat(configs): fish shim 8本を各ツールへ帰属させ configs/ へ移行する

### DIFF
--- a/configs/fish/manifest.toml
+++ b/configs/fish/manifest.toml
@@ -11,8 +11,9 @@
 #
 # functions/ の `_fzf_gh` / `_fzf_ghq_cd` / `_fzf_worktree_remove` / `__fzf_picker_preview` /
 # `__fzf_ghq_readme_preview` / `cdabbr` は fzf-picker、`gh-clone` は gh-clone、`ps-grep` は
-# ps-grep 自身へ帰属するため（configs/fzf-picker, configs/gh-clone, configs/ps-grep）ここには
-# 含めない（§6.3 ルール1・Issue #567）。conf.d は複数ツールが断片を持ち寄る合流点でもあり
+# ps-grep 自身へ帰属するため、D1（ソースは configs/<tool>/ に中身の帰属で並べる。§4）に従い
+# それぞれ独立したツールディレクトリ（configs/fzf-picker, configs/gh-clone, configs/ps-grep）
+# が持つ。ここには含めない（Issue #567）。conf.d は複数ツールが断片を持ち寄る合流点でもあり
 # （eza の 40-eza.fish 等、番号帯が重ならない限り併存可）、claude（08-claude.fish）・workers
 # （60-daily-check.fish・70-git-background-fetch.fish）・starship（95-starship-prompt.fish）は
 # 各ツール側の manifest（configs/claude/fish, configs/workers, configs/starship/fish）が持つ

--- a/configs/fish/manifest.toml
+++ b/configs/fish/manifest.toml
@@ -9,9 +9,12 @@
 #   themes/OneHalfLight-Ayu.theme → ~/.config/fish/themes/OneHalfLight-Ayu.theme
 # kind は省略時 "copy"。いずれも 0644（fish が autoload/source するだけで実行ビット不要）。
 #
-# `_fzf_gh` / `_fzf_ghq_cd` / `_fzf_worktree_remove` は各ツール（fzf-picker）側へ帰属するため
-# ここには含めない。conf.d は複数ツールが断片を持ち寄る合流点でもあり（eza の 40-eza.fish 等、
-# 番号帯が重ならない限り併存可）、claude（08-claude.fish）・workers（60-daily-check.fish・
-# 70-git-background-fetch.fish）・starship（95-starship-prompt.fish）は各ツール側の manifest
-# （configs/claude/fish, configs/workers, configs/starship/fish）が持つためここには含めない。
+# functions/ の `_fzf_gh` / `_fzf_ghq_cd` / `_fzf_worktree_remove` / `__fzf_picker_preview` /
+# `__fzf_ghq_readme_preview` / `cdabbr` は fzf-picker、`gh-clone` は gh-clone、`ps-grep` は
+# ps-grep 自身へ帰属するため（configs/fzf-picker, configs/gh-clone, configs/ps-grep）ここには
+# 含めない（§6.3 ルール1・Issue #567）。conf.d は複数ツールが断片を持ち寄る合流点でもあり
+# （eza の 40-eza.fish 等、番号帯が重ならない限り併存可）、claude（08-claude.fish）・workers
+# （60-daily-check.fish・70-git-background-fetch.fish）・starship（95-starship-prompt.fish）は
+# 各ツール側の manifest（configs/claude/fish, configs/workers, configs/starship/fish）が持つ
+# ためここには含めない。
 dst = "~/.config/fish"

--- a/configs/fzf-picker/__fzf_ghq_readme_preview.fish
+++ b/configs/fzf-picker/__fzf_ghq_readme_preview.fish
@@ -1,0 +1,12 @@
+function __fzf_ghq_readme_preview
+    set -l rel (string trim -- $argv[1])
+    test -n "$rel"; or return 1
+    set -l r (ghq root)/$rel
+    for n in README.md readme.md README Readme.md
+        if test -f "$r/$n"
+            head -n 400 "$r/$n"
+            return 0
+        end
+    end
+    echo "No README"
+end

--- a/configs/fzf-picker/__fzf_picker_preview.fish
+++ b/configs/fzf-picker/__fzf_picker_preview.fish
@@ -1,0 +1,7 @@
+function __fzf_picker_preview --argument-names type path rel
+    if test "$type" = repo
+        __fzf_ghq_readme_preview "$rel"
+    else
+        git -C "$path" log --oneline -20
+    end
+end

--- a/configs/fzf-picker/_fzf_gh.fish
+++ b/configs/fzf-picker/_fzf_gh.fish
@@ -1,0 +1,10 @@
+# ロジックは Rust バイナリ（src/fzf_picker の fzf-gh）に移した。
+# Issue/PR 混在リストを fzf で選び、種別に応じたアクションを fzf で選んで、
+# 組み上げた `gh <group> <action> <number>` を stdout に出す。fish はそれを
+# コマンドラインへ挿入するだけの薄い shim（実行は Enter で自分が行う）。
+function _fzf_gh
+    set -l cmd (command fzf-gh)
+    or return
+    test -n "$cmd"; and commandline -i -- "$cmd "
+    commandline -f repaint
+end

--- a/configs/fzf-picker/_fzf_ghq_cd.fish
+++ b/configs/fzf-picker/_fzf_ghq_cd.fish
@@ -1,0 +1,10 @@
+# ロジックは Rust バイナリ（src/fzf_picker の fzf-ghq-cd, ~/.cargo/bin）に移した。
+# 別プロセスでは親シェルの cd を変えられないため、ここはバイナリが選択結果として
+# 出力した絶対パスへ cd するだけの薄い shim（zoxide / starship と同じ定石）。
+# fzf 本体はバイナリが TTY を継承して実行し、選択パスのみ stdout に出す。
+function _fzf_ghq_cd
+    set -l dest (command fzf-ghq-cd)
+    or return
+    test -n "$dest"; and cd "$dest"
+    commandline -f repaint
+end

--- a/configs/fzf-picker/_fzf_worktree_remove.fish
+++ b/configs/fzf-picker/_fzf_worktree_remove.fish
@@ -1,0 +1,9 @@
+# ロジックは Rust バイナリ（src/fzf_picker の fzf-worktree-remove）に移した。
+# 選択・確認・削除はバイナリが行う。削除対象 worktree の内側にいた場合だけ、退避先
+# （メイン worktree）パスを stdout に出すので、fish はそこへ cd するだけの薄い shim。
+function _fzf_worktree_remove
+    set -l dest (command fzf-worktree-remove)
+    or return
+    test -n "$dest"; and cd "$dest"
+    commandline -f repaint
+end

--- a/configs/fzf-picker/cdabbr.fish
+++ b/configs/fzf-picker/cdabbr.fish
@@ -1,0 +1,8 @@
+# ロジックは Rust バイナリ（src/fzf_picker の cdabbr, ~/.cargo/bin）に移した。
+# 別プロセスでは親シェルの cd を変えられないため、ここはバイナリが選択結果として
+# 出力した絶対パスへ cd するだけの薄い shim。展開・fzf 選択はバイナリが行う。
+function cdabbr --description 'cd by expanding prompt_pwd-style abbreviated path'
+    set -l dest (command cdabbr $argv)
+    or return
+    test -n "$dest"; and cd "$dest"
+end

--- a/configs/fzf-picker/manifest.toml
+++ b/configs/fzf-picker/manifest.toml
@@ -1,0 +1,11 @@
+# fzf-picker 系バイナリ（fzf-gh / fzf-ghq-cd / fzf-worktree-remove / cdabbr、いずれも ~/.cargo/bin）
+# の fish 側 shim を fish の functions 合流点へ copy する。
+# 設計: docs/dotfiles-native-design.md §5・§6（合流点への copy 集約）/ Issue #558・#567
+#
+# dst は fish の functions（conf.d・completions と同様、複数ツールが断片を持ち寄る合流点）。
+# 中身は fzf-picker に帰属するため fish 本体（configs/fish）ではなくここに置く（§6.3 ルール1）。
+# shim 本体はいずれもバイナリを `command <bin>` で呼び、選択結果を cd / commandline へ渡すだけの
+# 薄いラッパー（別プロセスは親シェルの cd を変えられないため。バイナリ側に shim 生成サブコマンドは
+# 無く fish 側定義が必須）。20-fzf-bindings.fish の bind・30-cdabbr.fish の `ca` abbr・
+# ピッカーの preview から参照される。kind は省略時 "copy"。
+dst = "~/.config/fish/functions"

--- a/configs/fzf-picker/manifest.toml
+++ b/configs/fzf-picker/manifest.toml
@@ -3,7 +3,8 @@
 # 設計: docs/dotfiles-native-design.md §5・§6（合流点への copy 集約）/ Issue #558・#567
 #
 # dst は fish の functions（conf.d・completions と同様、複数ツールが断片を持ち寄る合流点）。
-# 中身は fzf-picker に帰属するため fish 本体（configs/fish）ではなくここに置く（§6.3 ルール1）。
+# 中身は fzf-picker に帰属するため、D1（ソースは configs/<tool>/ に中身の帰属で並べる。§4）に
+# 従い fish 本体（configs/fish）ではなく独立したツールディレクトリとしてここに置く。
 # shim 本体はいずれもバイナリを `command <bin>` で呼び、選択結果を cd / commandline へ渡すだけの
 # 薄いラッパー（別プロセスは親シェルの cd を変えられないため。バイナリ側に shim 生成サブコマンドは
 # 無く fish 側定義が必須）。20-fzf-bindings.fish の bind・30-cdabbr.fish の `ca` abbr・

--- a/configs/gh-clone/gh-clone.fish
+++ b/configs/gh-clone/gh-clone.fish
@@ -1,0 +1,8 @@
+# gh-clone のロジックは Rust バイナリ（src/gh_clone, ~/.cargo/bin）に移した。
+# 別プロセスでは親シェルの cd を変えられないため、ここはバイナリが出力した
+# 移設先パスへ cd するだけの薄い shim（zoxide / starship と同じ定石）。
+function gh-clone --description 'Clone repository via gh and migrate with ghq'
+    set -l migrated_path (command gh-clone $argv)
+    or return
+    test -n "$migrated_path"; and cd "$migrated_path"
+end

--- a/configs/gh-clone/manifest.toml
+++ b/configs/gh-clone/manifest.toml
@@ -2,7 +2,8 @@
 # 設計: docs/dotfiles-native-design.md §5・§6（合流点への copy 集約）/ Issue #558・#567
 #
 # dst は fish の functions（conf.d・completions と同様、複数ツールが断片を持ち寄る合流点）。
-# 中身は gh-clone に帰属するため fish 本体（configs/fish）ではなくここに置く（§6.3 ルール1）。
+# 中身は gh-clone に帰属するため、D1（ソースは configs/<tool>/ に中身の帰属で並べる。§4）に
+# 従い fish 本体（configs/fish）ではなく独立したツールディレクトリとしてここに置く。
 # 別プロセスは親シェルの cd を変えられないため、バイナリが出力した移設先パスへ cd するだけの
 # 薄いラッパー（バイナリ側に shim 生成サブコマンドは無く fish 側定義が必須）。kind は省略時 "copy"。
 dst = "~/.config/fish/functions"

--- a/configs/gh-clone/manifest.toml
+++ b/configs/gh-clone/manifest.toml
@@ -1,0 +1,8 @@
+# gh-clone バイナリ（~/.cargo/bin）の fish 側 shim を fish の functions 合流点へ copy する。
+# 設計: docs/dotfiles-native-design.md §5・§6（合流点への copy 集約）/ Issue #558・#567
+#
+# dst は fish の functions（conf.d・completions と同様、複数ツールが断片を持ち寄る合流点）。
+# 中身は gh-clone に帰属するため fish 本体（configs/fish）ではなくここに置く（§6.3 ルール1）。
+# 別プロセスは親シェルの cd を変えられないため、バイナリが出力した移設先パスへ cd するだけの
+# 薄いラッパー（バイナリ側に shim 生成サブコマンドは無く fish 側定義が必須）。kind は省略時 "copy"。
+dst = "~/.config/fish/functions"

--- a/configs/ps-grep/manifest.toml
+++ b/configs/ps-grep/manifest.toml
@@ -3,6 +3,6 @@
 #
 # dst は fish の functions（conf.d・completions と同様、複数ツールが断片を持ち寄る合流点）。
 # fzf-picker / gh-clone と違い帰属先の Rust バイナリを持たず、ps-grep 自身が独立したツールとして
-# 帰属する（D1 ツール第一級）。fish 本体（configs/fish）ではなくここに置く（§6.3 ルール1）。
-# kind は省略時 "copy"。
+# D1（ソースは configs/<tool>/ に中身の帰属で並べる。§4）に従い、fish 本体（configs/fish）では
+# なく独立したツールディレクトリとしてここに置く。kind は省略時 "copy"。
 dst = "~/.config/fish/functions"

--- a/configs/ps-grep/manifest.toml
+++ b/configs/ps-grep/manifest.toml
@@ -1,0 +1,8 @@
+# ps-grep（バイナリ化なしの純 fish 関数）を fish の functions 合流点へ copy する。
+# 設計: docs/dotfiles-native-design.md §5・§6（合流点への copy 集約）/ Issue #567
+#
+# dst は fish の functions（conf.d・completions と同様、複数ツールが断片を持ち寄る合流点）。
+# fzf-picker / gh-clone と違い帰属先の Rust バイナリを持たず、ps-grep 自身が独立したツールとして
+# 帰属する（D1 ツール第一級）。fish 本体（configs/fish）ではなくここに置く（§6.3 ルール1）。
+# kind は省略時 "copy"。
+dst = "~/.config/fish/functions"

--- a/configs/ps-grep/ps-grep.fish
+++ b/configs/ps-grep/ps-grep.fish
@@ -1,0 +1,3 @@
+function ps-grep --description 'grep running processes'
+    ps aux | grep $argv[1] | grep -v grep
+end

--- a/docs/dotfiles-native-design.md
+++ b/docs/dotfiles-native-design.md
@@ -38,7 +38,7 @@
 | 配置先（OS物理位置） | そこに集まる「中身の帰属（ツール）」 |
 | --- | --- |
 | `~/.config/fish/conf.d/` | fish, **fzf, eza, delta, zoxide, starship, claude, browser-use, git-worker, 環境(PATH/EDITOR)** の断片が混在 |
-| `~/.config/fish/functions/` | fish(cdabbr, ps-grep), **fzf**(`_fzf_*`), **gh**(gh-clone) |
+| `~/.config/fish/functions/` | fish(`_fzf_file`/`_fzf_history`), **fzf-picker**(`_fzf_gh`/`_fzf_ghq_cd`/`_fzf_worktree_remove`/`cdabbr`/preview 2本), **gh-clone**(gh-clone), **ps-grep**（単独帰属） |
 | `~/.config/fish/completions/` | **bat, clip, docker, gh, merge-ready**（各バイナリから生成） |
 | `~/.config/git/config` | git の8部品を合成（うち delta は色設定も持つ） |
 | `~/.config/bat/` | bat 本体 + ayu-dark テーマ（**delta が共有**） |


### PR DESCRIPTION
## Summary
- fzf-picker 帰属6本(`_fzf_gh` / `_fzf_ghq_cd` / `_fzf_worktree_remove` / `__fzf_picker_preview` / `__fzf_ghq_readme_preview` / `cdabbr`)を `configs/fzf-picker/` へ、gh-clone 帰属1本(`gh-clone`)を `configs/gh-clone/` へ、単独維持1本(`ps-grep`)を `configs/ps-grep/` へ、`home/dot_config/fish/functions/` からコピーして起こす。
- いずれも `dst = "~/.config/fish/functions"` で fish 本体(`configs/fish`)の functions 合流点へ copy される(§6.3 ルール1)。
- `configs/fish/manifest.toml` のコメントを更新し、8本の帰属先を明記。
- `home/dot_config/fish/functions/` は変更しない(S9 #463 で一括撤去。§12.1 不変条件)。

## Test plan
- [x] `mise run check`(lint)が通る
- [x] `cargo fmt --all --check` が通る
- [x] `cargo test --workspace`(266件・E2E含む)が通る
- [x] `dotfiles apply` を実機 HOME に適用し、fish が8関数すべてを autoload できることを確認(`functions -q`)
- [x] `ps-grep` を実際に実行し動作確認

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)