### PR TITLE
chore: release v0.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.71.0] - 2026-07-08
+### Features
+- Rustdoc doc コメントの無駄を削る skill を追加する ([#583](https://github.com/toshiki670/dotfiles/pull/583)) ([`e546538`](https://github.com/toshiki670/dotfiles/commit/e546538600406c0698947d40e43219d05121a6d1))
+- Memory-tidy skill に有用性判定と階層化エスカレーションを追加する ([#586](https://github.com/toshiki670/dotfiles/pull/586)) ([`bf71f07`](https://github.com/toshiki670/dotfiles/commit/bf71f0745b9c1e883da8a16a3b5fa2a4e97d65ac))
+### Refactor
+- [**BREAKING**] Manifest.toml を steps パイプライン(input→merge→output)へ移行する ([`326fdc5`](https://github.com/toshiki670/dotfiles/commit/326fdc5aaeb160545d5204bb0c09fee666e99e97))
+
+
 ## [0.70.0] - 2026-07-04
 ### Features
 - MacOS アプリの preference plist を一級扱いする(Stats.plist 移行) ([#559](https://github.com/toshiki670/dotfiles/pull/559)) ([`6940e68`](https://github.com/toshiki670/dotfiles/commit/6940e68e285fd730ed91f96bc67b9779a18a307d))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.70.0"
+version     = "0.71.0"
 
 [dependencies]
 clap          = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `dotfiles`: 0.70.0 -> 0.71.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.71.0] - 2026-07-08

### Features
- Rustdoc doc コメントの無駄を削る skill を追加する ([#583](https://github.com/toshiki670/dotfiles/pull/583)) ([`e546538`](https://github.com/toshiki670/dotfiles/commit/e546538600406c0698947d40e43219d05121a6d1))
- Memory-tidy skill に有用性判定と階層化エスカレーションを追加する ([#586](https://github.com/toshiki670/dotfiles/pull/586)) ([`bf71f07`](https://github.com/toshiki670/dotfiles/commit/bf71f0745b9c1e883da8a16a3b5fa2a4e97d65ac))
### Refactor
- [**BREAKING**] Manifest.toml を steps パイプライン(input→merge→output)へ移行する ([`326fdc5`](https://github.com/toshiki670/dotfiles/commit/326fdc5aaeb160545d5204bb0c09fee666e99e97))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).