### PR TITLE
feat(claude): 呼び出し時だけ CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS を有効化する claude-teams 関数を追加する

### DIFF
--- a/configs/claude/fish-functions/claude-teams.fish
+++ b/configs/claude/fish-functions/claude-teams.fish
@@ -1,0 +1,3 @@
+function claude-teams --wraps claude --description 'claude with agent teams enabled'
+    env CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude $argv
+end

--- a/configs/claude/fish-functions/manifest.toml
+++ b/configs/claude/fish-functions/manifest.toml
@@ -1,0 +1,9 @@
+# Claude Code の呼び出し時専用 fish 関数（claude-teams）を fish の functions 合流点へ copy する。
+#
+# 配置先は fish の functions（conf.d・completions と同様、複数ツールが持ち寄る合流点）。
+
+[[steps]]
+input = "."
+
+[[steps]]
+output = "~/.config/fish/functions"

--- a/configs/claude/manifest.toml
+++ b/configs/claude/manifest.toml
@@ -1,15 +1,12 @@
 # Claude Code の静的設定一式（rules / skills / statusline スクリプト）を ~/.claude へ copy する。
 #
-# output=~/.claude のディレクトリ単位ツリー配置。配下は相対構造を保って再帰配置される:
+# output=~/.claude のディレクトリ単位ツリー配置:
 #   rules/*.md                     → ~/.claude/rules/*.md
 #   skills/memory-tidy/SKILL.md    → ~/.claude/skills/memory-tidy/SKILL.md
 #   statusline-command.py          → ~/.claude/statusline-command.py
-# いずれも 0644（statusline-command.py は python3 経由で起動されるため実行ビット不要
-# ＝ executable は付けない）。
+# statusline-command.py は python3 経由で起動するため executable は付けない。
 #
-# settings/（json 合成で settings.json を組む別単位）・fish/（conf.d 合流点へ環境変数
-# 断片を置く別単位）はサブ manifest を持つので、このツリー配置からは委譲され除外される
-# （bat/completion と同じ親子関係）。
+# settings/・fish/・fish-functions/ は別ユニットで、このツリー配置には含まれない。
 #
 # 依存の結線: settings/settings.json は statusLine に `python3 ~/.claude/statusline-command.py`
 # を指す。そのスクリプト実体をこの単位が配置することで、両単位が揃って初めて statusLine が成立する。

--- a/configs/claude/manifest.toml
+++ b/configs/claude/manifest.toml
@@ -6,8 +6,6 @@
 #   statusline-command.py          → ~/.claude/statusline-command.py
 # statusline-command.py は python3 経由で起動するため executable は付けない。
 #
-# settings/・fish/・fish-functions/ は別ユニットで、このツリー配置には含まれない。
-#
 # 依存の結線: settings/settings.json は statusLine に `python3 ~/.claude/statusline-command.py`
 # を指す。そのスクリプト実体をこの単位が配置することで、両単位が揃って初めて statusLine が成立する。
 

--- a/configs/fish/manifest.toml
+++ b/configs/fish/manifest.toml
@@ -1,23 +1,15 @@
 # fish 本体（config.fish・conf.d・functions・themes）を ~/.config/fish へ copy する。
-# 決定経緯: Issue #530・#558
 #
-# output=~/.config/fish のディレクトリ単位ツリー配置。配下は相対構造を保って再帰配置される:
+# output=~/.config/fish のディレクトリ単位ツリー配置:
 #   config.fish                   → ~/.config/fish/config.fish
 #   conf.d/*.fish, README.md      → ~/.config/fish/conf.d/*
 #   functions/_fzf_file.fish      → ~/.config/fish/functions/_fzf_file.fish
 #   functions/_fzf_history.fish   → ~/.config/fish/functions/_fzf_history.fish
 #   themes/OneHalfLight-Ayu.theme → ~/.config/fish/themes/OneHalfLight-Ayu.theme
-# いずれも 0644（fish が autoload/source するだけで実行ビット不要）。
+# いずれも fish が autoload/source するだけで実行されないため executable は付けない。
 #
-# functions/ の `_fzf_gh` / `_fzf_ghq_cd` / `_fzf_worktree_remove` / `__fzf_picker_preview` /
-# `__fzf_ghq_readme_preview` / `cdabbr` は fzf-picker、`gh-clone` は gh-clone、`ps-grep` は
-# ps-grep 自身へ帰属するため、それぞれ独立したツールディレクトリ（configs/fzf-picker,
-# configs/gh-clone, configs/ps-grep）が持つ。ここには含めない（Issue #567）。
-# conf.d は複数ツールが断片を持ち寄る合流点でもあり
-# （eza の 40-eza.fish 等、番号帯が重ならない限り併存可）、claude（08-claude.fish）・workers
-# （60-daily-check.fish・70-git-background-fetch.fish）・starship（95-starship-prompt.fish）は
-# 各ツール側の manifest（configs/claude/fish, configs/workers, configs/starship/fish）が持つ
-# ためここには含めない。
+# conf.d・functions は複数ツールが断片を持ち寄る合流点でもある（例: eza の 40-eza.fish。conf.d は
+# 番号帯が重ならない限り併存可）。他ツールに帰属するファイルも並ぶが、このツリー配置には含まれない。
 
 [[steps]]
 input = "."

--- a/configs/fish/manifest.toml
+++ b/configs/fish/manifest.toml
@@ -9,7 +9,7 @@
 # いずれも fish が autoload/source するだけで実行されないため executable は付けない。
 #
 # conf.d・functions は複数ツールが断片を持ち寄る合流点でもある（例: eza の 40-eza.fish。conf.d は
-# 番号帯が重ならない限り併存可）。他ツールに帰属するファイルも並ぶが、このツリー配置には含まれない。
+# 番号帯が重ならない限り併存可）。
 
 [[steps]]
 input = "."


### PR DESCRIPTION
## Summary
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` を常時 export せず、呼び出し時だけ有効化する fish 関数 `claude-teams` を追加する
- 配置先は `~/.config/fish/functions/claude-teams.fish`。新設した `configs/claude/fish-functions/` manifest 単位（output=`~/.config/fish/functions`）が持つ。conf.d 用の既存 `configs/claude/fish/`（常時 export）とは用途が異なる別ユニット
- `configs/claude/manifest.toml` / `configs/fish/manifest.toml` のコメントも合わせて整理（詳細は個別 Issue で追跡）

Closes #646

## Test plan
- [x] `cargo fmt --all --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo nextest run`（304 tests）
- [x] `mise run lint`
- [x] 一時 `HOME` への `dotfiles apply` で `~/.config/fish/functions/claude-teams.fish` の配置を確認
- [x] fish 上で `claude-teams` を実行し、引数が `claude` へ透過すること・実行後に親シェルへ環境変数が残らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)