### PR TITLE
feat(local): dotfiles local list で設定済み named value を一覧する

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ Some configs need a value that differs per machine (e.g. git email/name). Store 
 
 ```bash
 dotfiles local set <name> <value>
+dotfiles local list
 ```
 
-Values are kept in `~/.config/dotfiles/local.toml` and injected during `apply`. Run `dotfiles doctor` to see which declared names are still unset.
+Values are kept in `~/.config/dotfiles/local.toml` and injected during `apply`. `list` shows what is currently stored; `dotfiles doctor` shows which declared names are still unset.
 
 ## Machine profile
 

--- a/src/bin/dotfiles/cli.rs
+++ b/src/bin/dotfiles/cli.rs
@@ -48,7 +48,7 @@ enum Commands {
     },
     /// 配置の一覧（各ユニットの配置先と方式）を表示する。
     List,
-    /// マシン固有の値（git の email 等）をストアへ保存する。
+    /// マシン固有の値（git の email 等）をストアへ保存・一覧する。
     Local {
         #[command(subcommand)]
         action: LocalAction,
@@ -78,11 +78,13 @@ enum ColorAction {
     Sample,
 }
 
-/// `local` のサブコマンド。将来 `get` / `list` / `unset` を足す余地を見越し `local <action>` 形を保つ。
+/// `local` のサブコマンド。将来 `get` / `unset` を足す余地を見越し `local <action>` 形を保つ。
 #[derive(Subcommand)]
 enum LocalAction {
     /// 名前→値をストア（`~/.config/dotfiles/local.toml`）へ設定する。
     Set { name: String, value: String },
+    /// ストアに設定済みの名前→値を一覧する。
+    List,
 }
 
 /// `dotfiles` の入口。引数を解釈し、サブコマンドへディスパッチする。
@@ -99,9 +101,7 @@ pub fn run() {
     let result = match cli.command {
         Some(Commands::Apply { force }) => run_apply(source, force),
         Some(Commands::List) => run_list(source),
-        Some(Commands::Local {
-            action: LocalAction::Set { name, value },
-        }) => run_local_set(&name, &value),
+        Some(Commands::Local { action }) => run_local(action),
         Some(Commands::Profile { name }) => run_profile(name.as_deref()),
         Some(Commands::Color {
             action: ColorAction::Sample,
@@ -137,10 +137,14 @@ fn run_list(source: Option<&Path>) -> Result<(), String> {
     list::run(resolved.root(), &resolved.origin().to_string())
 }
 
-/// `dotfiles local set <name> <value>`：named value をストアへ保存する。
-fn run_local_set(name: &str, value: &str) -> Result<(), String> {
+/// `dotfiles local <action>`：named value をストアへ保存（`set`）、または一覧（`list`）する。
+fn run_local(action: LocalAction) -> Result<(), String> {
     let home = home_dir()?;
-    local::set(Path::new(&home), name, value)
+    let home = Path::new(&home);
+    match action {
+        LocalAction::Set { name, value } => local::set(home, &name, &value),
+        LocalAction::List => local::list(home),
+    }
 }
 
 /// `dotfiles profile [<name>]`：`<name>` 指定で profile 状態を設定、省略で現在値を表示する。

--- a/src/bin/dotfiles/local.rs
+++ b/src/bin/dotfiles/local.rs
@@ -1,7 +1,10 @@
-//! `dotfiles local set`: named value（マシンローカル値）をストアへ設定する明示経路。
+//! `dotfiles local`: named value（マシンローカル値）をストアへ設定し、設定済みの値を一覧する明示経路。
 //!
-//! ストアの読み書きは [`crate::locals::store`]。値は argv に載るためシェル履歴/ps に残る点は呼び出し側
-//! の選択であり、対話取得（[`crate::locals::prompt`]）は apply の TTY 経路が担う別物。
+//! ストアの読み書きは [`crate::locals::store`]。`set` の値は argv に載るためシェル履歴/ps に残る点は
+//! 呼び出し側の選択であり、対話取得（[`crate::locals::prompt`]）は apply の TTY 経路が担う別物。
+//!
+//! `list` は値を verbatim で出す ― 秘匿値のマスクは、それを宣言する語彙（per-entry `sensitive`・
+//! #588）が入る時に併せて入る。
 
 use crate::locals::store::Store;
 use std::path::Path;
@@ -15,5 +18,24 @@ pub fn set(home: &Path, name: &str, value: &str) -> Result<(), String> {
         "local set: {name} を保存しました（{}）",
         Store::path(home).display()
     );
+    Ok(())
+}
+
+/// ストアの全 named value を `名前 = 値` の形で名前順に表示する。
+pub fn list(home: &Path) -> Result<(), String> {
+    let store = Store::load(home)?;
+    let path = Store::path(home);
+
+    let rows: Vec<_> = store.entries().collect();
+    if rows.is_empty() {
+        println!("local list: 対象なし（{} に値がない）", path.display());
+        return Ok(());
+    }
+
+    let width = rows.iter().map(|(name, _)| name.len()).max().unwrap_or(0);
+    println!("dotfiles local list（store: {}）", path.display());
+    for (name, value) in rows {
+        println!("  {name:<width$} = {value}");
+    }
     Ok(())
 }

--- a/src/bin/dotfiles/locals/store.rs
+++ b/src/bin/dotfiles/locals/store.rs
@@ -43,6 +43,11 @@ impl Store {
         self.values.insert(name.to_string(), value.to_string());
     }
 
+    /// 全エントリを名前の昇順で返す。
+    pub fn entries(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
     /// ストアを **原子的に** 0600 で書き出す（親ディレクトリを作成）。同一ディレクトリへ
     /// 一時ファイルを 0600 で作成し、fsync してから rename で置き換える。rename は既存の
     /// `local.toml`（live ファイル）を切り詰めないため、書き込み途中のクラッシュ/kill でも

--- a/tests/e2e/local.rs
+++ b/tests/e2e/local.rs
@@ -1,7 +1,8 @@
 //! マシンローカル値（named value）機構の E2E（S4 / #458）。
 //!
 //! `dotfiles local set` でストアへ設定 →`apply` で `@@name@@` 注入、未設定時の非 TTY 警告と
-//! placeholder 残し、`doctor` の未設定警告を架空 fixture（`demo` 単位）で検証する。
+//! placeholder 残し、`local list` の一覧、`doctor` の未設定警告を架空 fixture（`demo` 単位）で
+//! 検証する。
 //!
 //! 注: `assert_cmd` の `.assert()` は `Command::output()` 経由で子の stdin を継承しない（= 非 TTY）。
 //! よって apply は常に非対話経路（警告のみ）を通り、テストがプロンプトでハングしない。
@@ -98,6 +99,54 @@ fn local_set_writes_owner_only_store() {
         fs::read_to_string(&store).unwrap().contains("val"),
         "ストアに値が保存されていない",
     );
+}
+
+/// `local list` が設定済みの名前→値を名前順で出すことを検証。
+#[test]
+fn local_list_shows_stored_values_in_name_order() {
+    let home = tempfile::tempdir().unwrap();
+
+    for (name, value) in [("git.name", "Toshiki"), ("git.email", "me@example.com")] {
+        dotfiles()
+            .args(["local", "set", name, value])
+            .env("HOME", home.path())
+            .assert()
+            .success();
+    }
+
+    let stdout = dotfiles()
+        .args(["local", "list"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(stdout).unwrap();
+
+    let email = stdout.find("git.email").expect("git.email が出ていない");
+    let name = stdout.find("git.name").expect("git.name が出ていない");
+    assert!(
+        email < name,
+        "名前順（git.email → git.name）で出ていない:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("me@example.com") && stdout.contains("Toshiki"),
+        "値が出ていない:\n{stdout}",
+    );
+}
+
+/// ストアが空（ファイル未作成）なら `list` / `doctor` と同じ作法で「対象なし」を出して成功する。
+#[test]
+fn local_list_reports_empty_store() {
+    let home = tempfile::tempdir().unwrap();
+
+    dotfiles()
+        .args(["local", "list"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("対象なし"));
 }
 
 /// `doctor` が未設定 locals を警告し、`local set` 後は「設定済み」になることを検証。


### PR DESCRIPTION
Closes #587

## 変更

`dotfiles local list` を追加した。ストアの全 named value を `名前 = 値` の形で名前順に表示する。設定済みの値を確認するのに `~/.config/dotfiles/local.toml` を直接 cat する必要がなくなる。

```
dotfiles local list（store: /Users/t/.config/dotfiles/local.toml）
  git.email  = me@example.com
  git.name   = Toshiki
  yt.browser = firefox
```

ストアが空なら `list` / `doctor` と同じ作法で「対象なし」を出して成功する。

- `Store::entries()`: 全エントリを名前の昇順で返す（`BTreeMap` なので走査順がそのまま名前順）
- `local::list()`: 表示。`local set` と同じくストアだけを見るため、source 解決も manifest 集約も要らない
- `LocalAction::List` を追加し、`run_local` で `set` / `list` をディスパッチ

## sensitive マスクを実装しない理由

#587 は受け入れ条件に「sensitive 宣言された名前の値はマスクされて表示される」を挙げていたが、これは実装しない。`sensitive` は #588 スライス1 で削除済みで、値を秘匿と宣言する語彙が manifest に無いため。

#588 は削除理由を「1つの named value を2配列（locals / sensitive）に記載し ⊆ 検証で整合を貼る構造で、現利用者もゼロ」とし、「秘匿値が実際に現れた時に per-entry 構造（`{ name, sensitive }`）で再導入する」と定めている。現在の named value は `git.email` / `git.name` / `yt.browser` の3つでいずれも非秘匿なので、再導入のトリガーは満たされていない。

今マスクを実装するなら per-entry スキーマの再導入（#588 が明示的に見送った変更）か、名前のヒューリスティック（`*token*` 等）になるが、後者は engine にツール知識を持ち込むため取れない。#588 の方針どおり、秘匿値が現れた時に per-entry 構造とあわせて入れる。

## 検証

- `cargo nextest run`: 304 passed
- `cargo clippy --all-targets -- -D warnings` / `cargo fmt --all --check` / `mise run check`: clean
- E2E 2件を `tests/e2e/local.rs` へ追加（名前順の表示・空ストア）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
