### PR TITLE
fix(ghostty): Application Support への symlink 生成を削除する

### DIFF
--- a/configs/ghostty/manifest.toml
+++ b/configs/ghostty/manifest.toml
@@ -1,29 +1,15 @@
-# ghostty の設定（config）を ~/.config/ghostty へ配置し、macOS 参照先への symlink を張る。
+# ghostty の設定（config）を ~/.config/ghostty へ配置する。
 #
-# when = { deps = ["ghostty"], os = "darwin" }: トップレベル when はユニットスコープ gate。
-#   when.deps = ["ghostty"]: ghostty CLI は GUI アプリの app バンドル内
-#     （/Applications/Ghostty.app/Contents/MacOS/ghostty）にあり、これが PATH 解決される。
-#   when.os = "darwin": symlink 生成は macOS 専用なので darwin gate する。darwin 以外では配置も
-#     末尾の output.cmd も skip される（ユニット gate がツリー全体を覆う）。macOS 専用である知識は
-#     この manifest（when.os ＋下記コマンド）が持ち、binary は関知しない。
-#
-# 末尾の output.cmd: 配置後、~/Library/Application Support/com.mitchellh.ghostty/config →
-#   ~/.config/ghostty/config の symlink を張る（`ln -sf` は既存リンク/ファイルを置き換えるので
-#   毎 apply 実行しても安全）。
+# when.deps（トップレベル when ＝ ユニットスコープ gate）: ghostty CLI は GUI アプリの app バンドル内
+#   （/Applications/Ghostty.app/Contents/MacOS/ghostty）にあり、これが PATH 解決される。ghostty が
+#   PATH に無い環境ではユニットごと skip する。
 #
 # 注: テーマ（config 内の theme 行）の light/dark 切替は color スライスの担当。`theme` 属性は
 #   そのスライスで付与する。
-when = { deps = [ "ghostty" ], os = "darwin" }
+when = { deps = [ "ghostty" ] }
 
 [[steps]]
 input = "."
 
 [[steps]]
 output = "~/.config/ghostty"
-
-[[steps]]
-output.cmd = [
-  "sh",
-  "-c",
-  "mkdir -p \"$HOME/Library/Application Support/com.mitchellh.ghostty\" && ln -sf \"$HOME/.config/ghostty/config\" \"$HOME/Library/Application Support/com.mitchellh.ghostty/config\"",
-]


### PR DESCRIPTION
## Summary
- 現行 ghostty (1.3.1) は macOS でも `~/.config/ghostty/config` を XDG パスとして直接読むことを確認した。これは公式ドキュメント（https://ghostty.org/docs/config）に明記されている仕様で、XDG configuration path は "all platforms" 向けであり、macOS-specific path（Application Support）はそれに加えて後から読まれる追加パス（両方存在する場合は後発側がスカラー値を上書き）。
- symlink（`~/Library/Application Support/com.mitchellh.ghostty/config` → `~/.config/ghostty/config`）で両パスを同一ファイルにしていたため、同じ config を二重読込していた。`ghostty +show-config` で `font-family`（複数値許容キー）が重複表示されることで実測確認した。symlink を外すと重複は解消し、theme/background 等のスカラー値も正しく読み込まれ続ける。
- `configs/ghostty/manifest.toml` から末尾の `output.cmd`（symlink 生成）step と `when.os = "darwin"` gate を削除し、純粋なツリー配置にした。
- 実機に残っていた旧 symlink も trash で削除済み。

## 検証方法
1. `ghostty +show-config` で symlink がある状態を確認（`font-family` が2重に出力される）。
2. symlink を一時的にリネームし、`+show-config` を再実行 → 重複が消え、`theme` / `background` / `font-family` は変わらず正しく反映される。
3. symlink を復元 → 重複が再現することを確認（元の状態に戻したことも確認）。
4. 公式ドキュメント（ghostty.org/docs/config）の File Location 節を直接取得し、"XDG configuration Path (all platforms)" と "macOS also supports the XDG configuration path... macOS-specific files are loaded after all XDG files" の記述で仕様面からも裏付けた。
5. manifest 修正後、`dotfiles apply` で `ghostty → ~/.config/ghostty (tree)`（`output.cmd` 無し）になることを確認。
6. `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo nextest run`（302 tests）/ `mise run check` すべて成功。

Closes #661

## Test plan
- [x] `mise run check`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
- [x] `dotfiles apply` で ghostty ユニットが tree 配置のみになることを確認