### PR TITLE
chore(deps): Dependabot に Cargo エコシステムの依存更新を追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,18 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      cargo:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要
`.github/dependabot.yml` に `package-ecosystem: "cargo"` を追加する。既存の `github-actions` エントリと同じ schedule（毎週月曜・Asia/Tokyo）/ commit-message prefix（chore）/ groups（1グループへまとめる）をそのまま踏襲した。

## 検討事項への回答（#606 に記載していたもの）
- **個別 PR か グルーピングか**: 既存の `github-actions` エントリに合わせ `patterns: ["*"]` で1グループにまとめた。依存数が少なく、個別 PR にすると管理コストの方が勝るため。
- **Cargo.toml のバージョン制約自体を上げるか**: この設定自体では変更しない。Dependabot cargo の既定挙動（`versioning-strategy: auto`）に任せる。現状の依存指定は `"1"` のような緩い制約が多く、パッチ/マイナー更新は `Cargo.lock` のみの PR になり、`Cargo.toml` の制約変更が要る場合（メジャー更新等）だけ Dependabot が `Cargo.toml` も書き換える。
- **release-plz との競合**: Dependabot の PR は `Cargo.lock` / `Cargo.toml` の依存部分のみを変更し、パッケージ version は変えない。release-plz 側は `release_commits` 設定により依存更新だけの空 bump を抑止済みのため、追加の調整は不要と判断した。

Closes #606

## Test plan
- [x] Ruby `YAML.load_file` で構文・構造を確認
- [x] `mise run lint` で既存 lint（taplo 等）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)