### PR TITLE
refactor(configs): completion manifest.toml のコメント重複を削る

### DIFF
--- a/configs/bat/completion/manifest.toml
+++ b/configs/bat/completion/manifest.toml
@@ -1,5 +1,4 @@
 # bat の fish 補完を生成・配置する。
-# `bat --completion fish` の標準出力を output のファイルへ書き出す。
 # 親の configs/bat からはこの単位（自前 manifest）は委譲され除外される。
 # when.deps = bat が PATH に無ければ生成をスキップ（ユニット gate）。
 when = { deps = [ "bat" ] }

--- a/configs/clip/completion/manifest.toml
+++ b/configs/clip/completion/manifest.toml
@@ -1,6 +1,4 @@
 # clip（src/bin/clip）の fish 補完を生成・配置する。
-# `clip --completions fish` の標準出力を output のファイルへ書き出す（completions は top-level option。
-# サブコマンドにしないことで `clip <Tab>` の候補に出さない）。
 # when.deps = clip が PATH に無ければ生成をスキップ（ユニット gate）。`dotfiles apply` 初回など
 # clip 未 install の段階では生成されない。
 when = { deps = [ "clip" ] }

--- a/configs/docker/completion/manifest.toml
+++ b/configs/docker/completion/manifest.toml
@@ -1,5 +1,4 @@
 # docker の fish 補完を生成・配置する。
-# `docker completion fish` の標準出力を output のファイルへ書き出す。
 # when.deps = docker が PATH に無ければ生成をスキップ（ユニット gate）。
 when = { deps = [ "docker" ] }
 

--- a/configs/dotfiles/completion/manifest.toml
+++ b/configs/dotfiles/completion/manifest.toml
@@ -1,6 +1,4 @@
 # dotfiles の fish 補完を生成・配置する。
-# `dotfiles --completions fish` の標準出力を output のファイルへ書き出す（completions は top-level option。
-# サブコマンドにしないことで `dotfiles <Tab>` の候補に出さない）。
 # when.deps = dotfiles が PATH に無ければ生成をスキップ（ユニット gate）。`dotfiles apply` 初回など
 # dotfiles 未 install の段階では生成されない。
 when = { deps = [ "dotfiles" ] }

--- a/configs/gh/completion/manifest.toml
+++ b/configs/gh/completion/manifest.toml
@@ -1,7 +1,6 @@
 # gh の fish 補完を生成・配置する。
-# `gh completion --shell fish` の標準出力に、同ディレクトリの custom.fish（ID 補完の独自
-# ブロック）を明示 append で連結して output へ書き出す。fish は補完をコマンド名のファイル（gh.fish）
-# でのみ autoload するため、独自補完も同じ gh.fish へ同梱する必要がある。
+# custom.fish（ID 補完の独自ブロック）を append で連結する。fish は補完をコマンド名のファイル
+# （gh.fish）でのみ autoload するため、独自補完も同じ gh.fish へ同梱する必要がある。
 # when.deps = gh が PATH に無ければ生成をスキップ（ユニット gate）。
 format = "text"
 when   = { deps = [ "gh" ] }

--- a/configs/merge-ready/completion/manifest.toml
+++ b/configs/merge-ready/completion/manifest.toml
@@ -1,5 +1,4 @@
 # merge-ready（外部ツール）の fish 補完を生成・配置する。
-# `merge-ready completions fish` の標準出力を output のファイルへ書き出す。
 # when.deps = merge-ready が PATH に無ければ生成をスキップ（ユニット gate）。
 when = { deps = [ "merge-ready" ] }
 


### PR DESCRIPTION
## Summary

- `--completions` が top-level option である理由の再掲（`configs/clip`, `configs/dotfiles`）を削除。理由は `src/bin/<bin>/cli.rs` 側に既に SSOT として存在する。
- `input.cmd`/`output` の機構を言い換えるコメント（`configs/bat`, `configs/docker`, `configs/merge-ready`, `configs/gh`）を削除。`[[steps]]` 自身が示す内容の焼き増しだった。
- `configs/gh` は custom.fish 連結の本物の Why（fish はコマンド名ファイルでのみ補完を autoload する）は残し、機構の言い換え部分だけを削った。
- upkeep（#636）で先行して整理済みの粒度へ、他の completion manifest を揃える。

Closes #637

## Test plan

- [x] `mise run check`（taplo）が成功することを確認
- [x] `dotfiles list` で全ユニット（特に7つの completion 定義）の配置定義が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)