### PR TITLE
refactor(configs): 他 manifest.toml に残る dotfiles バイナリ仕様の重複を削る

### DIFF
--- a/configs/bash/manifest.toml
+++ b/configs/bash/manifest.toml
@@ -6,7 +6,6 @@
 # 薄い委譲層 ── git config の native [include]（configs/git/manifest.toml 参照）と同じ発想で
 # bash 自身の `source` に合成を委ねる（engine の steps 合成は使わない）。
 #
-# configs/bash/scripts/ はサブ manifest を持つため対象外。
 # ディレクトリ名は lib でなく scripts（`.gitignore` の Python テンプレート由来の非アンカー
 # `lib/` パターンと衝突し、git add で静かに無視されるため）。
 

--- a/configs/bat/completion/manifest.toml
+++ b/configs/bat/completion/manifest.toml
@@ -1,5 +1,4 @@
 # bat の fish 補完を生成・配置する。
-# 親の configs/bat からはこの単位（自前 manifest）は委譲され除外される。
 # when.deps = bat が PATH に無ければ生成をスキップ（ユニット gate）。
 when = { deps = [ "bat" ] }
 

--- a/configs/claude/fish/manifest.toml
+++ b/configs/claude/fish/manifest.toml
@@ -2,9 +2,8 @@
 # Issue #558
 #
 # 配置先は fish の conf.d（複数ツールが断片を持ち寄る合流点。eza の 40-eza.fish 等と同じ場所）。
-# 中身は claude に帰属するため fish 本体（configs/fish）ではなくここに置く。親 configs/claude/
-# の manifest（output=~/.claude）から見るとこのディレクトリは別 manifest を持つので委譲される
-# （settings/ と同じ関係）。ファイル名の番号 prefix (08-) が読み込み順を表す。
+# 中身は claude に帰属するため fish 本体（configs/fish）ではなくここに置く。ファイル名の番号 prefix
+# (08-) が読み込み順を表す。
 
 [[steps]]
 input = "."

--- a/configs/cursor/manifest.toml
+++ b/configs/cursor/manifest.toml
@@ -1,6 +1,5 @@
 # Cursor のルール（rules/git-no-commit-on-main.mdc）を ~/.cursor へ copy する。
 #
-# output=~/.cursor のディレクトリ単位ツリー配置。配下は相対構造を保って再帰配置される:
 #   rules/git-no-commit-on-main.mdc → ~/.cursor/rules/git-no-commit-on-main.mdc
 #
 # claude/rules/git-no-commit-on-main.md と内容が重複しているが、ルール本体の出所の一本化・

--- a/configs/git/manifest.toml
+++ b/configs/git/manifest.toml
@@ -9,8 +9,8 @@
 # "DOTFILES_GIT_EMAIL/NAME" 注入＋user.tmpl の if 分岐を廃し、宣言的な locals に一本化する。
 # email/name は commit に載る値であり秘匿ではない。
 #
-# hooks（configs/git/hooks）と ignore（configs/git/ignore）はそれぞれ別 manifest を持つ別単位
-# （配置先が ~/.config/git/hooks・~/.config/git/ignore で本単位の ~/.config/git と異なるため）。
+# hooks（configs/git/hooks）と ignore（configs/git/ignore）は配置先が ~/.config/git/hooks・
+# ~/.config/git/ignore で本単位の ~/.config/git と異なるため、別単位として持つ。
 locals = [ "git.email", "git.name" ]
 
 [[steps]]

--- a/configs/merge-ready/manifest.toml
+++ b/configs/merge-ready/manifest.toml
@@ -2,9 +2,6 @@
 #
 # output=~/.config のディレクトリ単位ツリー配置。配下の merge-ready.toml を相対構造のまま配置し
 # ~/.config/merge-ready.toml に置く。~/.config 配下の他ツール設定には触れない。
-#
-# completion/（fish 補完を生成する別単位）はサブ manifest を持つので、このツリー配置からは委譲され
-# 除外される（gh/config と gh/completion と同じ関係）。
 
 [[steps]]
 input = "."

--- a/configs/starship/fish/manifest.toml
+++ b/configs/starship/fish/manifest.toml
@@ -1,8 +1,6 @@
 # starship の fish 連携（起動時に `starship init fish` を source）を conf.d 合流点へ配置する。
 #
 # 配置先は fish の conf.d（複数ツールが断片を持ち寄る合流点。eza の 40-eza.fish 等と同じ場所）。
-# 親 configs/starship/manifest.toml は ~/.config へのツリー配置（starship.toml を配置）だが、
-# このディレクトリは別 manifest を持つので委譲され、~/.config/fish 側からは触れない。
 # ファイル名の番号 prefix (95-) が読み込み順を表す（プロンプトは fish 起動の最終段で初期化する）。
 
 [[steps]]

--- a/configs/starship/manifest.toml
+++ b/configs/starship/manifest.toml
@@ -3,9 +3,6 @@
 # output=~/.config（ディレクトリ）。配下の starship.toml を相対構造のまま配置し
 # ~/.config/starship.toml に置く。~/.config 配下の他ツール設定には触れない。
 #
-# fish/（fish 起動連携 `starship init fish` を conf.d 合流点へ置く別単位）はサブ manifest を
-# 持つので、このツリー配置からは委譲され除外される（claude の settings/ と同じ関係）。
-#
 # starship.toml 先頭の `$schema` は starship 公式のスキーマ URL を設定。
 # エディタや taplo はこの URL を取得して設定を検証する。
 #


### PR DESCRIPTION
## Summary
- discover.rs の委譲規則・manifest.rs の Tree 配置仕様を言い換えていたコメントを8ファイルから削除
- issue #649 列挙の7件（claude/fish, starship, starship/fish, merge-ready, bash, bat/completion, cursor）に加え、網羅grepで見つかった git/manifest.toml も対象に含めた（hooks/ignoreが別単位である旨の記述は、機構部分のみ削り「配置先が異なるため」という固有Whyは残した）
- 機能面（`[[steps]]` / `input` / `output` / `when`）の変更は無し。コメントのみが対象

## Test plan
- [x] `mise run check`（taplo lint 含む）が通ることを確認
- [x] `git diff` で変更が `#` コメント行のみであることを確認

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)