### PR TITLE
feat(deps): plist_dict! マクロでテストの Dictionary 手動構築を置き換える

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ clap_complete = "4"
 ignore        = "0.4"
 include_dir   = "0.7"
 libc          = "0.2"
-plist         = "1"
+plist         = "1.10"
 serde         = { version = "1", features = [ "derive" ] }
 serde_json    = "1"
 strum         = { version = "0.28", features = [ "derive" ] }

--- a/src/bin/dotfiles/apply/fold/plist.rs
+++ b/src/bin/dotfiles/apply/fold/plist.rs
@@ -188,12 +188,10 @@ mod tests {
         // plist（`defaults export <domain> <file>` が実際に書く形式）で与えても、xml plist の断片と
         // 同じく shallow merge できることを確認する ― `shallow` が「XML の合成」ではなく
         // 「plist（直列化非依存）の合成」であることの直接の証拠。
-        let mut base_dict = Dictionary::new();
-        base_dict.insert(
-            "NSWindow Frame".to_string(),
-            PlistValue::String("0 0 100 200".to_string()),
-        );
-        base_dict.insert("CPU_state".to_string(), PlistValue::Boolean(false));
+        let base_dict = plist::plist_dict! {
+            "NSWindow Frame": "0 0 100 200",
+            "CPU_state": false,
+        };
         let mut base_bin = Vec::new();
         PlistValue::Dictionary(base_dict)
             .to_writer_binary(&mut base_bin)


### PR DESCRIPTION
## Summary
- `plist` 1.10.0 で追加された `plist_dict!` マクロで、`shallow_accepts_binary_plist_input_not_just_xml` テストの `Dictionary::new()` + `insert` 連鎖を JSON 風リテラルに置き換え
- `Cargo.toml` の `plist` バージョン制約を `"1"` → `"1.10"` へ引き上げ（マクロが使えるバージョンを明示）

対象を絞った理由: 他のテストは XML 文字列を意図的に手書きしており（`shallow`/`deep` が受け取る `&[u8]` そのものの検証、XML/binary 入力の書き分けもカバレッジの一部）、無理に統一していない。プロダクションコード（`shallow`/`deep`）は plist を parse するだけでリテラル構築はしないため、マクロの適用範囲はテストコードに限られる。

Closes #611

## Test plan
- [x] `cargo test`（290 件パス）
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `mise run check`