### PR TITLE
ci: PR title に Conventional Commits 形式を必須化する

### DIFF
--- a/.github/bin/check-pr-title.sh
+++ b/.github/bin/check-pr-title.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+title="${PR_TITLE:-}"
+
+if [ -z "$title" ]; then
+  printf 'ERROR: PR_TITLE is required.\n' >&2
+  exit 1
+fi
+
+conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9._/-]+\))?(!)?: .+'
+
+if [[ "$title" =~ $conventional_title ]]; then
+  echo "PR title is Conventional Commit compatible. OK"
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+ERROR: PR title must use Conventional Commit format.
+
+Accepted examples:
+  feat: add watch PR column
+  fix(daemon): avoid startup race
+  chore!: remove legacy config
+
+Allowed types:
+  build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+MSG
+printf '\nActual title:\n  %s\n' "$title" >&2
+exit 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,21 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-title:
+    name: check-pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash .github/bin/check-pr-title.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ dotfiles の利用に必要なツールは [`README.md`](README.md) を参照し
 
 ## コミット規約
 
-[Conventional Commits](https://www.conventionalcommits.org/ja/) 形式を必須とする。PR は squash merge で `main` に入り、PR title がそのままコミットメッセージになるため、**PR title を Conventional Commits 形式にすること**（CI の `check-pr-title` が強制。型は `build` / `chore` / `ci` / `docs` / `feat` / `fix` / `perf` / `refactor` / `revert` / `style` / `test`）。
+[Conventional Commits](https://www.conventionalcommits.org/ja/) 形式を必須とする。**PR title も Conventional Commits 形式にすること**。
 
 ### このリポジトリ固有の判断基準
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ dotfiles の利用に必要なツールは [`README.md`](README.md) を参照し
 
 ## コミット規約
 
-[Conventional Commits](https://www.conventionalcommits.org/ja/) 形式を推奨（任意）。
+[Conventional Commits](https://www.conventionalcommits.org/ja/) 形式を必須とする。PR は squash merge で `main` に入り、PR title がそのままコミットメッセージになるため、**PR title を Conventional Commits 形式にすること**（CI の `check-pr-title` が強制。型は `build` / `chore` / `ci` / `docs` / `feat` / `fix` / `perf` / `refactor` / `revert` / `style` / `test`）。
 
 ### このリポジトリ固有の判断基準
 


### PR DESCRIPTION
## Summary
- 今回の #590 (`2accb34`) が Conventional Commits 形式でないまま main に squash merge され、release-plz のバージョン判定・CHANGELOG生成の前提が崩れていた事故を受けての再発防止
- `merge-ready` リポジトリで先行導入済みの `check-pr-title.sh`(PR title を Conventional Commits の正規表現で検証)をそのまま移植し、`.github/bin/check-pr-title.sh` に配置(このリポジトリでは `scripts/` ではなく `.github/bin/` を使う方針)
- PR title が Conventional Commits 形式でなければ CI(`check-pr-title` job)が落ちるようにする。squash merge のため PR title = main の commit message になる
- CONTRIBUTING.md の「推奨（任意）」表記を、CI強制の実態に合わせて更新

## Test plan
- [x] `PR_TITLE` に元の非準拠タイトル("manifest.toml を steps パイプライン...")を渡すとエラーになることを確認
- [x] `PR_TITLE` に修正後のタイトル("refactor(manifest)!: ...")を渡すと通過することを確認
- [ ] この PR 自体の title(`ci: PR title に...`)で `check-pr-title` job が green になることを CI 上で確認
- [ ] マージ後、`Main protect` ruleset(https://github.com/toshiki670/dotfiles/settings/rules/12972983)の `required_status_checks` に `check-pr-title` を追加(gh api でのruleset書き込みが権限不足で失敗するため、Web UIでの手動対応が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)