### PR TITLE
fix(manifest): when.os の typo を load 時に弾く（silent skip をやめる）

### DIFF
--- a/src/bin/dotfiles/apply/gate.rs
+++ b/src/bin/dotfiles/apply/gate.rs
@@ -12,7 +12,7 @@
 //! ・全 step の評価で共有する（評価ごとにファイルを読み直さない）。`theme`（color スライス）も
 //! 同じ snapshot にフィールドを足して同じ機構を使い回す想定（状態駆動 gate 族）。
 
-use crate::manifest::{Manifest, When};
+use crate::manifest::{Manifest, Os, When};
 use crate::state;
 use std::path::{Path, PathBuf};
 
@@ -42,14 +42,15 @@ impl GateState {
     }
 }
 
-/// 現在の OS を `when.os` 表記で返す（macOS は `darwin`）。
+/// 現在の OS を manifest の語彙（[`Os`]）で返す。
 ///
-/// manifest の `when.os` は `darwin` / `linux` 表記で書くため、Rust の
-/// `std::env::consts::OS`（macOS では `macos`）を `darwin` に正規化して比較する。
-pub fn current_os() -> &'static str {
+/// `darwin` / `linux` 以外のビルドターゲットは None ＝ どの `os` gate とも一致しない（`os` を
+/// 書いたユニット / step は skip）。
+pub fn current_os() -> Option<Os> {
     match std::env::consts::OS {
-        "macos" => "darwin",
-        other => other,
+        "macos" => Some(Os::Darwin),
+        "linux" => Some(Os::Linux),
+        _ => None,
     }
 }
 
@@ -85,10 +86,13 @@ fn when_unsatisfied_reason(when: &When, state: &GateState) -> Option<String> {
     if let Some(missing) = first_missing_dep(&when.deps) {
         return Some(format!("依存 `{missing}` が PATH にない"));
     }
-    if let Some(want) = &when.os
-        && want != current_os()
+    if let Some(want) = when.os
+        && Some(want) != current_os()
     {
-        return Some(format!("OS `{want}` 不一致（現在 {}）", current_os()));
+        // 未対応 OS（None）は生の OS 名で出す ― 不一致の相手が読めないと直せない。
+        let current =
+            current_os().map_or_else(|| std::env::consts::OS.to_string(), |os| os.to_string());
+        return Some(format!("OS `{want}` 不一致（現在 {current}）"));
     }
     if let Some(want) = &when.profile
         && state.profile.as_deref() != Some(want.as_str())
@@ -137,14 +141,16 @@ fn is_executable(p: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use strum::IntoEnumIterator;
 
     #[test]
-    fn current_os_normalizes_macos_to_darwin() {
-        // ビルドした OS に応じて `darwin`/`linux` 表記を返す。
+    fn current_os_maps_build_target_to_manifest_vocabulary() {
         let expected = if cfg!(target_os = "macos") {
-            "darwin"
+            Some(Os::Darwin)
+        } else if cfg!(target_os = "linux") {
+            Some(Os::Linux)
         } else {
-            std::env::consts::OS
+            None
         };
         assert_eq!(current_os(), expected);
     }
@@ -161,19 +167,19 @@ mod tests {
 
     #[test]
     fn when_os_matches_current_only() {
-        let hit = When {
-            deps: vec![],
-            os: Some(current_os().to_string()),
-            profile: None,
-        };
-        assert!(when_satisfied(&Some(hit), &no_profile()));
-
-        let miss = When {
-            deps: vec![],
-            os: Some("nonsuch-os".to_string()),
-            profile: None,
-        };
-        assert!(!when_satisfied(&Some(miss), &no_profile()));
+        // 不正値（`macos` / typo）は型で構築できない ― load で弾く検証は manifest 側にある。
+        for os in Os::iter() {
+            let want = When {
+                deps: vec![],
+                os: Some(os),
+                profile: None,
+            };
+            assert_eq!(
+                when_satisfied(&Some(want), &no_profile()),
+                Some(os) == current_os(),
+                "os gate が現在 OS 一致のときだけ成立していない: {os}"
+            );
+        }
     }
 
     #[test]
@@ -245,7 +251,7 @@ mod tests {
         // deps・os は満たすが profile が外れる → 全体は false（AND）。
         let mixed = When {
             deps: vec!["/bin/sh".to_string()],
-            os: Some(current_os().to_string()),
+            os: current_os(),
             profile: Some("private".to_string()),
         };
         assert!(!when_satisfied(&Some(mixed), &no_profile()));
@@ -253,7 +259,7 @@ mod tests {
         assert!(when_satisfied(
             &Some(When {
                 deps: vec!["/bin/sh".to_string()],
-                os: Some(current_os().to_string()),
+                os: current_os(),
                 profile: Some("private".to_string()),
             }),
             &GateState::with_profile(Some("private")),

--- a/src/bin/dotfiles/manifest.rs
+++ b/src/bin/dotfiles/manifest.rs
@@ -180,6 +180,20 @@ pub struct Hook {
     pub cmd: Vec<String>,
 }
 
+/// `when.os` が受理する OS。表示名と TOML トークンを揃える規則は [`Format`] と同じ。
+///
+/// 受理値を型で閉じ、typo を load 時に弾く ― 任意文字列を受けると、どの環境とも一致しない値が
+/// ユニット / step を黙って恒久 skip させる。
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Display, EnumIter)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum Os {
+    /// macOS（Rust の `std::env::consts::OS` は `macos`）。
+    Darwin,
+    /// Linux。
+    Linux,
+}
+
 /// gate の採用条件。トップレベル（ユニットスコープ）と step（step スコープ）で共有する
 /// 1 つの語彙。複数キーは AND（全て満たす時だけ採用）。
 #[derive(Debug, Deserialize, Default)]
@@ -189,9 +203,9 @@ pub struct When {
     /// 単数 `dep` は廃止し、複数形＝配列で統一する（語感の破綻を避ける）。
     #[serde(default)]
     pub deps: Vec<String>,
-    /// OS（スカラ）。現在 OS と一致時だけ採用（`darwin` / `linux` 表記）。
+    /// OS（スカラ）。現在 OS と一致時だけ採用（[`Os`]）。
     #[serde(default)]
-    pub os: Option<String>,
+    pub os: Option<Os>,
     /// マシンクラス（スカラ・状態 gate）。`dotfiles profile <name>` が書いた現在の profile 状態
     /// （[`crate::state`]）と一致するときだけ採用する。`deps`（環境検出）・`os`（環境検出）と違い
     /// **user が選んでおく状態**を読む点が族として `theme`（color スライス）と同じ。未設定の既定は
@@ -792,7 +806,7 @@ mod tests {
         ));
     }
 
-    // ── Format / Merge の Display ↔ serde round-trip ──
+    // ── Format / Merge / Os の Display ↔ serde round-trip ──
 
     #[test]
     fn format_display_round_trips_through_serde() {
@@ -837,6 +851,27 @@ mod tests {
                 "Display と serde 表現がズレている: {merge}"
             );
         }
+    }
+
+    #[test]
+    fn os_display_round_trips_through_serde() {
+        for os in Os::iter() {
+            let parsed = parse(&format!("when = {{ os = \"{os}\" }}\n{TREE}")).unwrap();
+            assert_eq!(
+                parsed.when.and_then(|when| when.os),
+                Some(os),
+                "Display と serde 表現がズレている: {os}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_os() {
+        let err = parse(&format!("when = {{ os = \"macos\" }}\n{TREE}")).unwrap_err();
+        assert!(
+            err.contains("darwin") && err.contains("linux"),
+            "受理値を示さずに弾いている: {err}"
+        );
     }
 
     // ── shape ──

--- a/tests/e2e/hooks.rs
+++ b/tests/e2e/hooks.rs
@@ -8,7 +8,7 @@
 //! hooks は onchange 固定（`frequency` は #588 スライス1で削除。生きた外部状態への反映は
 //! `output.cmd` step が担う ― [`crate::steps`] 参照）。
 
-use crate::{dotfiles, write_stub};
+use crate::{dotfiles, foreign_os, write_stub};
 use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
@@ -106,7 +106,10 @@ fn os_gate_skips_unit_hooks() {
     fs::create_dir_all(&unit).unwrap();
     fs::write(
         unit.join("manifest.toml"),
-        "when = { os = \"nonsuch-os\" }\nhooks = [{ cmd = [\"faketool\"] }]\n[[steps]]\ninput = \".\"\n[[steps]]\noutput = \"~/.config/demo\"\n",
+        format!(
+            "when = {{ os = \"{other}\" }}\nhooks = [{{ cmd = [\"faketool\"] }}]\n[[steps]]\ninput = \".\"\n[[steps]]\noutput = \"~/.config/demo\"\n",
+            other = foreign_os(),
+        ),
     )
     .unwrap();
     fs::write(unit.join("data.txt"), "v1").unwrap();

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -56,6 +56,25 @@ pub(crate) fn dotfiles() -> Command {
     Command::cargo_bin("dotfiles").unwrap()
 }
 
+/// 現在の OS を `when.os` 表記（macOS = darwin）で返す。gate が成立する fixture に埋める。
+pub(crate) fn current_os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "darwin"
+    } else {
+        "linux"
+    }
+}
+
+/// 現在 OS ではない方の `when.os` 値。gate が成立しない fixture に埋める。架空の OS 名は load
+/// エラーになるため、不一致はもう一方の実在 OS で書く。
+pub(crate) fn foreign_os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "linux"
+    } else {
+        "darwin"
+    }
+}
+
 /// PATH に置く実行可能スタブを書き出す（固定テキストを stdout に出す）。
 /// generate / steps / hooks の各テストが共有する。
 #[cfg(unix)]

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -57,6 +57,9 @@ pub(crate) fn dotfiles() -> Command {
 }
 
 /// 現在の OS を `when.os` 表記（macOS = darwin）で返す。gate が成立する fixture に埋める。
+/// `when.os` の受理値は darwin / linux だけなので、それ以外のターゲットには「成立する値」が
+/// 無い ― 使う側のテストごと同じ cfg で外す。
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) fn current_os() -> &'static str {
     if cfg!(target_os = "macos") {
         "darwin"
@@ -65,8 +68,8 @@ pub(crate) fn current_os() -> &'static str {
     }
 }
 
-/// 現在 OS ではない方の `when.os` 値。gate が成立しない fixture に埋める。架空の OS 名は load
-/// エラーになるため、不一致はもう一方の実在 OS で書く。
+/// 現在 OS と一致しない `when.os` 値。gate が成立しない fixture に埋める（darwin / linux 以外の
+/// ターゲットではどちらも一致しない）。架空の OS 名は load エラーになるため、不一致は実在 OS で書く。
 pub(crate) fn foreign_os() -> &'static str {
     if cfg!(target_os = "macos") {
         "linux"

--- a/tests/e2e/steps.rs
+++ b/tests/e2e/steps.rs
@@ -11,7 +11,7 @@
 //! （`configs/stats` の実例）を架空ツール `prefctl` で検証する。実 configs を名指ししない契約
 //! テストなので `when` は `deps` のみ（`os` gate は付けない＝ Linux CI でも実行される）。
 
-use crate::{current_os, dotfiles, foreign_os, write_stub};
+use crate::{dotfiles, foreign_os, write_stub};
 use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
@@ -91,6 +91,8 @@ fn apply_text_append_drops_step_when_dep_absent() {
 }
 
 /// when.os は現在 OS 一致の step だけ採用し、不一致の step は脱落する。
+/// 「一致する `when.os` 値」は受理値（darwin / linux）のターゲットにしか無い（[`crate::current_os`]）。
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn apply_step_when_os_gates_by_current_os() {
     let work = tempfile::tempdir().unwrap();
@@ -114,7 +116,7 @@ fn apply_step_when_os_gates_by_current_os() {
              merge = \"append\"\n\
              [[steps]]\n\
              output = \"~/.config/demo/out.txt\"\n",
-            os = current_os(),
+            os = crate::current_os(),
             other = foreign_os(),
         ),
     )

--- a/tests/e2e/steps.rs
+++ b/tests/e2e/steps.rs
@@ -11,19 +11,10 @@
 //! （`configs/stats` の実例）を架空ツール `prefctl` で検証する。実 configs を名指ししない契約
 //! テストなので `when` は `deps` のみ（`os` gate は付けない＝ Linux CI でも実行される）。
 
-use crate::{dotfiles, write_stub};
+use crate::{current_os, dotfiles, foreign_os, write_stub};
 use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
-
-/// 現在の OS を `when.os` 表記（macOS=darwin）で返す。`when.os` fixture に埋める。
-fn current_os() -> &'static str {
-    if cfg!(target_os = "macos") {
-        "darwin"
-    } else {
-        std::env::consts::OS
-    }
-}
 
 /// text append 単位（base 常時 ＋ faketool 断片 when.deps=["faketool"]）の単位を書き出す。
 fn write_text_append_unit(work: &Path) {
@@ -119,11 +110,12 @@ fn apply_step_when_os_gates_by_current_os() {
              merge = \"append\"\n\
              [[steps]]\n\
              input = \"elsewhere.txt\"\n\
-             when  = {{ os = \"nonsuch-os\" }}\n\
+             when  = {{ os = \"{other}\" }}\n\
              merge = \"append\"\n\
              [[steps]]\n\
              output = \"~/.config/demo/out.txt\"\n",
             os = current_os(),
+            other = foreign_os(),
         ),
     )
     .unwrap();
@@ -153,11 +145,14 @@ fn apply_unit_os_gate_short_circuits_without_touching_dst() {
     let work = tempfile::tempdir().unwrap();
     let home = tempfile::tempdir().unwrap();
 
-    let unit = work.path().join("configs/maconly");
+    let unit = work.path().join("configs/otheros");
     fs::create_dir_all(&unit).unwrap();
     fs::write(
         unit.join("manifest.toml"),
-        "when = { os = \"nonsuch-os\" }\n[[steps]]\ninput = \".\"\n[[steps]]\noutput = \"~/.config/maconly\"\n",
+        format!(
+            "when = {{ os = \"{other}\" }}\n[[steps]]\ninput = \".\"\n[[steps]]\noutput = \"~/.config/otheros\"\n",
+            other = foreign_os(),
+        ),
     )
     .unwrap();
     fs::write(unit.join("f.txt"), "x\n").unwrap();
@@ -169,10 +164,10 @@ fn apply_unit_os_gate_short_circuits_without_touching_dst() {
         .assert()
         .success()
         .stdout(predicate::str::contains("skip"))
-        .stdout(predicate::str::contains("maconly"));
+        .stdout(predicate::str::contains("otheros"));
 
     assert!(
-        !home.path().join(".config/maconly").exists(),
+        !home.path().join(".config/otheros").exists(),
         "os gate=false でユニット全体が skip されず宛先が作られた",
     );
 }
@@ -697,6 +692,36 @@ fn apply_output_cmd_reflects_composed_content_every_apply() {
 }
 
 // ── load 時検証（#588 スライス1で新設した規則の代表例。網羅は manifest.rs の #[cfg(test)]） ──
+
+/// `when.os` の typo（`macos` 等）は load 時にエラーで、宛先を作らない（黙って恒久 skip させない）。
+#[test]
+fn apply_errors_when_os_is_not_an_accepted_value() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "when = { os = \"macos\" }\n[[steps]]\ninput = \".\"\n[[steps]]\noutput = \"~/.config/demo\"\n",
+    )
+    .unwrap();
+    fs::write(unit.join("f.txt"), "x\n").unwrap();
+
+    dotfiles()
+        .arg("apply")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("darwin"))
+        .stderr(predicate::str::contains("linux"));
+
+    assert!(
+        !home.path().join(".config/demo").exists(),
+        "load エラーの単位が配置されている",
+    );
+}
 
 /// 2 つ目以降の input に `merge` を書かないと load 時にエラー（暗黙の合成規則を持たない）。
 #[test]


### PR DESCRIPTION
Closes #625

## 概要

`When.os` は `Option<String>` で任意文字列を受けており、`os = "macos"`（正規化前の Rust 表記）や `drawin` のような typo はパースを通り、どの環境とも一致しない gate としてユニット / step を静かに恒久 skip していた。受理値を `enum Os { Darwin, Linux }` で閉じ、load 時に弾く。

## 変更

- `Os` を `Format` / `Merge` と同じ規則で追加（serde の受理トークンと `Display` を `lowercase` で揃え、round-trip テストが全 variant を突き合わせる）
- `When.os` を `Option<Os>` へ。`darwin` / `linux` 以外は load エラー（エラーに受理値を出す）
- `gate::current_os()` は `Option<Os>` を返し、比較を型付きにする。`darwin` / `linux` 以外のビルドターゲットは `None` ＝ どの `os` gate とも一致しない（`os` を書いたユニット / step は skip）

## テスト

- typo が apply を fail-loud で落とし、受理値を示すことを CLI 表面の E2E（`apply_errors_when_os_is_not_an_accepted_value`）で確認する。網羅は `manifest.rs` の unit test（`os_display_round_trips_through_serde` / `rejects_unknown_os`）
- E2E で「決して一致しない OS」を架空名で書いていた 3 か所は、現在 OS の反対側（有効値）へ書き換えた。型で不正値を潰した以上、gate の不一致も有効値どうしで書く
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo nextest run`（303 pass）/ `cargo doc --document-private-items`（リンク切れなし）

既存 configs（`os = "darwin"` のみ）は無変更で load・apply できる（`real_configs` E2E で担保）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)