### PR TITLE
refactor(manifest): Tree/Pipeline と step の input/output 択一を型で表現する

### DIFF
--- a/src/bin/dotfiles/apply/pipeline.rs
+++ b/src/bin/dotfiles/apply/pipeline.rs
@@ -1,13 +1,15 @@
 //! step 列の実行器: 内容（Content）を空から始め、宣言順に input（読む）→ output（書く）を畳む。
 //!
-//! `manifest.toml` の `[[steps]]` を上から評価する。各 step は `when`（step スコープ gate）で採否を
-//! 決め、採用された input は内容へ中身を畳み、output は内容を宛先へ書く。ツリー input（`input = "."`）は
-//! 内容を「ファイルツリー」にし、パス output で相対構造を保って再帰配置する（[`crate::apply::copy`]）。
+//! `manifest.toml` の `[[steps]]` を解釈した [`crate::manifest::Steps`] を実行する。ツリー配置
+//! （[`Steps::Tree`]）は step 列を持たないため、畳み込みを経ず単位ディレクトリを output へ再帰配置
+//! する（[`crate::apply::copy`]）。パイプライン（[`Steps::Pipeline`]）は step 列を上から評価する:
+//! 各 step は `when`（step スコープ gate）で採否を決め、採用された input は内容へ中身を畳み、
+//! output は内容を宛先へ書く。
 //!
 //! バイト内容の畳み込みは unit レベルの `format` が内容種別を決め、各 input step 自身の `merge`
 //! （値の一覧は [`crate::manifest`]）が「どう重ねるか」を選ぶ（[`fold_in`]） ― `fold_in` は unit 全体
 //! ではなくその step の `merge` だけを見て畳み込み関数を選ぶ。最初の input は `merge` を持たない
-//! （[`crate::manifest`] の `validate` が禁止）が、土台なし（`base = None`）から畳むといずれの畳み込み
+//! （load 時の解釈が禁止）が、土台なし（`base = None`）から畳むといずれの畳み込み
 //! 関数も断片そのもの（再直列化）を返す ― [`crate::apply::fold`] の各関数に共通する性質 ― ため、
 //! optional / gate で先頭 input が実行時に飛んでも（宣言上の 2 番目が実際の最初になっても）結果は
 //! 一定になる。
@@ -18,7 +20,9 @@
 use super::gate::{self, GateState};
 use super::{cmd, copy, fold, set_mode, write_if_changed};
 use crate::locals::resolve;
-use crate::manifest::{Format, Manifest, Merge, StepSource, resolve_output_path};
+use crate::manifest::{
+    Format, InputStep, Manifest, Merge, OutputStep, Step, StepSource, Steps, resolve_output_path,
+};
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -30,11 +34,9 @@ enum Content {
     Empty,
     /// バイト列の内容（input を `format` × `merge` で畳んだ結果）。
     Bytes(Vec<u8>),
-    /// 単位ディレクトリツリー（`input = "."`）。パス output で再帰配置する。
-    Tree,
 }
 
-/// 1 単位（`unit_dir`）の step 列を実行する。`home` は `~` 展開先、`locals` は解決済み named value、
+/// 1 単位（`unit_dir`）の steps を実行する。`home` は `~` 展開先、`locals` は解決済み named value、
 /// `gate_state` は step の `when`（状態 gate）評価に使う現在状態スナップショット。
 pub fn run(
     unit_dir: &Path,
@@ -43,94 +45,96 @@ pub fn run(
     locals: &BTreeMap<String, String>,
     gate_state: &GateState,
 ) -> Result<(), String> {
-    let mut content = Content::Empty;
-    for step in &manifest.steps {
-        // step gate: 満たさなければこの step を飛ばす（内容は不変）。
-        if !gate::when_satisfied(&step.when, gate_state) {
-            continue;
-        }
-        if let Some(input) = &step.input {
-            apply_input(
-                &mut content,
+    let (format, steps) = match &manifest.steps {
+        Steps::Tree { output } => {
+            return copy::place(
                 unit_dir,
-                home,
-                manifest.format,
-                step.merge,
-                step.optional,
-                input,
-            )?;
-        } else if let Some(output) = &step.output {
-            apply_output(&content, unit_dir, home, manifest, locals, output)?;
+                &resolve_output_path(home, output),
+                manifest,
+                locals,
+            );
+        }
+        Steps::Pipeline { format, steps } => (*format, steps),
+    };
+    let mut content = Content::Empty;
+    for step in steps {
+        match step {
+            Step::Input(input) => {
+                // step gate: 満たさなければこの step を飛ばす（内容は不変）。
+                if !gate::when_satisfied(&input.when, gate_state) {
+                    continue;
+                }
+                apply_input(&mut content, unit_dir, home, format, input)?;
+            }
+            Step::Output(output) => {
+                if !gate::when_satisfied(&output.when, gate_state) {
+                    continue;
+                }
+                apply_output(&content, home, manifest, locals, output)?;
+            }
         }
     }
     Ok(())
 }
 
-/// input step: 読んだ中身を内容へ畳む（`format` × この step の `merge` で駆動）。ツリー input は
-/// 内容をツリーにする。optional なパス input が不在なら内容を触らず飛ばす（次の input が土台になる）。
+/// input step: 読んだ中身を内容へ畳む（`format` × この step の `merge` で駆動）。
+/// optional なパス input が不在なら内容を触らず飛ばす（次の input が土台になる）。
 fn apply_input(
     content: &mut Content,
     unit_dir: &Path,
     home: &Path,
     format: Option<Format>,
-    merge: Option<Merge>,
-    optional: bool,
-    input: &StepSource,
+    input: &InputStep,
 ) -> Result<(), String> {
-    match input {
-        StepSource::Path(p) if p == "." => *content = Content::Tree,
+    match &input.source {
         StepSource::Path(p) => {
             let path = resolve_input_path(unit_dir, home, p);
             match std::fs::read(&path) {
                 // パースエラーには input パスのラベルを添える（どの input が壊れたか）。
                 Ok(bytes) => {
-                    fold_in(content, format, merge, &bytes).map_err(|e| format!("{p}: {e}"))?;
+                    fold_in(content, format, input.merge, &bytes)
+                        .map_err(|e| format!("{p}: {e}"))?;
                 }
                 // optional な不在は内容を触らず飛ばす（既定は「無ければエラー」）。
-                Err(e) if e.kind() == io::ErrorKind::NotFound && optional => {}
+                Err(e) if e.kind() == io::ErrorKind::NotFound && input.optional => {}
                 Err(e) => return Err(format!("{}: 読み込み失敗: {e}", path.display())),
             }
         }
         StepSource::Cmd(c) => {
             let bytes = cmd::run(&c.cmd)?;
             // パースエラーには cmd argv のラベルを添える。
-            fold_in(content, format, merge, &bytes)
+            fold_in(content, format, input.merge, &bytes)
                 .map_err(|e| format!("{}: {e}", c.cmd.join(" ")))?;
         }
     }
     Ok(())
 }
 
-/// output step: 内容を宛先へ書く。パス output はファイル/ツリーを配置、cmd output は内容を
+/// output step: 内容を宛先へ書く。パス output はファイルを配置、cmd output は内容を
 /// 標準入力へ渡す。
 fn apply_output(
     content: &Content,
-    unit_dir: &Path,
     home: &Path,
     manifest: &Manifest,
     locals: &BTreeMap<String, String>,
-    output: &StepSource,
+    output: &OutputStep,
 ) -> Result<(), String> {
-    match (output, content) {
-        (StepSource::Path(p), Content::Tree) => {
-            copy::place(unit_dir, &resolve_output_path(home, p), manifest, locals)
-        }
-        (StepSource::Path(p), Content::Bytes(bytes)) => {
+    let Content::Bytes(bytes) = content else {
+        return Err(
+            "output に到達しましたが内容が空です（生成された中身がありません）".to_string(),
+        );
+    };
+    match &output.dest {
+        StepSource::Path(p) => {
             let injected = resolve::inject(bytes, locals);
             let path = resolve_output_path(home, p);
             write_if_changed(&path, &injected)?;
             // 書き込みを省略しても mode は毎回再適用する（属性変更が反映されるように）。
             set_mode(&path, manifest)
         }
-        (StepSource::Cmd(c), Content::Bytes(bytes)) => {
+        StepSource::Cmd(c) => {
             // cmd output は毎 apply 実行し、合成済みの内容を標準入力へ渡す（冪等契約）。
             cmd::run_piped(&c.cmd, &resolve::inject(bytes, locals))
-        }
-        (_, Content::Empty) => {
-            Err("output に到達しましたが内容が空です（生成された中身がありません）".to_string())
-        }
-        (StepSource::Cmd(_), Content::Tree) => {
-            unreachable!("validated: ツリー output はパス（cmd 不可）")
         }
     }
 }
@@ -150,7 +154,7 @@ fn fold_in(
 ) -> Result<(), String> {
     let base = match content {
         Content::Bytes(b) => Some(b.as_slice()),
-        _ => None,
+        Content::Empty => None,
     };
     let merged = match (format, merge) {
         (None, _) => bytes.to_vec(),
@@ -165,7 +169,7 @@ fn fold_in(
 }
 
 /// input パスを解決する: `~` 起点は `home` に展開、それ以外は単位相対（`unit_dir` に join）。
-/// 表記は [`crate::manifest`] の `validate` が保証済み（`~` / `~/...` / 単位相対）。
+/// 表記は load 時の解釈（[`crate::manifest`]）が保証済み（`~` / `~/...` / 単位相対）。
 fn resolve_input_path(unit_dir: &Path, home: &Path, p: &str) -> PathBuf {
     if let Some(rest) = p.strip_prefix("~/") {
         home.join(rest)

--- a/src/bin/dotfiles/doctor.rs
+++ b/src/bin/dotfiles/doctor.rs
@@ -11,7 +11,7 @@
 use crate::apply::gate;
 use crate::discover::{self, MANIFEST};
 use crate::locals::store::Store;
-use crate::manifest::{Manifest, StepSource, resolve_output_path};
+use crate::manifest::{Manifest, Step, StepSource, Steps, resolve_output_path};
 use crate::placements::{self, Placement};
 use crate::prune;
 use std::collections::BTreeMap;
@@ -130,10 +130,17 @@ fn stale_reason(source: &Path, home: &Path, gate_state: &gate::GateState, path: 
     if let Some(reason) = gate::unit_skip_reason(&manifest, gate_state) {
         return format!("{owner}: {reason}");
     }
-    let step_gated = manifest.steps.iter().any(|step| {
-        matches!(&step.output, Some(StepSource::Path(p)) if resolve_output_path(home, p) == path)
-            && !gate::when_satisfied(&step.when, gate_state)
-    });
+    let step_gated = match &manifest.steps {
+        // ツリー配置は step を持たず when も書けない（unit gate のみ）。
+        Steps::Tree { .. } => false,
+        Steps::Pipeline { steps, .. } => steps.iter().any(|step| match step {
+            Step::Output(out) => {
+                matches!(&out.dest, StepSource::Path(p) if resolve_output_path(home, p) == path)
+                    && !gate::when_satisfied(&out.when, gate_state)
+            }
+            Step::Input(_) => false,
+        }),
+    };
     if step_gated {
         return format!("{owner}: output step の when が不成立です");
     }

--- a/src/bin/dotfiles/locals/resolve.rs
+++ b/src/bin/dotfiles/locals/resolve.rs
@@ -53,9 +53,9 @@ pub fn inject(bytes: &[u8], values: &BTreeMap<String, String>) -> Vec<u8> {
 mod tests {
     use super::*;
 
-    /// テキストから Manifest をパースする（検証込み）。
+    /// テキストから Manifest を読み込む（パース＋解釈）。
     fn manifest(src: &str) -> Manifest {
-        toml::from_str(src).unwrap()
+        src.parse().unwrap()
     }
 
     #[test]

--- a/src/bin/dotfiles/manifest.rs
+++ b/src/bin/dotfiles/manifest.rs
@@ -25,41 +25,30 @@ use serde::Deserialize;
 use std::path::{Component, Path, PathBuf};
 use strum::{Display, EnumIter};
 
-/// 1 つの設定単位（`manifest.toml` を持つディレクトリ）の配置仕様。
+/// 1 つの設定単位（`manifest.toml` を持つディレクトリ）の配置仕様（解釈済みの確定形）。
 ///
-/// `deny_unknown_fields` で未知キーを load 時に弾く。旧スキーマの語彙（`dst` / `kind` / `strategy` /
-/// `preserve` / ユニット直下 `cmd` / `[[overlay]]` / `sensitive` 等）が残った manifest はここで
-/// エラーになる（後方互換は持たせず、誤連想の再発を防ぐ）。
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+/// [`Manifest::load`] が生スキーマ（[`RawManifest`]）を検証しながらこの型へ解釈する。「パースは
+/// 通るが意味的に不正」な形の多く（step の input / output の併記・欠落、ツリーへの format /
+/// merge / step gate の指定等）はこの型では表現できず、残る不整合（パス表記・merge と format の
+/// 両立等）も解釈時に弾かれるため、この型の値は常に配置可能な宣言を表す。
+#[derive(Debug)]
 pub struct Manifest {
     /// ユニット全体 gate。トップレベルに書いた `when` はユニットスコープで、
     /// 満たさなければユニット全体を skip する（配置も `hooks` も触らない ＝ all-or-nothing）。
     /// `when.deps`（配列・AND）が PATH に揃い、`when.os`（スカラ）が現在 OS と一致し、
     /// `when.profile`（スカラ・状態）が現在の profile 状態と一致した時だけ真。省略時は常時採用。
     /// 同じ語彙を各 step の `when` がその step スコープで再利用する。
-    #[serde(default)]
     pub when: Option<When>,
     /// マシンローカル値（named value）の宣言。ここで宣言した名前 `n` に対し、この単位の
     /// 配置ファイル中の `@@n@@` をストア（`~/.config/dotfiles/local.toml`）の値で置換する。
     /// 置換は `locals` を宣言した単位のファイルにだけ走る（無関係ファイルの `@@…@@` を巻き込まない）。
     /// 例: `locals = ["git.email", "git.name"]`。
-    #[serde(default)]
     pub locals: Vec<String>,
-    /// 合成の内容型（`merge` を使うユニットに必須・使わないユニットには書けない）。
-    /// `json` / `plist` / `text`。実行時の畳み込みのバイト種別（内容の解釈のしかた）を決め、
-    /// 「どう重ねるか」は各 step 自身の `merge` が選ぶ（[`Step::merge`]）。
-    #[serde(default)]
-    pub format: Option<Format>,
-    /// 配置パイプライン。input（読む）→ output（書く）の step 列。空は load 時エラー
-    /// （input を 1 つ以上・output を 1 つ以上必須）。
-    #[serde(default)]
-    pub steps: Vec<Step>,
+    /// 配置の形。`[[steps]]` の列を解釈した結果（ツリー配置 or バイト内容パイプライン）。
+    pub steps: Steps,
     /// 所有者のみアクセス可（0600 相当）。省略時 false。パス output を持つユニットのみ。
-    #[serde(default)]
     pub private: bool,
     /// 実行ビットを付与（0644→0755 / 0600→0700）。省略時 false。パス output を持つユニットのみ。
-    #[serde(default)]
     pub executable: bool,
     /// 配置後フック（onchange 固定）。このユニットの配置後に**宣言順**で実行するエントリの配列
     /// （例 `[[hooks]]` ＋ `cmd = ["bat", "cache", "--build"]`）。各エントリは実行する [`Hook::cmd`]
@@ -67,36 +56,71 @@ pub struct Manifest {
     /// → 新ツールのフック追加に binary 変更は不要・configs と疎結合。各 `cmd` が非空であることを
     /// load 時に検証する。実行は [`crate::hooks`]。トップレベル `when`（ユニット gate）が false の
     /// ユニットは配置ごと skip されるため hooks も走らない（＝ `when.os` でフックを分岐できる）。
-    #[serde(default)]
     pub hooks: Vec<Hook>,
 }
 
-/// 配置パイプラインの 1 step。`input` / `output` の択一を持つ。
-/// `deny_unknown_fields` でキーの typo を load 時に弾く。
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Step {
-    /// 読む内容源（パス or cmd 標準出力）。`output` との併記・双方省略は load 時エラー。
-    #[serde(default)]
-    pub input: Option<StepSource>,
-    /// 書く宛先（パス or cmd 標準入力）。`input` との併記・双方省略は load 時エラー。
-    #[serde(default)]
-    pub output: Option<StepSource>,
-    /// 重ね方（2 つ目以降の input に必須・最初の input と output には禁止）。値は `format` と両立する
-    /// ものを選ぶ: json / plist → `shallow` | `deep`、text → `append`。この step の畳み込みをそのまま
-    /// 駆動する（[`crate::apply::pipeline`]）。
-    #[serde(default)]
+/// 配置の形。`[[steps]]` の列は load 時にどちらかへ解釈される。ツリー配置とバイト内容パイプライン
+/// は持てる語彙が違い（ツリーは format / merge / step の when / optional を持たない）、混在も
+/// できないため、別 variant で表現する。
+#[derive(Debug)]
+pub enum Steps {
+    /// ツリー配置（`input = "."` ＋ パス output の 2 step）: 単位ディレクトリを丸ごと、相対構造を
+    /// 保って配置する（[`crate::apply::copy`]）。step 列は持たない ― バイト内容の合成語彙
+    /// （merge / format）はツリーに意味を持たず、step の `when` は unit gate と冗長になるため、
+    /// いずれも解釈時に弾かれる。
+    Tree {
+        /// 配置先ディレクトリ（`~` 起点の生表記）。
+        output: String,
+    },
+    /// バイト内容パイプライン: 内容を空から始め、宣言順に input（読む）→ output（書く）を畳む
+    /// （[`crate::apply::pipeline`]）。input 1 つ以上・output 1 つ以上。
+    Pipeline {
+        /// 合成の内容型（`merge` を使うユニットに必須・使わないユニットには書けない）。
+        /// `json` / `plist` / `text`。実行時の畳み込みのバイト種別（内容の解釈のしかた）を決め、
+        /// 「どう重ねるか」は各 input step 自身の `merge` が選ぶ（[`InputStep::merge`]）。
+        format: Option<Format>,
+        /// step 列（宣言順）。
+        steps: Vec<Step>,
+    },
+}
+
+/// 配置パイプラインの 1 step。input（読む）と output（書く）の択一を variant で表現する
+/// （manifest.toml 上の併記・欠落は解釈時に弾かれ、ここには到達しない）。
+#[derive(Debug)]
+pub enum Step {
+    /// 読む: 中身を内容へ畳む。
+    Input(InputStep),
+    /// 書く: 内容を宛先へ書く。
+    Output(OutputStep),
+}
+
+/// input step。読んだ中身を内容へ畳む。
+#[derive(Debug)]
+pub struct InputStep {
+    /// 読む内容源（パス or cmd 標準出力）。
+    pub source: StepSource,
+    /// 重ね方（2 つ目以降の input に必須・最初の input には禁止）。値は `format` と両立する
+    /// ものを選ぶ: json / plist → `shallow` | `deep`、text → `append`。この step の畳み込みを
+    /// そのまま駆動する（[`crate::apply::pipeline`]）。
     pub merge: Option<Merge>,
     /// この step の採否（省略 = 常時採用）。unit gate と共通の語彙（`deps` / `os` / `profile`）。
-    #[serde(default)]
     pub when: Option<When>,
     /// `~` 起点のパス input が存在しなければこの step を飛ばす（次の input が土台になる）。既定は
     /// 「無ければエラー」。`~` 起点のパス input のみ有効 ― 単位相対ファイルは repo 追跡の静的ファイルで
-    /// 不在は typo の可能性が高く、恒久的に step を握り潰すため、cmd input・output への指定と併せて
-    /// load 時エラー。唯一の正当な用途は宛先の現在内容（初回 apply 前は未在り得る `~` 起点ファイル）を
+    /// 不在は typo の可能性が高く、恒久的に step を握り潰すため、cmd input への指定と併せて解釈時
+    /// エラー。唯一の正当な用途は宛先の現在内容（初回 apply 前は未在り得る `~` 起点ファイル）を
     /// 土台に読むこと。
-    #[serde(default)]
     pub optional: bool,
+}
+
+/// output step。組み立てた内容を宛先へ書く。`merge` / `optional` は持たない（重ね方は input 側の
+/// 語彙で、output の書き込みは常に実行される）。manifest.toml 上の指定は解釈時に弾かれる。
+#[derive(Debug)]
+pub struct OutputStep {
+    /// 書く宛先（パス or cmd 標準入力）。
+    pub dest: StepSource,
+    /// この step の採否（省略 = 常時採用）。unit gate と共通の語彙（`deps` / `os` / `profile`）。
+    pub when: Option<When>,
 }
 
 /// step の内容源。パス文字列（`"settings.json"` / `"~/.claude/settings.json"`）か
@@ -105,8 +129,9 @@ pub struct Step {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum StepSource {
-    /// パス: input は単位相対 or `~` 起点、output は `~` 起点のみ（[`Manifest::validate`] が検証）。
-    /// 特例として input `"."` は「単位ディレクトリツリー」を表す。
+    /// パス: input は単位相対 or `~` 起点、output は `~` 起点のみ（load 時の解釈
+    /// （[`RawManifest::into_manifest`]）が検証）。特例として input `"."` は
+    /// 「単位ディレクトリツリー」を表す。
     Path(String),
     /// コマンド: input は標準出力を読み、output は内容を標準入力へ渡す（argv）。
     Cmd(CmdSource),
@@ -183,105 +208,213 @@ impl When {
     ///
     /// 空テーブル `when = {}` や `when = { deps = [] }` は常時採用の silent no-op になり、
     /// 「gate を書いたのに効かない」typo（編集で内部キーだけ消えた等）を黙って通す。これを
-    /// load 時に弾くため [`Manifest::validate`] が使う。`theme` 等のキー追加時はここに足す。
+    /// load 時に弾くため [`RawManifest::into_manifest`] が使う。`theme` 等のキー追加時はここに足す。
     fn has_no_effective_key(&self) -> bool {
         self.deps.is_empty() && self.os.is_none() && self.profile.is_none()
     }
 }
 
-/// step が「ツリー input」（`input = "."` ＝ 単位ディレクトリをそのまま配置）か。
-fn is_tree_input(step: &Step) -> bool {
-    matches!(&step.input, Some(StepSource::Path(p)) if p == ".")
-}
-
 impl Manifest {
-    /// `manifest.toml` を読み込み、パース後にセマンティックバリデーションを行う。
+    /// `manifest.toml` を読み込む。TOML パース（[`RawManifest`]）→ 検証・解釈
+    /// （[`std::str::FromStr`] 実装）。
     pub fn load(path: &Path) -> Result<Self, String> {
         let text = std::fs::read_to_string(path)
             .map_err(|e| format!("{}: 読み込み失敗: {e}", path.display()))?;
-        let manifest: Self =
-            toml::from_str(&text).map_err(|e| format!("{}: パース失敗: {e}", path.display()))?;
-        manifest
-            .validate()
-            .map_err(|e| format!("{}: {e}", path.display()))?;
-        Ok(manifest)
-    }
-
-    /// このユニットがツリー配置（単位ディレクトリを丸ごと配置）か。`validate` 後に呼ぶ前提
-    /// （検証済みなら `steps[0]` が唯一のツリー input）。list / apply の表示に使う。
-    pub fn is_tree(&self) -> bool {
-        self.steps.iter().any(is_tree_input)
+        text.parse().map_err(|e| format!("{}: {e}", path.display()))
     }
 
     /// apply の 1 行出力と `list` が共有する宛先表記: 最初のパス output の生表記（`~/...`）。
     /// パス output を持たない（cmd output だけの）ユニットは `(cmd)` を返す。
     pub fn display_dst(&self) -> String {
-        self.steps
-            .iter()
-            .find_map(|s| match &s.output {
-                Some(StepSource::Path(p)) => Some(p.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "(cmd)".to_string())
+        match &self.steps {
+            Steps::Tree { output } => output.clone(),
+            Steps::Pipeline { steps, .. } => steps
+                .iter()
+                .find_map(|step| match step {
+                    Step::Output(OutputStep {
+                        dest: StepSource::Path(p),
+                        ..
+                    }) => Some(p.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| "(cmd)".to_string()),
+        }
     }
 
     /// apply のラベルと `list` の属性が共有する steps サマリ。ツリーは `tree`、それ以外は
     /// `steps=Nin/Mout`（＋ `format` ＋ cmd output があれば `output=cmd`）。
     pub fn summary(&self) -> String {
-        if self.is_tree() {
+        let Steps::Pipeline { format, steps } = &self.steps else {
             return "tree".to_string();
-        }
-        let n_in = self.steps.iter().filter(|s| s.input.is_some()).count();
-        let n_out = self.steps.iter().filter(|s| s.output.is_some()).count();
+        };
+        let n_in = steps.iter().filter(|s| matches!(s, Step::Input(_))).count();
+        let n_out = steps
+            .iter()
+            .filter(|s| matches!(s, Step::Output(_)))
+            .count();
         let mut parts = vec![format!("steps={n_in}in/{n_out}out")];
-        if let Some(format) = self.format {
+        if let Some(format) = format {
             parts.push(format.to_string());
         }
-        if self
-            .steps
-            .iter()
-            .any(|s| matches!(&s.output, Some(StepSource::Cmd(_))))
-        {
+        if steps.iter().any(|s| {
+            matches!(
+                s,
+                Step::Output(OutputStep {
+                    dest: StepSource::Cmd(_),
+                    ..
+                })
+            )
+        }) {
             parts.push("output=cmd".to_string());
         }
         parts.join(", ")
     }
 
-    /// パース後のセマンティック検証。manifest の typo を配置前に弾く（fail-loud）。
+    /// この単位の配置ファイルへ与える Unix パーミッション（8 進）。
     ///
-    /// - **各 step は input / output のちょうど 1 つ**。両方・どちらも無しは typo。
+    /// base は `private` で決まる（0600 / 0644）。`executable` のとき、read ビットが
+    /// 立っている桁へ execute ビットを足す（0644→0755 / 0600→0700）。`private` /
+    /// `executable` 属性の合成規則。
+    #[cfg(unix)]
+    pub fn mode(&self) -> u32 {
+        let base: u32 = if self.private { 0o600 } else { 0o644 };
+        if self.executable {
+            base | ((base & 0o444) >> 2)
+        } else {
+            base
+        }
+    }
+}
+
+impl std::str::FromStr for Manifest {
+    type Err = String;
+
+    /// TOML テキストを [`RawManifest`] へパースし、検証しながら [`Manifest`] へ解釈する。
+    /// [`Manifest::load`] とテストが共有する（load はエラーへファイルパスを前置する）。
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        let raw: RawManifest = toml::from_str(text).map_err(|e| format!("パース失敗: {e}"))?;
+        raw.into_manifest()
+    }
+}
+
+/// `manifest.toml` の生スキーマ（TOML と 1:1 の serde ミラー）。[`Manifest`] が表現できない形も
+/// いったんパースで受け、[`RawManifest::into_manifest`] が検証しながら解釈する。
+///
+/// `deny_unknown_fields` で未知キーを load 時に弾く。旧スキーマの語彙（`dst` / `kind` / `strategy` /
+/// `preserve` / ユニット直下 `cmd` / `[[overlay]]` / `sensitive` 等）が残った manifest はここで
+/// エラーになる（後方互換は持たせず、誤連想の再発を防ぐ）。
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifest {
+    #[serde(default)]
+    when: Option<When>,
+    #[serde(default)]
+    locals: Vec<String>,
+    #[serde(default)]
+    format: Option<Format>,
+    #[serde(default)]
+    steps: Vec<RawStep>,
+    #[serde(default)]
+    private: bool,
+    #[serde(default)]
+    executable: bool,
+    #[serde(default)]
+    hooks: Vec<Hook>,
+}
+
+/// `[[steps]]` の生スキーマ。`input` / `output` の択一は TOML では表現できない（どちらも任意キー）
+/// ため、ここでは両方を受けて [`RawStep::into_sided`] が解決する。`deny_unknown_fields` でキーの
+/// typo を load 時に弾く。
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawStep {
+    #[serde(default)]
+    input: Option<StepSource>,
+    #[serde(default)]
+    output: Option<StepSource>,
+    #[serde(default)]
+    merge: Option<Merge>,
+    #[serde(default)]
+    when: Option<When>,
+    #[serde(default)]
+    optional: bool,
+}
+
+/// 向き（input / output）を解決した中間形の step。ツリー / パイプラインへの解釈前で、`merge` /
+/// `optional` は output 側にも保持する ― output への指定は不正だが、弾く文言がツリーと
+/// パイプラインで違うため、判定は解釈側（[`tree_steps`] / [`pipeline_steps`]）に置く。
+struct SidedStep {
+    /// step の向きと内容源。
+    side: Side,
+    merge: Option<Merge>,
+    when: Option<When>,
+    optional: bool,
+}
+
+/// step の向き（input / output）と内容源。
+enum Side {
+    Input(StepSource),
+    Output(StepSource),
+}
+
+impl RawStep {
+    /// `input` / `output` の択一を解決する（`i` はエラー表示用の step 位置）。両方・どちらも無しは
+    /// typo として弾く。
+    fn into_sided(self, i: usize) -> Result<SidedStep, String> {
+        let side = match (self.input, self.output) {
+            (Some(source), None) => Side::Input(source),
+            (None, Some(source)) => Side::Output(source),
+            (input, output) => {
+                let n = [input.is_some(), output.is_some()]
+                    .into_iter()
+                    .filter(|&set| set)
+                    .count();
+                return Err(format!(
+                    "steps[{i}] は input / output のうちちょうど 1 つを持つ必要があります（現在 {n} 個）"
+                ));
+            }
+        };
+        Ok(SidedStep {
+            side,
+            merge: self.merge,
+            when: self.when,
+            optional: self.optional,
+        })
+    }
+}
+
+impl SidedStep {
+    /// 「ツリー input」（`input = "."` ＝ 単位ディレクトリをそのまま配置）か。
+    fn is_tree_input(&self) -> bool {
+        matches!(&self.side, Side::Input(StepSource::Path(p)) if p == ".")
+    }
+}
+
+impl RawManifest {
+    /// 生スキーマを検証しながら [`Manifest`] へ解釈する。manifest の typo を配置前に弾く（fail-loud）。
+    ///
+    /// - **各 step は input / output のちょうど 1 つ**（[`RawStep::into_sided`]）。両方・どちらも
+    ///   無しは typo。
     /// - **steps は input を 1 つ以上・output を 1 つ以上**持つ（空パイプラインは無意味）。
     /// - **パス表記**（#579）: output は `~` 起点のみ。input は単位相対 or `~` 起点。`$`・絶対は不可。
     /// - **`hooks` の各 `cmd` は非空**。
     /// - **`when` は実効キーを 1 つ以上**（unit・各 step とも。空 when の silent no-op を弾く）。
     /// - **`private` / `executable` はパス output を持つユニットのみ**（cmd output だけのユニットには
     ///   書き込み先ファイルが無い）。
-    /// - **ツリー**（`input = "."`）: steps はちょうど 2 つ（`input = "."` ＋ output パス）、step に
-    ///   `when` / `merge` / `optional` は付けない、`format` は書けない（merge / format はバイト内容の
-    ///   step のみ意味を持ち、step の `when` は unit gate と冗長になる）。
-    /// - **非ツリーは先頭 step が input**（[`Manifest::validate_pipeline`]）: output が先頭だと、
-    ///   apply で内容がまだ空のまま書き込みへ到達する。
-    /// - **`merge`**: 2 つ目以降の input に必須・最初の input / output には禁止（暗黙の合成規則を持た
-    ///   ない・#580）。
-    /// - **`format`**: `merge` を使うユニットに必須・使わないユニットには禁止。`shallow` / `deep` は
-    ///   json / plist・`append` は text とだけ両立。
-    /// - **`optional`**: `~` 起点のパス input のみ（単位相対ファイルは静的なので不在は typo・cmd input・
-    ///   output への指定も typo）。
-    fn validate(&self) -> Result<(), String> {
-        // 各 step は input / output のちょうど 1 つ。
-        for (i, step) in self.steps.iter().enumerate() {
-            let n = [step.input.is_some(), step.output.is_some()]
-                .into_iter()
-                .filter(|&set| set)
-                .count();
-            if n != 1 {
-                return Err(format!(
-                    "steps[{i}] は input / output のうちちょうど 1 つを持つ必要があります（現在 {n} 個）"
-                ));
-            }
-        }
-        let n_input = self.steps.iter().filter(|s| s.input.is_some()).count();
-        let n_output = self.steps.iter().filter(|s| s.output.is_some()).count();
+    /// - **ツリー**（`input = "."`）は [`tree_steps`]、それ以外は [`pipeline_steps`] が形を検証して
+    ///   [`Steps`] へ解釈する。
+    fn into_manifest(self) -> Result<Manifest, String> {
+        let sided: Vec<SidedStep> = self
+            .steps
+            .into_iter()
+            .enumerate()
+            .map(|(i, step)| step.into_sided(i))
+            .collect::<Result<_, _>>()?;
+        let n_input = sided
+            .iter()
+            .filter(|s| matches!(s.side, Side::Input(_)))
+            .count();
+        let n_output = sided.len() - n_input;
         if n_input == 0 || n_output == 0 {
             return Err(format!(
                 "steps は input を 1 つ以上・output を 1 つ以上持つ必要があります（現在 input {n_input}・output {n_output}）"
@@ -289,29 +422,24 @@ impl Manifest {
         }
 
         // パス表記（#579）: 全 step の path 内容源を検証する。
-        for step in &self.steps {
-            if let Some(StepSource::Path(p)) = &step.input {
-                validate_input_path(p)?;
-            }
-            if let Some(StepSource::Path(p)) = &step.output {
-                validate_output_path(p)?;
+        for step in &sided {
+            match &step.side {
+                Side::Input(StepSource::Path(p)) => validate_input_path(p)?,
+                Side::Output(StepSource::Path(p)) => validate_output_path(p)?,
+                _ => {}
             }
         }
 
         // 各 step の cmd（input.cmd / output.cmd）は非空。空 argv は cmd::run/run_piped の cmd[0]
         // インデックスで panic するため、load 時に弾く（hooks の非空検証と同じ「静かに無視しない」方針）。
-        for (i, step) in self.steps.iter().enumerate() {
-            let empty_side = if matches!(&step.input, Some(StepSource::Cmd(c)) if c.cmd.is_empty())
-            {
-                Some("input")
-            } else if matches!(&step.output, Some(StepSource::Cmd(c)) if c.cmd.is_empty()) {
-                Some("output")
-            } else {
-                None
+        for (i, step) in sided.iter().enumerate() {
+            let (label, source) = match &step.side {
+                Side::Input(source) => ("input", source),
+                Side::Output(source) => ("output", source),
             };
-            if let Some(side) = empty_side {
+            if matches!(source, StepSource::Cmd(c) if c.cmd.is_empty()) {
                 return Err(format!(
-                    "steps[{i}].{side}.cmd は非空のコマンド（argv）である必要があります"
+                    "steps[{i}].{label}.cmd は非空のコマンド（argv）である必要があります"
                 ));
             }
         }
@@ -330,8 +458,7 @@ impl Manifest {
                     .to_string(),
             );
         }
-        if let Some(i) = self
-            .steps
+        if let Some(i) = sided
             .iter()
             .position(|s| s.when.as_ref().is_some_and(When::has_no_effective_key))
         {
@@ -342,10 +469,9 @@ impl Manifest {
 
         // private / executable はパス output を持つユニットのみ。
         if (self.private || self.executable)
-            && !self
-                .steps
+            && !sided
                 .iter()
-                .any(|s| matches!(&s.output, Some(StepSource::Path(_))))
+                .any(|s| matches!(&s.side, Side::Output(StepSource::Path(_))))
         {
             return Err(
                 "private / executable はパス output を持つユニットのみに指定できます（cmd output だけの \
@@ -354,76 +480,89 @@ impl Manifest {
             );
         }
 
-        // ツリー（input = "."）は専用の形に固定する。
-        if self.steps.iter().any(is_tree_input) {
-            return self.validate_tree();
-        }
+        // ツリー（input = "."）は専用の形（Steps::Tree）へ、それ以外はパイプラインへ解釈する。
+        let steps = if sided.iter().any(SidedStep::is_tree_input) {
+            tree_steps(self.format, &sided)?
+        } else {
+            pipeline_steps(self.format, sided)?
+        };
 
-        self.validate_pipeline()
+        Ok(Manifest {
+            when: self.when,
+            locals: self.locals,
+            steps,
+            private: self.private,
+            executable: self.executable,
+            hooks: self.hooks,
+        })
+    }
+}
+
+/// ツリー（`input = "."` を含む steps）の形を検証し、[`Steps::Tree`] へ解釈する。バイト内容の
+/// 合成語彙（merge / format）はツリーには意味を持たず、step の `when` は unit gate と冗長になる
+/// ため、いずれも禁止する。
+fn tree_steps(format: Option<Format>, steps: &[SidedStep]) -> Result<Steps, String> {
+    if steps.len() != 2 {
+        return Err(format!(
+            "ツリー input（input = \".\"）を持つユニットは steps がちょうど 2 つ（input = \".\" と \
+             output）である必要があります（現在 {} 個）",
+            steps.len()
+        ));
+    }
+    if !steps[0].is_tree_input() {
+        return Err("ツリー input（input = \".\"）は最初の step である必要があります".to_string());
+    }
+    if steps[0].when.is_some() || steps[0].merge.is_some() || steps[0].optional {
+        return Err(
+            "ツリー input（input = \".\"）には when / merge / optional を指定できません（ユニット \
+             全体の when gate を使ってください）"
+                .to_string(),
+        );
+    }
+    let out = &steps[1];
+    let Side::Output(dest) = &out.side else {
+        return Err("ツリー input の次の step は output である必要があります".to_string());
+    };
+    if out.when.is_some() || out.merge.is_some() || out.optional {
+        return Err("ツリー output には when / merge / optional を指定できません".to_string());
+    }
+    let StepSource::Path(output) = dest else {
+        return Err(
+            "ツリー output は cmd ではなくパスである必要があります（ツリーを標準入力へ渡すことは \
+             できません）"
+                .to_string(),
+        );
+    };
+    if format.is_some() {
+        return Err(
+            "ツリーユニットに format は指定できません（merge / format はバイト内容の step のみ）"
+                .to_string(),
+        );
+    }
+    Ok(Steps::Tree {
+        output: output.clone(),
+    })
+}
+
+/// バイト内容パイプライン（非ツリー）の形（先頭 step）と merge / format / optional を検証し、
+/// [`Steps::Pipeline`] へ解釈する。
+fn pipeline_steps(format: Option<Format>, steps: Vec<SidedStep>) -> Result<Steps, String> {
+    // 先頭 step は input。ここに来る時点で input・output が各 1 つ以上あるので steps は 2 つ以上 ―
+    // `steps[0]` の添字は安全。output が先頭だと、宣言順に畳む apply で内容がまだ空のまま書き込みへ
+    // 到達する（実行時エラーになる前に load で弾く）。
+    if matches!(steps[0].side, Side::Output(_)) {
+        return Err(
+            "steps[0] が output です（先頭は input である必要があります）。output より前に内容を \
+             組み立てる input が無く、apply 時に内容が空のまま書き込みに到達します"
+                .to_string(),
+        );
     }
 
-    /// ツリー（`input = "."`）ユニットの形を検証する。バイト内容の合成語彙（merge / format）は
-    /// ツリーには意味を持たず、step の `when` は unit gate と冗長になるため、いずれも禁止する。
-    fn validate_tree(&self) -> Result<(), String> {
-        if self.steps.len() != 2 {
-            return Err(format!(
-                "ツリー input（input = \".\"）を持つユニットは steps がちょうど 2 つ（input = \".\" と \
-                 output）である必要があります（現在 {} 個）",
-                self.steps.len()
-            ));
-        }
-        if !is_tree_input(&self.steps[0]) {
-            return Err(
-                "ツリー input（input = \".\"）は最初の step である必要があります".to_string(),
-            );
-        }
-        if self.steps[0].when.is_some() || self.steps[0].merge.is_some() || self.steps[0].optional {
-            return Err(
-                "ツリー input（input = \".\"）には when / merge / optional を指定できません（ユニット \
-                 全体の when gate を使ってください）"
-                    .to_string(),
-            );
-        }
-        let out = &self.steps[1];
-        if out.output.is_none() {
-            return Err("ツリー input の次の step は output である必要があります".to_string());
-        }
-        if out.when.is_some() || out.merge.is_some() || out.optional {
-            return Err("ツリー output には when / merge / optional を指定できません".to_string());
-        }
-        if !matches!(&out.output, Some(StepSource::Path(_))) {
-            return Err(
-                "ツリー output は cmd ではなくパスである必要があります（ツリーを標準入力へ渡すことは \
-                 できません）"
-                    .to_string(),
-            );
-        }
-        if self.format.is_some() {
-            return Err(
-                "ツリーユニットに format は指定できません（merge / format はバイト内容の step のみ）"
-                    .to_string(),
-            );
-        }
-        Ok(())
-    }
-
-    /// バイト内容パイプライン（非ツリー）の形（先頭 step）と merge / format / optional を検証する。
-    fn validate_pipeline(&self) -> Result<(), String> {
-        // 先頭 step は input。ここに来る時点で input・output が各 1 つ以上あり、各 step は input /
-        // output のちょうど 1 つなので steps は 2 つ以上 ―`steps[0]` の添字は安全。output が先頭だと、
-        // 宣言順に畳む apply で内容がまだ空のまま書き込みへ到達する（実行時エラーになる前に load で弾く）。
-        if self.steps[0].output.is_some() {
-            return Err(
-                "steps[0] が output です（先頭は input である必要があります）。output より前に内容を \
-                 組み立てる input が無く、apply 時に内容が空のまま書き込みに到達します"
-                    .to_string(),
-            );
-        }
-
-        // merge: 最初の input と output には禁止・2 つ目以降の input には必須。
-        let mut input_index = 0usize;
-        for (i, step) in self.steps.iter().enumerate() {
-            if step.input.is_some() {
+    // merge: 最初の input と output には禁止・2 つ目以降の input には必須。
+    let mut input_index = 0usize;
+    for (i, step) in steps.iter().enumerate() {
+        match step.side {
+            Side::Input(_) => {
                 if input_index == 0 && step.merge.is_some() {
                     return Err(format!(
                         "steps[{i}]: 最初の input step は merge を持てません（最初の input は内容の土台）"
@@ -436,94 +575,96 @@ impl Manifest {
                 }
                 input_index += 1;
             }
-            if step.output.is_some() && step.merge.is_some() {
-                return Err(format!("steps[{i}]: output step は merge を持てません"));
+            Side::Output(_) => {
+                if step.merge.is_some() {
+                    return Err(format!("steps[{i}]: output step は merge を持てません"));
+                }
             }
         }
+    }
 
-        // format: merge を使うユニットに必須・使わないユニットには禁止。
-        let any_merge = self.steps.iter().any(|s| s.merge.is_some());
-        match (self.format, any_merge) {
-            (Some(_), false) => {
-                return Err(
-                    "format は merge を宣言する step が無いユニットには書けません（merge を使うユニット \
-                     のみ）"
-                        .to_string(),
-                );
-            }
-            (None, true) => {
-                return Err(
-                    "merge を宣言する step があるユニットには format（json / plist / text）が必要です"
-                        .to_string(),
-                );
-            }
-            _ => {}
+    // format: merge を使うユニットに必須・使わないユニットには禁止。
+    let any_merge = steps.iter().any(|s| s.merge.is_some());
+    match (format, any_merge) {
+        (Some(_), false) => {
+            return Err(
+                "format は merge を宣言する step が無いユニットには書けません（merge を使うユニット \
+                 のみ）"
+                    .to_string(),
+            );
         }
-        // 各 merge の値と format の両立（shallow / deep ↔ json/plist・append ↔ text）。
-        for (i, step) in self.steps.iter().enumerate() {
-            if let Some(merge) = step.merge {
-                let compatible = matches!(
-                    (merge, self.format),
-                    (
-                        Merge::Shallow | Merge::Deep,
-                        Some(Format::Json | Format::Plist)
-                    ) | (Merge::Append, Some(Format::Text))
-                );
-                if !compatible {
-                    let format = self
-                        .format
-                        .map_or_else(|| "（未設定）".to_string(), |f| f.to_string());
+        (None, true) => {
+            return Err(
+                "merge を宣言する step があるユニットには format（json / plist / text）が必要です"
+                    .to_string(),
+            );
+        }
+        _ => {}
+    }
+    // 各 merge の値と format の両立（shallow / deep ↔ json/plist・append ↔ text）。
+    for (i, step) in steps.iter().enumerate() {
+        if let Some(merge) = step.merge {
+            let compatible = matches!(
+                (merge, format),
+                (
+                    Merge::Shallow | Merge::Deep,
+                    Some(Format::Json | Format::Plist)
+                ) | (Merge::Append, Some(Format::Text))
+            );
+            if !compatible {
+                let format = format.map_or_else(|| "（未設定）".to_string(), |f| f.to_string());
+                return Err(format!(
+                    "steps[{i}]: merge = \"{merge}\" は format = \"{format}\" と両立しません（shallow / \
+                     deep は json / plist・append は text）"
+                ));
+            }
+        }
+    }
+
+    // optional は ~ 起点のパス input のみ。単位相対ファイルは repo 追跡の静的ファイルで、typo に
+    // よる不在を「無ければ飛ばす」で恒久的に握り潰してしまう（optional の正当な用途は宛先の現在
+    // 内容＝初回 apply 前は未在り得る ~ 起点ファイルを土台に読むことだけ）。
+    for (i, step) in steps.iter().enumerate() {
+        if step.optional {
+            match &step.side {
+                Side::Input(StepSource::Path(p)) if p == "~" || p.starts_with("~/") => {}
+                Side::Input(StepSource::Path(_)) => {
                     return Err(format!(
-                        "steps[{i}]: merge = \"{merge}\" は format = \"{format}\" と両立しません（shallow / \
-                         deep は json / plist・append は text）"
+                        "steps[{i}]: optional は ~ 起点の input にのみ使えます（単位相対ファイルは \
+                         repo 追跡の静的ファイルで、不在は typo の可能性が高く step を恒久的に握り潰す）"
+                    ));
+                }
+                Side::Input(StepSource::Cmd(_)) => {
+                    return Err(format!(
+                        "steps[{i}]: optional は cmd input には使えません（~ 起点のパス input のみ）"
+                    ));
+                }
+                Side::Output(_) => {
+                    return Err(format!(
+                        "steps[{i}]: optional は output step には使えません（~ 起点のパス input のみ）"
                     ));
                 }
             }
         }
-
-        // optional は ~ 起点のパス input のみ。単位相対ファイルは repo 追跡の静的ファイルで、typo に
-        // よる不在を「無ければ飛ばす」で恒久的に握り潰してしまう（optional の正当な用途は宛先の現在
-        // 内容＝初回 apply 前は未在り得る ~ 起点ファイルを土台に読むことだけ）。
-        for (i, step) in self.steps.iter().enumerate() {
-            if step.optional {
-                match &step.input {
-                    Some(StepSource::Path(p)) if p == "~" || p.starts_with("~/") => {}
-                    Some(StepSource::Path(_)) => {
-                        return Err(format!(
-                            "steps[{i}]: optional は ~ 起点の input にのみ使えます（単位相対ファイルは \
-                             repo 追跡の静的ファイルで、不在は typo の可能性が高く step を恒久的に握り潰す）"
-                        ));
-                    }
-                    Some(StepSource::Cmd(_)) => {
-                        return Err(format!(
-                            "steps[{i}]: optional は cmd input には使えません（~ 起点のパス input のみ）"
-                        ));
-                    }
-                    None => {
-                        return Err(format!(
-                            "steps[{i}]: optional は output step には使えません（~ 起点のパス input のみ）"
-                        ));
-                    }
-                }
-            }
-        }
-        Ok(())
     }
 
-    /// この単位の配置ファイルへ与える Unix パーミッション（8 進）。
-    ///
-    /// base は `private` で決まる（0600 / 0644）。`executable` のとき、read ビットが
-    /// 立っている桁へ execute ビットを足す（0644→0755 / 0600→0700）。`private` /
-    /// `executable` 属性の合成規則。
-    #[cfg(unix)]
-    pub fn mode(&self) -> u32 {
-        let base: u32 = if self.private { 0o600 } else { 0o644 };
-        if self.executable {
-            base | ((base & 0o444) >> 2)
-        } else {
-            base
-        }
-    }
+    // 検証済みの step を確定形へ。output 側の merge / optional は上で弾いた後なので現れない。
+    let steps = steps
+        .into_iter()
+        .map(|step| match step.side {
+            Side::Input(source) => Step::Input(InputStep {
+                source,
+                merge: step.merge,
+                when: step.when,
+                optional: step.optional,
+            }),
+            Side::Output(dest) => Step::Output(OutputStep {
+                dest,
+                when: step.when,
+            }),
+        })
+        .collect();
+    Ok(Steps::Pipeline { format, steps })
 }
 
 /// output パスの表記検証（#579）: `~` / `~/...` のみ。`$` 含み・絶対・相対・`~/` 後の `..` は load
@@ -610,11 +751,17 @@ mod tests {
     use super::*;
     use strum::IntoEnumIterator;
 
-    /// パース → validate を一括で通す（load のファイル I/O を介さずに検証）。
+    /// テキストから Manifest を読み込む（load のファイル I/O を介さず、パース＋解釈を通す）。
     fn parse(toml_src: &str) -> Result<Manifest, String> {
-        let manifest: Manifest = toml::from_str(toml_src).map_err(|e| e.to_string())?;
-        manifest.validate()?;
-        Ok(manifest)
+        toml_src.parse()
+    }
+
+    /// パイプラインとして解釈された (format, steps) を取り出す（ツリーなら panic）。
+    fn pipeline(m: &Manifest) -> (Option<Format>, &[Step]) {
+        match &m.steps {
+            Steps::Pipeline { format, steps } => (*format, steps),
+            Steps::Tree { .. } => panic!("パイプラインを期待したがツリーだった"),
+        }
     }
 
     /// 最小のツリーユニット（`input = "."` ＋ output）。多くのテストのベース。
@@ -626,18 +773,28 @@ mod tests {
     fn step_source_parses_path_and_cmd_forms() {
         // input = "x"（bare string）→ Path、input.cmd = [...]（inline table）→ Cmd。
         let m = parse("[[steps]]\ninput = \"a.txt\"\n[[steps]]\noutput = \"~/x\"\n").unwrap();
-        assert!(matches!(&m.steps[0].input, Some(StepSource::Path(p)) if p == "a.txt"));
+        assert!(matches!(
+            &pipeline(&m).1[0],
+            Step::Input(InputStep { source: StepSource::Path(p), .. }) if p == "a.txt"
+        ));
 
         let m =
             parse("[[steps]]\ninput.cmd = [\"gh\", \"completion\"]\n[[steps]]\noutput = \"~/x\"\n")
                 .unwrap();
-        assert!(
-            matches!(&m.steps[0].input, Some(StepSource::Cmd(c)) if c.cmd == ["gh", "completion"])
-        );
+        assert!(matches!(
+            &pipeline(&m).1[0],
+            Step::Input(InputStep { source: StepSource::Cmd(c), .. }) if c.cmd == ["gh", "completion"]
+        ));
 
         // output.cmd も同様。
         let m = parse("[[steps]]\ninput.cmd = [\"defaults\", \"export\"]\n[[steps]]\noutput.cmd = [\"defaults\", \"import\"]\n").unwrap();
-        assert!(matches!(&m.steps[1].output, Some(StepSource::Cmd(_))));
+        assert!(matches!(
+            &pipeline(&m).1[1],
+            Step::Output(OutputStep {
+                dest: StepSource::Cmd(_),
+                ..
+            })
+        ));
     }
 
     // ── Format / Merge の Display ↔ serde round-trip ──
@@ -657,7 +814,7 @@ mod tests {
             );
             let parsed = parse(&src).unwrap();
             assert_eq!(
-                parsed.format,
+                pipeline(&parsed).0,
                 Some(format),
                 "Display と serde 表現がズレている: {format}"
             );
@@ -676,8 +833,11 @@ mod tests {
                 "format = \"{format}\"\n[[steps]]\ninput = \"a\"\n[[steps]]\ninput = \"b\"\nmerge = \"{merge}\"\n[[steps]]\noutput = \"~/x\"\n",
             );
             let parsed = parse(&src).unwrap();
+            let Step::Input(second) = &pipeline(&parsed).1[1] else {
+                panic!("steps[1] は input のはず");
+            };
             assert_eq!(
-                parsed.steps[1].merge,
+                second.merge,
                 Some(merge),
                 "Display と serde 表現がズレている: {merge}"
             );
@@ -688,7 +848,36 @@ mod tests {
 
     #[test]
     fn accepts_minimal_tree() {
-        assert!(parse(TREE).is_ok());
+        // ツリーは step 列を持たない専用の形（output だけ）へ解釈される。
+        let m = parse(TREE).unwrap();
+        assert!(matches!(&m.steps, Steps::Tree { output } if output == "~/x"));
+    }
+
+    #[test]
+    fn interprets_pipeline_step_annotations() {
+        // merge / when / optional が各 step の確定形（InputStep / OutputStep）へ載ることを固定する。
+        let m = parse(
+            "format = \"json\"\n\
+             [[steps]]\ninput = \"~/.claude/settings.json\"\noptional = true\n\
+             [[steps]]\ninput = \"settings.json\"\nmerge = \"shallow\"\nwhen = { deps = [\"rtk\"] }\n\
+             [[steps]]\noutput = \"~/.claude/settings.json\"\n",
+        )
+        .unwrap();
+        let (format, steps) = pipeline(&m);
+        assert_eq!(format, Some(Format::Json));
+        let Step::Input(first) = &steps[0] else {
+            panic!("steps[0] は input のはず");
+        };
+        assert!(first.optional && first.merge.is_none() && first.when.is_none());
+        let Step::Input(second) = &steps[1] else {
+            panic!("steps[1] は input のはず");
+        };
+        assert_eq!(second.merge, Some(Merge::Shallow));
+        assert!(second.when.is_some() && !second.optional);
+        assert!(matches!(
+            &steps[2],
+            Step::Output(OutputStep { dest: StepSource::Path(p), .. }) if p == "~/.claude/settings.json"
+        ));
     }
 
     #[test]
@@ -1183,16 +1372,15 @@ mod tests {
         ] {
             let src = format!("{legacy}{TREE}");
             assert!(
-                toml::from_str::<Manifest>(&src).is_err(),
+                src.parse::<Manifest>().is_err(),
                 "旧語彙が弾かれていない: {legacy}"
             );
         }
         // hooks[].frequency も Hook の deny_unknown_fields で弾く。
         assert!(
-            toml::from_str::<Manifest>(&format!(
-                "{TREE}[[hooks]]\ncmd = [\"x\"]\nfrequency = \"always\"\n"
-            ))
-            .is_err()
+            format!("{TREE}[[hooks]]\ncmd = [\"x\"]\nfrequency = \"always\"\n")
+                .parse::<Manifest>()
+                .is_err()
         );
     }
 }

--- a/src/bin/dotfiles/manifest.rs
+++ b/src/bin/dotfiles/manifest.rs
@@ -27,10 +27,9 @@ use strum::{Display, EnumIter};
 
 /// 1 つの設定単位（`manifest.toml` を持つディレクトリ）の配置仕様（解釈済みの確定形）。
 ///
-/// [`Manifest::load`] が生スキーマ（[`RawManifest`]）を検証しながらこの型へ解釈する。「パースは
-/// 通るが意味的に不正」な形の多く（step の input / output の併記・欠落、ツリーへの format /
-/// merge / step gate の指定等）はこの型では表現できず、残る不整合（パス表記・merge と format の
-/// 両立等）も解釈時に弾かれるため、この型の値は常に配置可能な宣言を表す。
+/// [`Manifest::load`] が生スキーマ（[`RawManifest`]）を検証しながらこの型へ解釈する。パースは
+/// 通るが意味的に不正な形は load 時に弾かれ、その多くはそもそも表現できない（[`Steps`] /
+/// [`Step`] が択一を variant で持つ）ため、この型の値は常に配置可能な宣言を表す。
 #[derive(Debug)]
 pub struct Manifest {
     /// ユニット全体 gate。トップレベルに書いた `when` はユニットスコープで、
@@ -60,14 +59,13 @@ pub struct Manifest {
 }
 
 /// 配置の形。`[[steps]]` の列は load 時にどちらかへ解釈される。ツリー配置とバイト内容パイプライン
-/// は持てる語彙が違い（ツリーは format / merge / step の when / optional を持たない）、混在も
-/// できないため、別 variant で表現する。
+/// は持てる語彙が違い、混在もできないため、別 variant で表現する。
 #[derive(Debug)]
 pub enum Steps {
     /// ツリー配置（`input = "."` ＋ パス output の 2 step）: 単位ディレクトリを丸ごと、相対構造を
     /// 保って配置する（[`crate::apply::copy`]）。step 列は持たない ― バイト内容の合成語彙
-    /// （merge / format）はツリーに意味を持たず、step の `when` は unit gate と冗長になるため、
-    /// いずれも解釈時に弾かれる。
+    /// （merge / format）はツリーに意味を持たず、step の `when` は unit gate と冗長、`optional` の
+    /// 対象になる不在（repo 追跡の単位ディレクトリは常に在る）も無いため、いずれも load 時に弾かれる。
     Tree {
         /// 配置先ディレクトリ（`~` 起点の生表記）。
         output: String,
@@ -85,7 +83,7 @@ pub enum Steps {
 }
 
 /// 配置パイプラインの 1 step。input（読む）と output（書く）の択一を variant で表現する
-/// （manifest.toml 上の併記・欠落は解釈時に弾かれ、ここには到達しない）。
+/// （manifest.toml 上の併記・欠落は load 時に弾かれ、ここには到達しない）。
 #[derive(Debug)]
 pub enum Step {
     /// 読む: 中身を内容へ畳む。
@@ -107,14 +105,14 @@ pub struct InputStep {
     pub when: Option<When>,
     /// `~` 起点のパス input が存在しなければこの step を飛ばす（次の input が土台になる）。既定は
     /// 「無ければエラー」。`~` 起点のパス input のみ有効 ― 単位相対ファイルは repo 追跡の静的ファイルで
-    /// 不在は typo の可能性が高く、恒久的に step を握り潰すため、cmd input への指定と併せて解釈時
+    /// 不在は typo の可能性が高く、恒久的に step を握り潰すため、cmd input への指定と併せて load 時
     /// エラー。唯一の正当な用途は宛先の現在内容（初回 apply 前は未在り得る `~` 起点ファイル）を
     /// 土台に読むこと。
     pub optional: bool,
 }
 
 /// output step。組み立てた内容を宛先へ書く。`merge` / `optional` は持たない（重ね方は input 側の
-/// 語彙で、output の書き込みは常に実行される）。manifest.toml 上の指定は解釈時に弾かれる。
+/// 語彙で、output の書き込みは常に実行される）。manifest.toml 上の指定は load 時に弾かれる。
 #[derive(Debug)]
 pub struct OutputStep {
     /// 書く宛先（パス or cmd 標準入力）。
@@ -129,9 +127,8 @@ pub struct OutputStep {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum StepSource {
-    /// パス: input は単位相対 or `~` 起点、output は `~` 起点のみ（load 時の解釈
-    /// （[`RawManifest::into_manifest`]）が検証）。特例として input `"."` は
-    /// 「単位ディレクトリツリー」を表す。
+    /// パス: input は単位相対 or `~` 起点、output は `~` 起点のみ（[`RawManifest::into_manifest`]
+    /// が load 時に検証）。特例として input `"."` は「単位ディレクトリツリー」を表す。
     Path(String),
     /// コマンド: input は標準出力を読み、output は内容を標準入力へ渡す（argv）。
     Cmd(CmdSource),
@@ -393,8 +390,7 @@ impl SidedStep {
 impl RawManifest {
     /// 生スキーマを検証しながら [`Manifest`] へ解釈する。manifest の typo を配置前に弾く（fail-loud）。
     ///
-    /// - **各 step は input / output のちょうど 1 つ**（[`RawStep::into_sided`]）。両方・どちらも
-    ///   無しは typo。
+    /// - **各 step は input / output のちょうど 1 つ**（[`RawStep::into_sided`]）。
     /// - **steps は input を 1 つ以上・output を 1 つ以上**持つ（空パイプラインは無意味）。
     /// - **パス表記**（#579）: output は `~` 起点のみ。input は単位相対 or `~` 起点。`$`・絶対は不可。
     /// - **`hooks` の各 `cmd` は非空**。
@@ -498,9 +494,8 @@ impl RawManifest {
     }
 }
 
-/// ツリー（`input = "."` を含む steps）の形を検証し、[`Steps::Tree`] へ解釈する。バイト内容の
-/// 合成語彙（merge / format）はツリーには意味を持たず、step の `when` は unit gate と冗長になる
-/// ため、いずれも禁止する。
+/// ツリー（`input = "."` を含む steps）の形を検証し、[`Steps::Tree`] へ解釈する
+/// （merge / format / step の `when` / `optional` を禁止する理由は [`Steps::Tree`] の doc）。
 fn tree_steps(format: Option<Format>, steps: &[SidedStep]) -> Result<Steps, String> {
     if steps.len() != 2 {
         return Err(format!(

--- a/src/bin/dotfiles/placements.rs
+++ b/src/bin/dotfiles/placements.rs
@@ -27,12 +27,12 @@
 //! 報告してしまう。cmd output はファイルシステムに痕跡を残さないため対象外（∅）。比較は解決済み
 //! パスの完全一致だけなので、ツリーが `~/.config/foo/` 配下へ展開する一方で別ユニットが
 //! `~/.config/foo` というファイルへ output する「ディレクトリ×ファイルの前置衝突」も対象外
-//! （#593 が定義する衝突の範囲外として意図的に外す）。ツリーユニットの step に `when` は書けない
-//! （`Manifest::validate` が禁止・unit gate と冗長になるため）ので、ツリー展開そのものに step gate の
-//! 判定は要らない。
+//! （#593 が定義する衝突の範囲外として意図的に外す）。ツリー配置（[`crate::manifest::Steps::Tree`]）
+//! は step を持たず `when` も書けない（unit gate と冗長になるため）ので、ツリー展開そのものに
+//! step gate の判定は要らない。
 
 use crate::discover::{self, MANIFEST};
-use crate::manifest::{Manifest, StepSource, When, resolve_output_path};
+use crate::manifest::{Manifest, Step, StepSource, Steps, When, resolve_output_path};
 use std::path::{Path, PathBuf};
 
 /// 1 つの宣言された配置先。
@@ -79,13 +79,18 @@ fn collect(
             continue; // ユニット gate 不成立 ＝ このユニットは何も置かない。
         }
         let name = unit.rel.to_string_lossy().into_owned();
-        if manifest.is_tree() {
-            push_tree_placements(&unit.dir, &name, &manifest, home, &mut placements)?;
-        } else {
-            for step in &manifest.steps {
-                if let Some(StepSource::Path(p)) = &step.output {
+        match &manifest.steps {
+            Steps::Tree { output } => {
+                push_tree_placements(&unit.dir, &name, output, home, &mut placements)?;
+            }
+            Steps::Pipeline { steps, .. } => {
+                for step in steps {
+                    let Step::Output(out) = step else { continue };
+                    let StepSource::Path(p) = &out.dest else {
+                        continue;
+                    };
                     if let Some(satisfied) = gate
-                        && !satisfied(&step.when)
+                        && !satisfied(&out.when)
                     {
                         continue; // この output step 自身の gate 不成立 ＝ 今回は書かれない。
                     }
@@ -100,17 +105,16 @@ fn collect(
     Ok(placements)
 }
 
-/// ツリーユニット（`input = "."`）を配下ファイルへ展開し、それぞれの配置先を積む。
-/// ツリーの output パスは [`Manifest::display_dst`] が返す唯一のパス表記（`validate` 済みなら
-/// 常にパス output 1 つ）をそのまま使う。
+/// ツリーユニットを配下ファイルへ展開し、それぞれの配置先を積む。`output` はツリーの配置先
+/// （`~` 起点の生表記）。
 fn push_tree_placements(
     unit_dir: &Path,
     name: &str,
-    manifest: &Manifest,
+    output: &str,
     home: &Path,
     out: &mut Vec<Placement>,
 ) -> Result<(), String> {
-    let dst_root = resolve_output_path(home, &manifest.display_dst());
+    let dst_root = resolve_output_path(home, output);
     for file in discover::unit_files(unit_dir)? {
         let rel = file
             .strip_prefix(unit_dir)

--- a/src/bin/dotfiles/placements.rs
+++ b/src/bin/dotfiles/placements.rs
@@ -28,8 +28,7 @@
 //! パスの完全一致だけなので、ツリーが `~/.config/foo/` 配下へ展開する一方で別ユニットが
 //! `~/.config/foo` というファイルへ output する「ディレクトリ×ファイルの前置衝突」も対象外
 //! （#593 が定義する衝突の範囲外として意図的に外す）。ツリー配置（[`crate::manifest::Steps::Tree`]）
-//! は step を持たず `when` も書けない（unit gate と冗長になるため）ので、ツリー展開そのものに
-//! step gate の判定は要らない。
+//! は step を持たず `when` も書けないため、ツリー展開そのものに step gate の判定は要らない。
 
 use crate::discover::{self, MANIFEST};
 use crate::manifest::{Manifest, Step, StepSource, Steps, When, resolve_output_path};


### PR DESCRIPTION
Closes #621

## 概要

`manifest.rs` を「TOML と 1:1 の生スキーマ」と「検証しながら解釈した確定形」の 2 層に分け、意味的に不正な形を確定形の型で表現できなくする。manifest.toml のスキーマ・エラーメッセージ文言は変更しない。

## 設計

- **生スキーマ（private）**: `RawManifest` / `RawStep`。serde の `deny_unknown_fields` を含む従来のパース層をそのまま担う
- **確定形**: `Manifest` は `steps: Steps` を持ち、`enum Steps { Tree { output }, Pipeline { format, steps } }` がツリー配置とバイト内容パイプラインを分ける。`format` は `Pipeline` variant へ移動
- **step**: `enum Step { Input(InputStep), Output(OutputStep) }`。`OutputStep` は `merge` / `optional` を持たない
- **解釈**: `RawManifest::into_manifest` が従来の `validate` と同じ順序・同じ文言で検証しながら変換する。input / output の択一解決（旧 manifest.rs:271-282）は変換の分岐そのものになり、多重違反時のエラー優先順位を保つため択一解決済みの中間形（`SidedStep`）を挟む

## 型で表現不能になった形状不整合

- step の input / output の併記・欠落（`Step` が択一）
- output step への merge / optional 指定（`OutputStep` にフィールドが無い）
- ツリーへの format / merge / step when / optional 指定・step 数の逸脱（`Steps::Tree` は output パスのみ持つ）

これに伴い下流の防御が消える: pipeline.rs の `Content::Tree`・`unreachable!`・input `"."` の特例、placements.rs / doctor.rs の `Option` 再判定、`display_dst` / `summary` の「validate 済み前提」。

## 受け入れ条件の対応

- [x] Tree/Pipeline の形状不整合の一部が型として表現不可能になり、対応する実行時チェックが下流から削減される（旧 `validate_tree` / `validate_pipeline` は解釈関数 `tree_steps` / `pipeline_steps` になり、検証後は不正形が型に残らない）
- [x] Step の input/output 併記・欠落が型として表現不可能になり、旧 manifest.rs:271-282 の独立チェックが不要になる（`RawStep::into_sided` の変換分岐に吸収）
- [x] 既存の `configs/` 全 33 manifest がスキーマ変更なしで読み込める（`dotfiles list` / sandbox HOME への `apply` 2 回で確認。ツリー・json 合成・optional 不在 skip・cmd input/output・hooks onchange skip・冪等 mtime 不変まで実挙動で確認）
- [x] 既存のユニットテストが同等以上のカバレッジで通る（300 件 pass。エラー文言のアサーションは無変更。確定形の構造を固定するテスト `interprets_pipeline_step_annotations` と `accepts_minimal_tree` の構造アサーションを追加）

## 検証

- `cargo fmt --all --check` / `cargo clippy --all-targets -- -D warnings` / `cargo nextest run`（300 pass）/ `mise run check` / `cargo doc --document-private-items`（リンク切れなし）
- 不正 manifest 9 種（併記・ツリー逸脱 4 種・merge/optional 誤指定・旧語彙・空 when・先頭 output）を CLI 表面から読み込ませ、エラー文言が従来と一致することを確認
- doctor のユニット間衝突検出（ツリー展開 × パイプライン output の交差）も新分岐で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)