### PR TITLE
refactor: PATH 実行ファイル存在確認を which crate に統一する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "strum",
  "tempfile",
  "toml",
+ "which",
 ]
 
 [[package]]
@@ -999,6 +1000,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json    = { workspace = true }
 strum         = { workspace = true }
 tempfile      = { workspace = true }
 toml          = { workspace = true }
+which         = { workspace = true }
 
 [lints]
 workspace = true
@@ -93,6 +94,7 @@ serde_json    = "1"
 strum         = { version = "0.28", features = [ "derive" ] }
 tempfile      = "3"
 toml          = "1.1"
+which         = "8"
 # E2E（dev-dependencies）
 assert_cmd = "2.2"
 predicates = "3.1"

--- a/src/bin/dotfiles/apply/gate.rs
+++ b/src/bin/dotfiles/apply/gate.rs
@@ -14,7 +14,7 @@
 
 use crate::manifest::{Manifest, Os, When};
 use crate::state;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// apply 開始時に 1 回解決した、状態駆動 gate（`profile` / 将来の `theme`）の現在状態スナップショット。
 ///
@@ -107,35 +107,7 @@ fn when_unsatisfied_reason(when: &When, state: &GateState) -> Option<String> {
 fn first_missing_dep(deps: &[String]) -> Option<&str> {
     deps.iter()
         .map(String::as_str)
-        .find(|dep| which(dep).is_none())
-}
-
-/// `name` の実行ファイルを `$PATH` から探す（簡易 which）。
-pub fn which(name: &str) -> Option<PathBuf> {
-    // パス区切りを含む名前は PATH 探索せず、そのまま実行ファイルとして扱う。
-    if name.contains('/') {
-        let p = PathBuf::from(name);
-        return is_executable(&p).then_some(p);
-    }
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
-        .map(|dir| dir.join(name))
-        .find(|candidate| is_executable(candidate))
-}
-
-/// 実ファイルかつ実行ビットが立っているか（Unix）。
-#[cfg(unix)]
-fn is_executable(p: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(p)
-        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
-}
-
-/// 非 Unix では実ファイルの存在のみで判定する。
-#[cfg(not(unix))]
-fn is_executable(p: &Path) -> bool {
-    p.is_file()
+        .find(|dep| which::which(dep).is_err())
 }
 
 #[cfg(test)]

--- a/src/bin/env-tools/command.rs
+++ b/src/bin/env-tools/command.rs
@@ -4,8 +4,7 @@ use std::process::Command;
 
 /// `command -v <name>` 相当: PATH 上に指定コマンドの実行ファイルがあるか判定する。
 pub fn command_exists(name: &str) -> bool {
-    std::env::var_os("PATH")
-        .is_some_and(|paths| std::env::split_paths(&paths).any(|dir| dir.join(name).is_file()))
+    which::which(name).is_ok()
 }
 
 /// `=== <label> ===` を出してコマンドを実行し、終了後に空行を入れる。

--- a/src/bin/gh-clone/main.rs
+++ b/src/bin/gh-clone/main.rs
@@ -83,6 +83,5 @@ fn main() -> ExitCode {
 
 /// `command -q` 相当: PATH 上に指定コマンドの実行ファイルがあるか判定する。
 fn command_exists(cmd: &str) -> bool {
-    std::env::var_os("PATH")
-        .is_some_and(|paths| std::env::split_paths(&paths).any(|dir| dir.join(cmd).is_file()))
+    which::which(cmd).is_ok()
 }

--- a/src/bin/workers/daily_check.rs
+++ b/src/bin/workers/daily_check.rs
@@ -70,6 +70,5 @@ fn capture(cmd: &str, args: &[&str]) -> Option<String> {
 
 /// `command -q` 相当: PATH 上に指定コマンドの実行ファイルがあるか判定する。
 fn command_exists(cmd: &str) -> bool {
-    std::env::var_os("PATH")
-        .is_some_and(|paths| std::env::split_paths(&paths).any(|dir| dir.join(cmd).is_file()))
+    which::which(cmd).is_ok()
 }

--- a/tests/e2e/real_configs.rs
+++ b/tests/e2e/real_configs.rs
@@ -12,7 +12,7 @@
 //! エンジンの契約を満たす実体である」結線（load＋ルート配置＋list）だけを見る。
 //!
 //! 前提: dep gate を空 PATH で外せるのは configs の dep が全て bare 名だから（`/` 区切りの絶対/相対
-//! dep は `gate::which` が PATH 非探索なので外れない）。実 apply のため un-gate な単位の onchange
+//! dep は PATH 非探索なので外れない）。実 apply のため un-gate な単位の onchange
 //! hooks も走り得るが、現状そのような単位は無く、bare hook は未インストール→skip で安全。前提が崩れる
 //! 単位が入ったら、ここではなく当該 manifest 側か別テストで扱う。
 


### PR DESCRIPTION
## Summary
- `gate.rs`（自前 `which()`/`is_executable()`）・`env-tools/command.rs`・`workers/daily_check.rs`・`gh-clone/main.rs` の4箇所で独立実装されていた PATH 実行ファイル存在確認ロジックを `which` crate（`which::which`）へ統一
- bin 間で共有 lib を持たない設計のため、重複解消の手段は crate 切り出しのみが整合する
- `gate.rs` の `first_missing_dep` が依存する「`/` を含む名前は PATH 非探索で直接パス扱い」という挙動は `which` crate でも再現されることを確認済み
- `is_file()` のみだった3箇所が実行ビット判定まで行うようになる差異は、より厳密になる方向の変化として許容（対象コマンドはいずれも実在の実行ファイル）

Closes #633

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace`（319 tests passed）
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `mise run check`