### PR TITLE
fix(docs): use fully-qualified brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ rtk init -g
 ## 1. Install the `dotfiles` CLI
 
 ```bash
-brew tap toshiki670/tap
-brew install dotfiles
+brew install toshiki670/tap/dotfiles
 ```
 
 Installs all 8 bins (`dotfiles`, `clip`, `gcm`, `gh-clone`, `git-upstream`, `fzf-picker`, `env-tools`, `workers`). `brew upgrade` keeps them current.


### PR DESCRIPTION
## Summary
- Homebrew's `HOMEBREW_REQUIRE_TAP_TRUST` defaults to `true`, so the previously documented two-step install (`brew tap toshiki670/tap` then bare `brew install dotfiles`) fails on a fresh machine:
  ```
  Error: Refusing to load formula toshiki670/tap/dotfiles from untrusted tap toshiki670/tap.
  Run `brew trust --formula toshiki670/tap/dotfiles` or `brew trust toshiki670/tap` to trust it.
  ```
- Reported after installing on a second machine (post #619/#610). Reproduced locally: the fully-qualified form (`brew install toshiki670/tap/dotfiles`) auto-taps and auto-trusts in one command, so it doesn't hit this at all — switched the documented command to that instead of adding a third `brew trust` step.

## Test plan
- [x] Reproduced the failure with the old two-step command on a clean local tap/trust state
- [x] Verified `brew install toshiki670/tap/dotfiles` installs cleanly with no trust prompt
- [x] Verified a subsequent bare `brew upgrade dotfiles` also works (trust persists per-formula)
- [x] `mise run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)