### PR TITLE
feat(doctor): 現在の profile が全 manifest の when.profile に現れない場合に警告する

### DIFF
--- a/src/bin/dotfiles/apply/gate.rs
+++ b/src/bin/dotfiles/apply/gate.rs
@@ -40,6 +40,12 @@ impl GateState {
             profile: profile.map(str::to_string),
         }
     }
+
+    /// 現在の profile 状態（未設定は None）。gate 評価を経由せず生の値が要る呼び出し元向け
+    /// （[`crate::doctor`] の宣言値集合との突合）。
+    pub fn profile(&self) -> Option<&str> {
+        self.profile.as_deref()
+    }
 }
 
 /// 現在の OS を manifest の語彙（[`Os`]）で返す。

--- a/src/bin/dotfiles/doctor.rs
+++ b/src/bin/dotfiles/doctor.rs
@@ -1,20 +1,22 @@
-//! `dotfiles doctor`: 全ユニットの `locals` 宣言・ユニット間の配置先衝突・不要になった配置を診断する。
+//! `dotfiles doctor`: 全ユニットの `locals` 宣言・ユニット間の配置先衝突・現在 profile の宣言状況・
+//! 不要になった配置を診断する。
 //!
 //! 全単位の `manifest.toml`（[`crate::discover`]）から `locals` を集め、ストア
 //! （[`crate::locals::store`]）に値が無い名前を報告する。加えて [`crate::placements::expected`] が
 //! 導出する期待配置集合から、複数ユニットが同一パスへ output を宣言している箇所（#593）を報告する。
-//! さらに [`crate::prune::stale`] が示す「前回 apply 時点は期待されていたが今回はもう期待されない」
-//! 配置（#521）も報告する ― 実削除はしない（`dotfiles apply --force` の役目）。いずれもツール別
-//! ロジックは持たず、宣言と現状の突合だけを見る（診断の拡張は #576）。問題があっても
+//! 現在の profile 状態が、全 unit の `when.profile` 宣言値集合に現れているかも突合する（#628・
+//! typo 検出）。さらに [`crate::prune::stale`] が示す「前回 apply 時点は期待されていたが今回はもう
+//! 期待されない」配置（#521）も報告する ― 実削除はしない（`dotfiles apply --force` の役目）。
+//! いずれもツール別ロジックは持たず、宣言と現状の突合だけを見る（診断の拡張は #576）。問題があっても
 //! **ブロックしない**（exit 0・情報提供）。
 
 use crate::apply::gate;
 use crate::discover::{self, MANIFEST};
 use crate::locals::store::Store;
-use crate::manifest::{Manifest, OutputSource, Step, Steps};
+use crate::manifest::{Manifest, OutputSource, Step, Steps, When};
 use crate::placements::{self, Placement};
 use crate::prune;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 /// `source` 配下の `locals` 宣言・期待配置集合を突き合わせ、未設定・衝突・不要な配置を stderr へ
@@ -28,6 +30,7 @@ pub fn run(source: &Path, home: &Path) -> Result<(), String> {
     report_placement_conflicts(&expected);
 
     let gate_state = gate::GateState::load(home)?;
+    report_unknown_profile(&units, gate_state.profile())?;
     let current =
         placements::expected_gated(source, home, &|w| gate::when_satisfied(w, &gate_state))?;
     let stale = prune::stale(home, &current);
@@ -84,6 +87,54 @@ fn report_placement_conflicts(expected: &[Placement]) {
     eprintln!("doctor: 配置先の衝突が {} 件あります:", conflicts.len());
     for (path, units) in &conflicts {
         eprintln!("  - {}: {}", path.display(), units.join(", "));
+    }
+}
+
+/// 現在の profile 状態が、全 unit の `when.profile` 宣言値集合に現れない場合に警告する（#628）。
+/// 未設定（`current` が None）は正常系（not-private 既定）のため対象外 ― 完全に沈黙する。
+///
+/// 「どの manifest も参照しない profile 値」は正当な使い方でもあり得る（private を避ける目的だけの
+/// 値等）ため、エラーにはせず typo の可能性を知らせる情報提供に留める。
+fn report_unknown_profile(units: &[discover::Unit], current: Option<&str>) -> Result<(), String> {
+    let Some(current) = current else {
+        return Ok(());
+    };
+
+    let mut declared = BTreeSet::new();
+    for unit in units {
+        let manifest = Manifest::load(&unit.dir.join(MANIFEST))?;
+        collect_profiles(&manifest, &mut declared);
+    }
+
+    if declared.contains(current) {
+        println!("doctor: profile `{current}` を参照する when.profile があります");
+        return Ok(());
+    }
+    eprintln!(
+        "doctor: profile `{current}` を参照する when.profile がありません（typo であれば意図した \
+         profile gate 付きの断片が配置されません。意図した値であれば無視してください）"
+    );
+    Ok(())
+}
+
+/// `manifest` のトップレベル `when` と（パイプラインなら）各 step の `when` から `profile` 宣言値を
+/// `into` へ集める。ツリー配置（[`Steps::Tree`]）は step の `when` を持てないためトップレベルのみ。
+fn collect_profiles(manifest: &Manifest, into: &mut BTreeSet<String>) {
+    collect_when_profile(&manifest.when, into);
+    if let Steps::Pipeline { steps, .. } = &manifest.steps {
+        for step in steps {
+            let when = match step {
+                Step::Input(s) => &s.when,
+                Step::Output(s) => &s.when,
+            };
+            collect_when_profile(when, into);
+        }
+    }
+}
+
+fn collect_when_profile(when: &Option<When>, into: &mut BTreeSet<String>) {
+    if let Some(profile) = when.as_ref().and_then(|w| w.profile.as_deref()) {
+        into.insert(profile.to_string());
     }
 }
 

--- a/tests/e2e/profile.rs
+++ b/tests/e2e/profile.rs
@@ -2,7 +2,8 @@
 //!
 //! `dotfiles profile` の設定／表示と、`when = { profile = … }` を持つ架空ユニットが現在の profile
 //! 状態で配置／skip されること（既定 not-private）・冪等性を検証する。実 yt/mise は名指ししない
-//! （架空 fixture `demo` で書く）。
+//! （架空 fixture `demo` で書く）。加えて `doctor` の「現在 profile が宣言値集合に無ければ警告」
+//! （#628）を検証する。
 //!
 //! 注: `assert_cmd` の `.assert()` は非 TTY なので、profile gate を通った locals 宣言付きユニットは
 //! 警告のみで継続する（本ファイルの gate fixture は locals を持たないので注入経路には入らない）。
@@ -137,4 +138,103 @@ fn profile_gate_skips_on_mismatch() {
         !home.path().join(".config/demo/conf").exists(),
         "profile 不一致なのに配置された",
     );
+}
+
+/// profile 未設定では doctor は宣言値集合との突合を行わず沈黙する（受け入れ条件: 未設定は対象外）。
+#[test]
+fn doctor_is_silent_about_profile_when_unset() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_gated_unit(work.path(), "when = { profile = \"private\" }\n");
+
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("profile").not());
+}
+
+/// 現在 profile がどの unit の `when.profile`（unit gate）にも現れなければ doctor が警告する
+/// （typo 検出・情報提供のみで exit success）。
+#[test]
+fn doctor_warns_when_current_profile_matches_no_unit_level_declaration() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_gated_unit(work.path(), "when = { profile = \"private\" }\n");
+
+    dotfiles()
+        .args(["profile", "privat"]) // typo: "private" の 1 文字欠け。
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "profile `privat` を参照する when.profile がありません",
+        ));
+}
+
+/// unit gate（トップレベル `when.profile`）で宣言されていれば警告しない。
+#[test]
+fn doctor_reports_when_profile_declared_at_unit_level() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_gated_unit(work.path(), "when = { profile = \"private\" }\n");
+
+    dotfiles()
+        .args(["profile", "private"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "profile `private` を参照する when.profile があります",
+        ));
+}
+
+/// unit gate は持たず、パイプラインの output step だけが `when.profile` を宣言していても、
+/// その step 由来の値は宣言値集合として拾われる（unit レベルしか見ない実装への回帰を防ぐ）。
+#[test]
+fn doctor_is_silent_when_profile_declared_only_at_step_level() {
+    let work = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    let unit = work.path().join("configs/demo");
+    fs::create_dir_all(&unit).unwrap();
+    fs::write(
+        unit.join("manifest.toml"),
+        "[[steps]]\ninput = \"conf\"\n\
+         [[steps]]\noutput = \"~/.config/demo\"\nwhen = { profile = \"work\" }\n",
+    )
+    .unwrap();
+    fs::write(unit.join("conf"), "x\n").unwrap();
+
+    dotfiles()
+        .args(["profile", "work"])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    dotfiles()
+        .arg("doctor")
+        .current_dir(work.path())
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("profile `work` を参照する when.profile がありません").not(),
+        );
 }


### PR DESCRIPTION
## Summary
- profile 名は開集合（固定集合にしない設計）のため、状態側（`dotfiles profile <name>`）・宣言側（`when.profile`）どちらの typo も型や load 検証では弾けなかった
- `dotfiles doctor` が全 unit の `when.profile`（unit gate・step gate 両方）宣言値集合を収集し、現在の profile 状態がどれとも一致しなければ警告するようにした（未設定は正常系のため対象外）
- 「どの manifest も参照しない profile 値」は正当な使い方でもあり得るため、エラーにはせず情報提供に留める

Closes #628

## Test plan
- [x] `cargo nextest run`（308 tests）
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo doc --document-private-items`
- [x] e2e: 未設定時は沈黙 / unit レベル宣言と一致 / step レベルのみの宣言と一致（回帰検出） / 不一致時に警告、の4パターン

🤖 Generated with [Claude Code](https://claude.com/claude-code)