### PR TITLE
feat: Homebrew tap 経由の自動 formula 更新を追加する

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -36,9 +36,8 @@ jobs:
           # タグ/Release 作成のみ（main への直接 push なし）。crates.io publish は無効。
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # この時点で main は Release PR マージ済み = root Cargo.toml は bump 後。上のタグ作成が
-      # 打つタグも同じ版なので、ここで読めば新規タグと一致する（release-plz アクションの
-      # 出力スキーマに依存しない。"Set Release PR title" ステップと同じ手法）。
+      # main は Release PR マージ済み（root Cargo.toml は bump 後）の時点なので、ここで読めば
+      # 直前に打った新規タグと同じ版になる。release-plz アクションの出力には依存しない。
       - name: Read root version
         id: version
         run: |
@@ -62,8 +61,7 @@ jobs:
       - name: Bump Formula/dotfiles.rb on toshiki670/homebrew-tap
         env:
           # homebrew-tap 専用の fine-grained PAT（contents:write, homebrew-tap のみ）。
-          # RELEASE_PLEASE_TOKEN は dotfiles リポジトリの Release PR 作成専用に留める
-          # （最小権限；tap への書き込み権限は持たせない）。
+          # RELEASE_PLEASE_TOKEN は dotfiles の Release PR 作成専用に留め、tap への書き込み権限は持たせない。
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ needs.release-publish.outputs.version }}
         run: |
@@ -89,7 +87,6 @@ jobs:
             exit 0
           fi
           git commit -m "chore: bump dotfiles to v${VERSION}"
-          # 合意のとおり直接 main へ push（PR は挟まない）。dotfiles 側 Release PR の
-          # 人間レビューが既にゲートになっている。homebrew-tap main に push 保護が
-          # 無いことが前提。
+          # 直接 main へ push する（PR は挟まない）。dotfiles 側 Release PR の人間レビューが
+          # 既にゲートになっている。homebrew-tap の main に push 保護が無いことが前提。
           git push origin main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,6 +17,8 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -33,3 +35,61 @@ jobs:
         env:
           # タグ/Release 作成のみ（main への直接 push なし）。crates.io publish は無効。
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # この時点で main は Release PR マージ済み = root Cargo.toml は bump 後。上のタグ作成が
+      # 打つタグも同じ版なので、ここで読めば新規タグと一致する（release-plz アクションの
+      # 出力スキーマに依存しない。"Set Release PR title" ステップと同じ手法）。
+      - name: Read root version
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Cargo.toml | head -n1)
+          if [ -z "$version" ]; then
+            echo "::error::root Cargo.toml から version を取得できず"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  homebrew-tap-bump:
+    name: homebrew-tap-bump
+    needs: release-publish
+    runs-on: ubuntu-latest
+    # このジョブは toshiki670/homebrew-tap のみを書き換える。dotfiles 側 contents への
+    # 書き込み権限は不要なため、workflow 既定の contents: write を明示的に落とす。
+    permissions:
+      contents: read
+    steps:
+      - name: Bump Formula/dotfiles.rb on toshiki670/homebrew-tap
+        env:
+          # homebrew-tap 専用の fine-grained PAT（contents:write, homebrew-tap のみ）。
+          # RELEASE_PLEASE_TOKEN は dotfiles リポジトリの Release PR 作成専用に留める
+          # （最小権限；tap への書き込み権限は持たせない）。
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ needs.release-publish.outputs.version }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/toshiki670/dotfiles/archive/refs/tags/v${VERSION}.tar.gz"
+          sha256=$(curl -fsSL "$url" | shasum -a 256 | cut -d' ' -f1)
+
+          # gh の credential helper 経由で認証する（token を clone URL に埋め込まない）。
+          gh auth setup-git
+          git clone --depth 1 https://github.com/toshiki670/homebrew-tap.git homebrew-tap
+          cd homebrew-tap
+
+          sed -i -E \
+            -e "s#^  url \".*\"\$#  url \"${url}\"#" \
+            -e "s#^  sha256 \".*\"\$#  sha256 \"${sha256}\"#" \
+            Formula/dotfiles.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/dotfiles.rb
+          if git diff --cached --quiet; then
+            echo "formula は既に v${VERSION} 相当のため commit をスキップ"
+            exit 0
+          fi
+          git commit -m "chore: bump dotfiles to v${VERSION}"
+          # 合意のとおり直接 main へ push（PR は挟まない）。dotfiles 側 Release PR の
+          # 人間レビューが既にゲートになっている。homebrew-tap main に push 保護が
+          # 無いことが前提。
+          git push origin main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,9 @@ dotfiles の利用に必要なツールは [`README.md`](README.md) を参照し
 1. `mise run release-prepare`（または GitHub の Release Prepare workflow を `workflow_dispatch`）で release-plz が Release PR（`release-*` ブランチ）を作成・更新する。
 2. Release PR には `Cargo.toml` の version と `CHANGELOG.md` の更新が含まれる（必要なら PR 上で version を手動調整できる）。
 3. Release PR を `main` にマージすると Release Publish workflow が走り、タグ `v{version}` と GitHub Release が作成される。
+4. 続けて同じ workflow が `toshiki670/homebrew-tap` の `Formula/dotfiles.rb`（`url` / `sha256`）を新版へ更新し、直接 `main` へ commit する（専用 PAT、PR は挟まない）。
 
-`main` への直接 push は不要・不可。Release PR のマージがリリースのトリガー（ブランチ保護と両立）。
+dotfiles の `main` への直接 push は不要・不可。Release PR のマージがリリースのトリガー（ブランチ保護と両立）。
 
 ### 現在のバージョン確認
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,19 @@ rtk init -g
 ## 1. Install the `dotfiles` CLI
 
 ```bash
-cargo install --git https://github.com/toshiki670/dotfiles
+brew tap toshiki670/tap
+brew install dotfiles
 ```
 
-The `configs/` tree is embedded in the binary, so this single command is enough (a local clone's working tree is used automatically when present). The Rust toolchain is supplied by mise (`mise install`); see [Rust commands](#rust-commands).
+Installs all 8 bins (`dotfiles`, `clip`, `gcm`, `gh-clone`, `git-upstream`, `fzf-picker`, `env-tools`, `workers`). `brew upgrade` keeps them current.
+
+Contributors and local development can install straight from a clone instead:
+
+```bash
+cargo install --path . dotfiles
+```
+
+(or `cargo install --git https://github.com/toshiki670/dotfiles dotfiles` without cloning first — the explicit `dotfiles` package name is required because the workspace's `tools/` members also ship bins). The `configs/` tree is embedded in the binary, so either install path is enough on its own (a local clone's working tree is used automatically when present, otherwise the embedded copy is used). The Rust toolchain for `cargo install` is supplied by mise (`mise install`); see [Rust commands](#rust-commands).
 
 ## 2. Review destinations (optional)
 
@@ -187,7 +196,7 @@ Requires the `trash` CLI (bundled with macOS 15+). Both guards are intentionally
 
 # Rust commands
 
-All distributable commands live in the single root `dotfiles` package as multiple bins (a **Cargo workspace** at the repository root, whose only other members are the dev/maintenance tools under `tools/`). Install them into `~/.cargo/bin` with one `cargo install --git https://github.com/toshiki670/dotfiles` (or `cargo install --path .` from a clone; the tools under `tools/` are not installed). The Rust toolchain and the lint tools are supplied by **mise** (`mise.toml`), so a fresh machine bootstraps as: `mise install` (rust) → `cargo install` (commands) → `dotfiles apply` (configs).
+All distributable commands live in the single root `dotfiles` package as multiple bins (a **Cargo workspace** at the repository root, whose only other members are the dev/maintenance tools under `tools/`). The recommended install path is Homebrew (see [Installation](#installation)); installing from a clone or via `cargo install --git` needs the package name given explicitly — `cargo install --path . dotfiles` (or `cargo install --git https://github.com/toshiki670/dotfiles dotfiles`) — because the workspace's `tools/` members also have bins, so a bare `cargo install --path .` is ambiguous (`error: multiple packages with binaries found`). The Rust toolchain and the lint tools are supplied by **mise** (`mise.toml`), so a fresh machine bootstraps as: `mise install` (rust) → `cargo install` (commands) → `dotfiles apply` (configs).
 
 Design and internals (manifest schema / apply pipeline / `locals` resolution / `when` gates / …) are not documented here. They live in the **[Rustdoc](https://toshiki670.github.io/dotfiles/)** (the `dotfiles` crate's own module docs), rebuilt on every push to `main`. Treat it as the architecture reference.
 


### PR DESCRIPTION
## Summary
- `release-publish.yml` に `homebrew-tap-bump` ジョブを追加。タグ/Release 作成後、`toshiki670/homebrew-tap` の `Formula/dotfiles.rb`（`url`/`sha256`）を新版へ更新し、専用 PAT で直接 `main` へ push する（PR は挟まない）。
- README.md: Installation セクションを `brew tap toshiki670/tap && brew install dotfiles` 主体に更新。`cargo install --git` 側の既知の不具合（パッケージ名指定漏れで `error: multiple packages with binaries found`）も修正。Rust commands セクションも同様に修正。
- CONTRIBUTING.md: リリースフローに homebrew-tap 更新のステップを追記。

## 前提（未完了・別途対応が必要）
- [ ] `toshiki670/homebrew-tap` のみに `Contents: Read and write` を持つ fine-grained PAT を新規発行し、`HOMEBREW_TAP_TOKEN` として `gh secret set HOMEBREW_TAP_TOKEN --repo toshiki670/dotfiles` で登録する（`RELEASE_PLEASE_TOKEN` とは分離）。
- [ ] `toshiki670/homebrew-tap` の `main` に push 保護が無いことを確認する（直接 commit 方式の前提）。
- 上記が完了するまで `homebrew-tap-bump` ジョブは次回リリースで失敗する。

## 関連
- Closes #610
- Formula 側 PR: toshiki670/homebrew-tap#1
- Formula 側は v0.71.0 に対して `brew style` / `brew audit --strict --online` / `brew install --build-from-source` / `brew test` を実施済み（8 bin が正しくインストールされることを確認）。v0.71.0 は本 PR 着手中に、8 bin へのサブコマンド統合（#585）を反映するため新規に切ったリリース。

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `mise run lint`（自動修正差分なし）
- [x] `.github/workflows/release-publish.yml` の YAML 構文確認
- [ ] 次回リリースで `homebrew-tap-bump` ジョブが実際に成功することを確認（前提の PAT/secret 登録後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)