### PR TITLE
fix(gcm): claude -p の JSON 出力を --json-schema で強制する

### DIFF
--- a/src/bin/gcm/claude.rs
+++ b/src/bin/gcm/claude.rs
@@ -11,19 +11,28 @@ Analyze the staged diff and split into the minimum number of semantically indepe
 - Single concern -> one entry
 - Multiple independent concerns (e.g. feat + fix, or unrelated files) -> multiple entries
 
-Output a JSON array of commit objects:
-
-[{\"message\": \"<type>[scope]: <description>\", \"files\": [\"path/to/file\"]}, ...]
-
 Rules:
 - type: feat, fix, docs, style, refactor, test, chore, perf, ci, build
 - description: English, imperative mood (add, fix, update, remove, ...)
 - Every staged file must appear in exactly one entry's files array";
 
+/// commit 提案の構造を Anthropic 側のツール呼び出しとして強制するスキーマ。
+const OUTPUT_SCHEMA: &str = r#"{"type":"object","properties":{"commits":{"type":"array","items":{"type":"object","properties":{"message":{"type":"string"},"files":{"type":"array","items":{"type":"string"}}},"required":["message","files"]}}},"required":["commits"]}"#;
+
 /// claude を呼び出して commit 提案を得る。
 pub(crate) fn call_claude(conversation: &str, model: &str) -> Option<Vec<Commit>> {
     let mut child = match Command::new("claude")
-        .args(["-p", "--model", model, "--system-prompt", SYSTEM_PROMPT])
+        .args([
+            "-p",
+            "--model",
+            model,
+            "--system-prompt",
+            SYSTEM_PROMPT,
+            "--json-schema",
+            OUTPUT_SCHEMA,
+            "--output-format",
+            "json",
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -54,9 +63,8 @@ pub(crate) fn call_claude(conversation: &str, model: &str) -> Option<Vec<Commit>
             eprintln!("コミット提案が空です。");
             None
         }
-        Err(_) => {
-            eprintln!("不正なJSON出力を受け取りました:");
-            eprintln!("{raw}");
+        Err(msg) => {
+            eprintln!("生成に失敗しました: {msg}");
             None
         }
     }

--- a/src/bin/gcm/main.rs
+++ b/src/bin/gcm/main.rs
@@ -77,7 +77,7 @@ fn main() -> ExitCode {
 
         let proposal_json = serde_json::to_string(&proposals).unwrap_or_default();
         conversation = format!(
-            "{conversation}\n\nPrevious proposal (JSON): {proposal_json}\nRevision instruction: {instruction}\nRevise accordingly. Output ONLY the JSON array."
+            "{conversation}\n\nPrevious proposal (JSON): {proposal_json}\nRevision instruction: {instruction}\nRevise accordingly."
         );
 
         // 修正はより高品質な sonnet で。

--- a/src/bin/gcm/proposals.rs
+++ b/src/bin/gcm/proposals.rs
@@ -1,8 +1,7 @@
 //! `gcm`（AI コミット）の純粋ロジック。
 //!
-//! claude の出力（markdown フェンスで包まれることがある）から commit 提案を
-//! 取り出す部分を切り出してユニットテスト対象にする。単一オブジェクトで返ってきた
-//! 場合も配列へ正規化する。
+//! `claude --output-format json` が返す envelope から commit 提案を取り出す
+//! 部分を切り出してユニットテスト対象にする。
 
 use serde::{Deserialize, Serialize};
 
@@ -13,35 +12,42 @@ pub struct Commit {
     pub files: Vec<String>,
 }
 
-/// markdown コードフェンス行（```... で始まる行）を除去する。
-pub fn strip_fences(s: &str) -> String {
-    s.lines()
-        .filter(|line| !line.trim_start().starts_with("```"))
-        .collect::<Vec<_>>()
-        .join("\n")
+/// `--output-format json` の結果 envelope。gcm が参照するフィールドだけ拾う。
+#[derive(Deserialize)]
+struct Envelope {
+    is_error: bool,
+    #[serde(default)]
+    errors: Vec<String>,
+    #[serde(default)]
+    structured_output: Option<StructuredOutput>,
 }
 
-/// claude の生出力から commit 提案の配列を取り出す。
+/// スキーマで強制した構造化出力。
+#[derive(Deserialize)]
+struct StructuredOutput {
+    commits: Vec<Commit>,
+}
+
+/// claude の envelope から commit 提案の配列を取り出す。
 ///
-/// 単一オブジェクトは配列に正規化する。オブジェクト/配列以外、または
-/// `message` / `files` を持たない要素は失敗。
+/// `is_error` が立っていれば `errors` を連結して失敗を返す。成功時は
+/// `structured_output.commits` を返す（欠けていれば失敗）。
 pub fn parse_proposals(raw: &str) -> Result<Vec<Commit>, String> {
-    let cleaned = strip_fences(raw);
-    let trimmed = cleaned.trim();
-    if trimmed.is_empty() {
-        return Err("empty output".to_string());
+    let envelope: Envelope =
+        serde_json::from_str(raw.trim()).map_err(|e| format!("invalid JSON: {e}"))?;
+
+    if envelope.is_error {
+        return Err(if envelope.errors.is_empty() {
+            "claude reported an error".to_string()
+        } else {
+            envelope.errors.join("; ")
+        });
     }
 
-    let value: serde_json::Value =
-        serde_json::from_str(trimmed).map_err(|e| format!("invalid JSON: {e}"))?;
-
-    let array = match value {
-        serde_json::Value::Object(_) => serde_json::Value::Array(vec![value]),
-        serde_json::Value::Array(_) => value,
-        _ => return Err("expected a JSON object or array".to_string()),
-    };
-
-    serde_json::from_value(array).map_err(|e| format!("invalid commit shape: {e}"))
+    envelope
+        .structured_output
+        .map(|output| output.commits)
+        .ok_or_else(|| "missing structured_output".to_string())
 }
 
 #[cfg(test)]
@@ -49,8 +55,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_fenced_array() {
-        let raw = "```json\n[{\"message\": \"feat: x\", \"files\": [\"a\"]}]\n```";
+    fn parses_success_envelope() {
+        let raw = r#"{"type":"result","is_error":false,"structured_output":{"commits":[{"message":"feat: x","files":["a"]}]}}"#;
         let got = parse_proposals(raw).unwrap();
         assert_eq!(
             got,
@@ -62,39 +68,37 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_lone_object_to_array() {
-        let raw = "{\"message\": \"fix: y\", \"files\": [\"b\", \"c\"]}";
+    fn parses_multiple_commits() {
+        let raw = r#"{"is_error":false,"structured_output":{"commits":[{"message":"feat: a","files":["a"]},{"message":"fix: b","files":["b","c"]}]}}"#;
         let got = parse_proposals(raw).unwrap();
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].files, vec!["b".to_string(), "c".to_string()]);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[1].files, vec!["b".to_string(), "c".to_string()]);
     }
 
     #[test]
-    fn parses_fenced_lone_object() {
-        let raw = "```\n{\"message\": \"chore: z\", \"files\": [\"d\"]}\n```";
-        assert_eq!(parse_proposals(raw).unwrap().len(), 1);
+    fn error_envelope_returns_error_message() {
+        let raw = r#"{"is_error":true,"errors":["Reached maximum budget ($0.0001)"]}"#;
+        let err = parse_proposals(raw).unwrap_err();
+        assert!(err.contains("budget"));
     }
 
     #[test]
-    fn rejects_non_object_or_array() {
-        assert!(parse_proposals("\"just a string\"").is_err());
-        assert!(parse_proposals("42").is_err());
+    fn missing_structured_output_is_error() {
+        assert!(parse_proposals(r#"{"is_error":false}"#).is_err());
+    }
+
+    #[test]
+    fn malformed_structured_output_is_error() {
+        assert!(parse_proposals(r#"{"is_error":false,"structured_output":42}"#).is_err());
+    }
+
+    #[test]
+    fn invalid_json_is_error() {
+        assert!(parse_proposals("not json at all").is_err());
     }
 
     #[test]
     fn rejects_empty() {
         assert!(parse_proposals("").is_err());
-        assert!(parse_proposals("```json\n```").is_err());
-    }
-
-    #[test]
-    fn rejects_missing_fields() {
-        assert!(parse_proposals("[{\"message\": \"feat: x\"}]").is_err());
-    }
-
-    #[test]
-    fn strip_fences_removes_fence_lines_only() {
-        assert_eq!(strip_fences("```json\nkeep\n```"), "keep");
-        assert_eq!(strip_fences("a\nb"), "a\nb");
     }
 }

--- a/tests/gcm/mod.rs
+++ b/tests/gcm/mod.rs
@@ -128,7 +128,7 @@ fn commits_single_proposal_with_real_git_repo() {
         .env("PATH", path_with(&fx.stub_path()))
         .env(
             "CLAUDE_JSON",
-            "[{\"message\":\"feat: add alpha\",\"files\":[\"a.txt\"]}]",
+            r#"{"type":"result","is_error":false,"structured_output":{"commits":[{"message":"feat: add alpha","files":["a.txt"]}]}}"#,
         )
         .write_stdin("\n")
         .assert()
@@ -161,7 +161,7 @@ fn commits_multiple_proposals_as_split_commits() {
         .env("PATH", path_with(&fx.stub_path()))
         .env(
             "CLAUDE_JSON",
-            r#"[{"message":"feat: add alpha","files":["a.txt"]},{"message":"fix: add beta","files":["b.txt"]}]"#,
+            r#"{"type":"result","is_error":false,"structured_output":{"commits":[{"message":"feat: add alpha","files":["a.txt"]},{"message":"fix: add beta","files":["b.txt"]}]}}"#,
         )
         .write_stdin("\n")
         .assert()


### PR DESCRIPTION
## Summary
- `gcm` が `claude -p` の出力に説明文が前置されると解析が丸ごと失敗する問題を修正（#644）
- `--json-schema` + `--output-format json` を併用し、モデルの自己申告に頼らず API 側で `{"commits":[...]}` 構造を強制する形に変更
- `parse_proposals` は result envelope の `is_error` / `errors` / `structured_output.commits` を読むだけになり、markdown フェンス除去・単一オブジェクトの正規化ロジックは不要になったため削除

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`（319件全通過、`gcm` の単体テスト・E2Eテスト含む）
- [x] `cargo doc --no-deps --document-private-items --bin gcm` でレンダリングを確認

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)