### PR TITLE
chore(test): cargo test を cargo-nextest へ切り替える

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.140
+
       - name: Format check
         run: cargo fmt --all --check
 
@@ -32,7 +37,7 @@ jobs:
         run: cargo build --workspace --locked
 
       - name: Test
-        run: cargo test --workspace --locked
+        run: cargo nextest run --workspace --locked
 
       # intra-doc リンク腐敗の恒久ガード（main.rs の #![deny(rustdoc::broken_intra_doc_links)]）。
       # rustdoc lint は cargo doc 実行時のみ効くため、CI でリンク切れを検出する。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,13 +80,15 @@ lint は Rust 製オーケストレータ `dotfiles-lint`（`tools/dotfiles-lint
 workspace 全体のテスト（各クレートの unit + E2E）を確認する。
 
 ```bash
-cargo test --workspace
+cargo nextest run --workspace
 ```
+
+`cargo-nextest` は mise から供給される（`mise install` で導入済み）。
 
 #### 補足
 
-- CI は `cargo run -p dotfiles-lint -- check`（lint）と `cargo test --workspace`（unit + E2E）を
-  実行する。
+- CI は `cargo run -p dotfiles-lint -- check`（lint）と `cargo nextest run --workspace`
+  （unit + E2E）を実行する。
 - 詳細ログが必要な場合は `cargo run -p dotfiles-lint -- check --summary --json` を使う。
 
 ### テスト方針（エンジンはツールのライフサイクルから独立）

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,11 @@
 # fresh machine は mise で rust を取得してから cargo install する。
 rust = "latest"
 
+# workspace のテストランナー（`cargo test` の代替）。再現性のため版をピンする。
+# CI（.github/workflows/rust.yml）はプリビルドバイナリを別経路で取得するため、
+# 更新時はそちらの版も揃えること。
+"cargo:cargo-nextest" = "0.9.140"
+
 # lint オーケストレータが呼ぶフォーマッタ/リンタ群。
 # 再現性のため版をピンする（更新時は初回 `mise run lint` で差分を吸収）。
 # fish は brew 既存（mise では供給しない）。


### PR DESCRIPTION
## Summary
- テストランナーを `cargo test` から `cargo-nextest` に統一（ローカル・CI 両方）
- mise.toml で `cargo-nextest` をピン留め供給（`cargo:` backend）
- CONTRIBUTING.md の手順・CI 説明、`.github/workflows/rust.yml` のテストステップを `cargo nextest run` に更新
- CI には `taiki-e/install-action` で `cargo-nextest` をインストールするステップを追加

## Test plan
- [x] `mise install` で `cargo-nextest` が供給されることを確認
- [x] `cargo nextest run --workspace --locked` が 305 件全パスすることを確認（ローカル）
- [x] `mise run check`（lint/format チェック）が通ることを確認
- [x] doctest の喪失有無を確認（このリポジトリは全 crate が `[lib]` なしの bin 構成のため doctest は存在せず、影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)