### PR TITLE
feat(upkeep): outdated --explain のリリースノート解決を brew / mise へ広げる

### DIFF
--- a/src/bin/upkeep/outdated/brew.rs
+++ b/src/bin/upkeep/outdated/brew.rs
@@ -1,10 +1,11 @@
-//! `brew outdated --json=v2` の検出。formulae/casks は同一シェイプなので共通デコードする。
+//! `brew outdated --json=v2` の検出と、`brew info --json=v2` からの上流解決。
 
 use std::process::Command;
 
 use serde::Deserialize;
 
 use super::package::{OutdatedPackage, Source};
+use super::upstream::{Repo, Upstream};
 
 #[derive(Deserialize)]
 struct BrewOutdatedV2 {
@@ -67,9 +68,95 @@ pub fn detect() -> Vec<OutdatedPackage> {
     }
 }
 
+#[derive(Deserialize)]
+struct BrewInfoV2 {
+    #[serde(default)]
+    formulae: Vec<FormulaInfo>,
+    #[serde(default)]
+    casks: Vec<CaskInfo>,
+}
+
+#[derive(Deserialize)]
+struct FormulaInfo {
+    homepage: Option<String>,
+    urls: Option<FormulaUrls>,
+}
+
+#[derive(Deserialize)]
+struct FormulaUrls {
+    stable: Option<FormulaUrl>,
+}
+
+#[derive(Deserialize)]
+struct FormulaUrl {
+    url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CaskInfo {
+    homepage: Option<String>,
+    url: Option<String>,
+}
+
+/// `brew info --json=v2` の stdout から上流を組み立てる。
+///
+/// リポジトリは配布物 URL → homepage の順に GitHub を探す。cask の homepage は製品サイト
+/// （`https://codexbar.app/`）でリポジトリを指さないことが多い一方、配布物 URL は
+/// GitHub リリース資産を直に指すため、配布物 URL を先に見る。
+fn parse_info(raw: &str) -> Upstream {
+    let Ok(info) = serde_json::from_str::<BrewInfoV2>(raw) else {
+        return Upstream::default();
+    };
+
+    let (homepage, download_url) = match (
+        info.formulae.into_iter().next(),
+        info.casks.into_iter().next(),
+    ) {
+        (Some(formula), _) => (
+            formula.homepage,
+            formula
+                .urls
+                .and_then(|urls| urls.stable)
+                .and_then(|stable| stable.url),
+        ),
+        (None, Some(cask)) => (cask.homepage, cask.url),
+        (None, None) => return Upstream::default(),
+    };
+
+    Upstream {
+        repo: download_url
+            .as_deref()
+            .and_then(Repo::from_url)
+            .or_else(|| homepage.as_deref().and_then(Repo::from_url)),
+        homepage,
+    }
+}
+
+/// formula/cask のメタデータから上流を引く。
+///
+/// 実行失敗（未知のパッケージ等）は解決なしとして扱う（呼び出し元は要約なしで続行する）。
+pub fn upstream(name: &str) -> Upstream {
+    let output = match Command::new("brew")
+        .args(["info", "--json=v2", name])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return Upstream::default(),
+    };
+
+    parse_info(&String::from_utf8_lossy(&output.stdout))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn repo(owner: &str, name: &str) -> Option<Repo> {
+        Some(Repo {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
 
     #[test]
     fn parses_formulae_and_casks() {
@@ -119,5 +206,63 @@ mod tests {
     #[test]
     fn invalid_json_is_error() {
         assert!(parse("not json at all").is_err());
+    }
+
+    #[test]
+    fn formula_resolves_repo_from_stable_url() {
+        let raw = r#"{"formulae":[{"homepage":"https://github.com/sharkdp/bat","urls":{"stable":{"url":"https://github.com/sharkdp/bat/archive/refs/tags/v0.26.1.tar.gz"}}}],"casks":[]}"#;
+        let got = parse_info(raw);
+        assert_eq!(got.repo, repo("sharkdp", "bat"));
+        assert_eq!(
+            got.homepage.as_deref(),
+            Some("https://github.com/sharkdp/bat")
+        );
+    }
+
+    #[test]
+    fn cask_resolves_repo_from_download_url_not_product_site() {
+        let raw = r#"{"formulae":[],"casks":[{"homepage":"https://codexbar.app/","url":"https://github.com/steipete/CodexBar/releases/download/v0.45.2/CodexBar-macos-universal-0.45.2.zip"}]}"#;
+        let got = parse_info(raw);
+        assert_eq!(got.repo, repo("steipete", "CodexBar"));
+        assert_eq!(got.homepage.as_deref(), Some("https://codexbar.app/"));
+    }
+
+    #[test]
+    fn falls_back_to_homepage_when_download_url_is_not_github() {
+        let raw = r#"{"formulae":[{"homepage":"https://github.com/owner/repo","urls":{"stable":{"url":"https://mirror.example.com/pkg-1.0.tar.gz"}}}],"casks":[]}"#;
+        assert_eq!(parse_info(raw).repo, repo("owner", "repo"));
+    }
+
+    #[test]
+    fn non_github_upstream_keeps_homepage_without_repo() {
+        let raw = r#"{"formulae":[{"homepage":"https://ffmpeg.org/","urls":{"stable":{"url":"https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz"}}}],"casks":[]}"#;
+        let got = parse_info(raw);
+        assert_eq!(got.repo, None);
+        assert_eq!(got.homepage.as_deref(), Some("https://ffmpeg.org/"));
+    }
+
+    #[test]
+    fn formula_wins_when_a_name_matches_both_kinds() {
+        let raw = r#"{"formulae":[{"homepage":"https://github.com/owner/formula","urls":null}],"casks":[{"homepage":"https://github.com/owner/cask","url":null}]}"#;
+        assert_eq!(parse_info(raw).repo, repo("owner", "formula"));
+    }
+
+    #[test]
+    fn missing_urls_falls_back_to_homepage() {
+        let raw = r#"{"formulae":[{"homepage":"https://github.com/owner/repo"}],"casks":[]}"#;
+        assert_eq!(parse_info(raw).repo, repo("owner", "repo"));
+    }
+
+    #[test]
+    fn empty_info_resolves_nothing() {
+        assert_eq!(
+            parse_info(r#"{"formulae":[],"casks":[]}"#),
+            Upstream::default()
+        );
+    }
+
+    #[test]
+    fn invalid_info_json_resolves_nothing() {
+        assert_eq!(parse_info("not json at all"), Upstream::default());
     }
 }

--- a/src/bin/upkeep/outdated/cargo.rs
+++ b/src/bin/upkeep/outdated/cargo.rs
@@ -1,4 +1,4 @@
-//! `cargo install-update --list` の検出。
+//! `cargo install-update --list` の検出と、crates.io からの上流解決。
 //!
 //! cargo は JSON 非対応なのでテーブル出力をパースする。ヘッダー行（先頭トークンが
 //! `"Package"`）より前に `Polling registry '...'.......` という進捗行が混ざる。
@@ -6,6 +6,8 @@
 use std::process::Command;
 
 use super::package::{OutdatedPackage, Source};
+use super::registry;
+use super::upstream::{Repo, Upstream};
 
 /// 2 個以上の連続空白で分割する。
 ///
@@ -89,6 +91,16 @@ pub fn detect() -> Vec<OutdatedPackage> {
     };
 
     parse(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// crates.io が名指しする `repository` から上流を引く。
+pub fn upstream(name: &str) -> Upstream {
+    Upstream {
+        repo: registry::crates_io(name)
+            .as_deref()
+            .and_then(Repo::from_url),
+        homepage: None,
+    }
 }
 
 #[cfg(test)]

--- a/src/bin/upkeep/outdated/explain.rs
+++ b/src/bin/upkeep/outdated/explain.rs
@@ -1,20 +1,16 @@
-//! `--explain` のリポジトリ解決とリリースノート要約。
+//! `--explain` の解決フロー: 上流の特定 → リリースノート取得 → 要約。
 //!
-//! 機械的にリポジトリを特定できるのは cargo バイナリ（crates.io の `repository` から
-//! GitHub リポジトリを特定できる）だけ。brew（formula/cask）・mise backend は解決を
-//! 試みず、常に [`Explanation::Unavailable`] を返す（過剰な推測はしない）。
-
-use std::process::Command;
-
-use serde::Deserialize;
+//! 上流の特定はパッケージマネージャ自身のメタデータだけを使う（[`super::brew`] /
+//! [`super::mise`] / [`super::cargo`] の `upstream`）。推測や検索はしない。
 
 use super::package::{OutdatedPackage, Source};
+use super::release;
 
 /// 1 パッケージについて `--explain` を試みた結果。
 pub enum Explanation {
-    /// リリースノート本文を機械的に解決できなかった
-    /// （brew/mise は無条件、cargo でも repository 不明・GitHub 以外・本文取得失敗）。
-    Unavailable,
+    /// リリースノート本文を機械的に解決できなかった。`reference_url` は、それでも
+    /// 利用者が一次情報へ辿れるようメタデータから引けた URL。
+    Unavailable { reference_url: Option<String> },
     /// リリースノートは取得できたが claude による要約に失敗した。
     GenerationFailed,
     /// 要約成功。`source_url` は要約元のリリースページ
@@ -22,215 +18,26 @@ pub enum Explanation {
     Summary { text: String, source_url: String },
 }
 
-/// GitHub の1リリース（本文とページ URL）。
-struct ReleaseNotes {
-    body: String,
-    url: String,
-}
-
 /// パッケージのリリースノートを解決し、取得できれば claude で要約する。
-///
-/// cargo 以外は解決を試みず即 [`Explanation::Unavailable`] を返す。
 pub fn resolve(pkg: &OutdatedPackage) -> Explanation {
-    if pkg.source != Source::Cargo {
-        return Explanation::Unavailable;
-    }
-
-    let Some(release) = release_notes_for_cargo_package(&pkg.name) else {
-        return Explanation::Unavailable;
+    let upstream = match pkg.source {
+        Source::Brew => super::brew::upstream(&pkg.name),
+        Source::Mise => super::mise::upstream(&pkg.name),
+        Source::Cargo => super::cargo::upstream(&pkg.name),
     };
 
-    match super::claude::summarize(&release.body) {
+    let notes = upstream.repo.as_ref().and_then(release::fetch);
+    let Some(notes) = notes else {
+        return Explanation::Unavailable {
+            reference_url: upstream.reference_url(),
+        };
+    };
+
+    match super::claude::summarize(&notes.body) {
         Some(text) => Explanation::Summary {
             text,
-            source_url: release.url,
+            source_url: notes.url,
         },
         None => Explanation::GenerationFailed,
-    }
-}
-
-fn release_notes_for_cargo_package(name: &str) -> Option<ReleaseNotes> {
-    let raw = fetch_crate_metadata(name)?;
-    let repo_url = extract_repository_url(&raw)?;
-    let (owner, repo) = parse_owner_repo(&repo_url)?;
-    fetch_release_body(&owner, &repo)
-}
-
-/// crates.io にパッケージのメタデータを問い合わせる。`User-Agent` が無いと 403 になる。
-fn fetch_crate_metadata(name: &str) -> Option<String> {
-    let output = Command::new("curl")
-        .args([
-            "-sS",
-            "-f",
-            "--max-time",
-            "10",
-            "-H",
-            "User-Agent: dotfiles-upkeep (https://github.com/toshiki670/dotfiles)",
-            &format!("https://crates.io/api/v1/crates/{name}"),
-        ])
-        .output()
-        .ok()?;
-
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
-/// GitHub の最新リリース（タグ省略）の本文と URL を取得する。
-///
-/// `current`→`latest` 間に複数リリースがあっても集約はしない
-/// （crates.io のバージョン文字列と GitHub タグの命名規則を機械的に突き合わせる処理は
-/// 信頼できないため。直近の変更として最新リリース1件を要約すれば実用上十分）。
-fn fetch_release_body(owner: &str, repo: &str) -> Option<ReleaseNotes> {
-    let output = Command::new("gh")
-        .args([
-            "release",
-            "view",
-            "--repo",
-            &format!("{owner}/{repo}"),
-            "--json",
-            "body,url",
-        ])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-    parse_release_notes(&String::from_utf8_lossy(&output.stdout))
-}
-
-#[derive(Deserialize)]
-struct GhReleaseView {
-    body: String,
-    url: String,
-}
-
-/// `gh release view --json body,url` の出力から [`ReleaseNotes`] を作る。本文が空なら
-/// 要約する材料が無いので `None` にする。
-fn parse_release_notes(raw: &str) -> Option<ReleaseNotes> {
-    let view: GhReleaseView = serde_json::from_str(raw.trim()).ok()?;
-    let body = view.body.trim().to_string();
-    (!body.is_empty()).then_some(ReleaseNotes {
-        body,
-        url: view.url,
-    })
-}
-
-#[derive(Deserialize)]
-struct CrateResponse {
-    #[serde(rename = "crate")]
-    krate: CrateInfo,
-}
-
-#[derive(Deserialize)]
-struct CrateInfo {
-    repository: Option<String>,
-}
-
-/// crates.io レスポンスから `repository` を取り出す。
-fn extract_repository_url(raw: &str) -> Option<String> {
-    serde_json::from_str::<CrateResponse>(raw)
-        .ok()?
-        .krate
-        .repository
-}
-
-/// `https://github.com/<owner>/<repo>(.git)?(/...)?` から owner/repo を取り出す。
-///
-/// GitHub 以外のホスト（GitLab 等）は `None`（機械的に特定できない扱い）。
-fn parse_owner_repo(url: &str) -> Option<(String, String)> {
-    let rest = url.split("github.com/").nth(1)?;
-    let mut parts = rest.trim_end_matches('/').splitn(3, '/');
-    let owner = parts.next()?.to_string();
-    let repo = parts.next()?.trim_end_matches(".git").to_string();
-    (!owner.is_empty() && !repo.is_empty()).then_some((owner, repo))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn extracts_repository_url() {
-        let raw = r#"{"crate":{"repository":"https://github.com/rustsec/rustsec"}}"#;
-        assert_eq!(
-            extract_repository_url(raw),
-            Some("https://github.com/rustsec/rustsec".to_string())
-        );
-    }
-
-    #[test]
-    fn missing_repository_is_none() {
-        let raw = r#"{"crate":{}}"#;
-        assert_eq!(extract_repository_url(raw), None);
-    }
-
-    #[test]
-    fn null_repository_is_none() {
-        let raw = r#"{"crate":{"repository":null}}"#;
-        assert_eq!(extract_repository_url(raw), None);
-    }
-
-    #[test]
-    fn invalid_json_is_none() {
-        assert_eq!(extract_repository_url("not json"), None);
-    }
-
-    #[test]
-    fn parses_plain_github_url() {
-        assert_eq!(
-            parse_owner_repo("https://github.com/rustsec/rustsec"),
-            Some(("rustsec".to_string(), "rustsec".to_string()))
-        );
-    }
-
-    #[test]
-    fn parses_git_suffixed_url() {
-        assert_eq!(
-            parse_owner_repo("https://github.com/kbknapp/cargo-outdated.git"),
-            Some(("kbknapp".to_string(), "cargo-outdated".to_string()))
-        );
-    }
-
-    #[test]
-    fn parses_monorepo_subpath_url() {
-        assert_eq!(
-            parse_owner_repo("https://github.com/owner/monorepo/tree/main/crates/pkg"),
-            Some(("owner".to_string(), "monorepo".to_string()))
-        );
-    }
-
-    #[test]
-    fn non_github_host_is_none() {
-        assert_eq!(parse_owner_repo("https://gitlab.com/owner/repo"), None);
-    }
-
-    #[test]
-    fn malformed_url_is_none() {
-        assert_eq!(parse_owner_repo("https://github.com/owner-only"), None);
-    }
-
-    #[test]
-    fn parses_release_notes() {
-        let raw = r#"{"body":"What's Changed","url":"https://github.com/rustsec/rustsec/releases/tag/v1.0.0"}"#;
-        let got = parse_release_notes(raw).unwrap();
-        assert_eq!(got.body, "What's Changed");
-        assert_eq!(
-            got.url,
-            "https://github.com/rustsec/rustsec/releases/tag/v1.0.0"
-        );
-    }
-
-    #[test]
-    fn empty_body_is_none() {
-        let raw = r#"{"body":"","url":"https://github.com/rustsec/rustsec/releases/tag/v1.0.0"}"#;
-        assert!(parse_release_notes(raw).is_none());
-    }
-
-    #[test]
-    fn invalid_release_json_is_none() {
-        assert!(parse_release_notes("not json").is_none());
     }
 }

--- a/src/bin/upkeep/outdated/mise.rs
+++ b/src/bin/upkeep/outdated/mise.rs
@@ -1,4 +1,4 @@
-//! `mise outdated --json` の検出。
+//! `mise outdated --json` の検出と、backend からの上流解決。
 //!
 //! `--bump` は付けない: `upkeep upgrade` は `mise upgrade` しか呼ばず、`mise upgrade`
 //! は設定の制約内でしか上げない。`--bump` を付けると「upgrade しても変わらないもの」
@@ -10,6 +10,8 @@ use std::process::Command;
 use serde::Deserialize;
 
 use super::package::{OutdatedPackage, Source};
+use super::registry;
+use super::upstream::{Repo, Upstream};
 
 #[derive(Deserialize)]
 struct MiseEntry {
@@ -56,9 +58,98 @@ pub fn detect() -> Vec<OutdatedPackage> {
     }
 }
 
+/// `core:` backend が指すツールの正典リポジトリ。
+///
+/// `core:` は mise 組み込みの固定集合で、backend 文字列がリポジトリを名指ししないので
+/// ここで対応を持つ。`java`（Adoptium / Zulu 等のビルドを入れる）と `dotnet`（SDK と
+/// ランタイムで別）は指すべきリポジトリが一つに定まらないため持たない。
+const CORE_REPOS: &[(&str, &str)] = &[
+    ("bun", "oven-sh/bun"),
+    ("deno", "denoland/deno"),
+    ("elixir", "elixir-lang/elixir"),
+    ("erlang", "erlang/otp"),
+    ("go", "golang/go"),
+    ("node", "nodejs/node"),
+    ("python", "python/cpython"),
+    ("ruby", "ruby/ruby"),
+    ("rust", "rust-lang/rust"),
+    ("swift", "swiftlang/swift"),
+    ("zig", "ziglang/zig"),
+];
+
+#[derive(Deserialize)]
+struct MiseTool {
+    backend: String,
+}
+
+/// `mise tool <name> --json` の出力から backend 文字列を取り出す。
+fn parse_backend(raw: &str) -> Option<String> {
+    serde_json::from_str::<MiseTool>(raw.trim())
+        .ok()
+        .map(|tool| tool.backend)
+}
+
+/// backend 文字列から上流を引く。
+///
+/// `asdf:` / `vfox:` は対象外にする。これらが名指すのはツール本体ではなく**プラグインの
+/// リポジトリ**（`asdf:luizm/asdf-shfmt`）で、辿ると無関係なリリースノートを要約してしまう。
+/// aqua は第1セグメントにドットを含む形（`aqua:atlassian.com/acli`）が GitHub 以外の
+/// 配布元を指すので除く。
+fn upstream_for_backend(backend: &str) -> Upstream {
+    let Some((kind, spec)) = backend.split_once(':') else {
+        return Upstream::default();
+    };
+
+    let repo = match kind {
+        "aqua" | "github" | "ubi" => Repo::from_slug(spec).filter(|r| !r.owner.contains('.')),
+        "core" => CORE_REPOS
+            .iter()
+            .find(|(tool, _)| *tool == spec)
+            .and_then(|(_, slug)| Repo::from_slug(slug)),
+        "cargo" => registry::crates_io(spec)
+            .as_deref()
+            .and_then(Repo::from_url),
+        "npm" => registry::npm(spec).as_deref().and_then(repo_from_npm),
+        _ => None,
+    };
+
+    Upstream {
+        repo,
+        homepage: None,
+    }
+}
+
+/// npm の `repository` は URL 形と `github:<owner>/<repo>` の短縮形の両方が使われる。
+fn repo_from_npm(url: &str) -> Option<Repo> {
+    Repo::from_url(url).or_else(|| Repo::from_slug(url.strip_prefix("github:")?))
+}
+
+/// インストール済みツールの backend から上流を引く。
+///
+/// 実行失敗（レジストリに無いツール等）は解決なしとして扱う。候補を複数返す
+/// `mise registry` ではなく `mise tool` を使う: インストール済みの backend が一つに定まる。
+pub fn upstream(name: &str) -> Upstream {
+    let output = match Command::new("mise").args(["tool", name, "--json"]).output() {
+        Ok(output) if output.status.success() => output,
+        _ => return Upstream::default(),
+    };
+
+    parse_backend(&String::from_utf8_lossy(&output.stdout))
+        .as_deref()
+        .map(upstream_for_backend)
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn repo(owner: &str, name: &str) -> Option<Repo> {
+        Some(Repo {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
 
     #[test]
     fn parses_single_entry() {
@@ -90,5 +181,97 @@ mod tests {
     #[test]
     fn invalid_json_is_error() {
         assert!(parse("not json at all").is_err());
+    }
+
+    #[test]
+    fn extracts_backend() {
+        let raw = r#"{"backend":"aqua:jqlang/jq","description":"Command-line JSON processor"}"#;
+        assert_eq!(parse_backend(raw).as_deref(), Some("aqua:jqlang/jq"));
+    }
+
+    #[test]
+    fn missing_backend_is_none() {
+        assert_eq!(parse_backend(r#"{"description":"x"}"#), None);
+    }
+
+    #[test]
+    fn invalid_tool_json_is_none() {
+        assert_eq!(parse_backend("not json at all"), None);
+    }
+
+    #[test]
+    fn aqua_backend_resolves_repo() {
+        assert_eq!(
+            upstream_for_backend("aqua:jqlang/jq").repo,
+            repo("jqlang", "jq")
+        );
+    }
+
+    #[test]
+    fn github_backend_resolves_repo() {
+        assert_eq!(
+            upstream_for_backend("github:rvben/rumdl").repo,
+            repo("rvben", "rumdl")
+        );
+    }
+
+    #[test]
+    fn aqua_domain_form_is_not_github() {
+        assert_eq!(upstream_for_backend("aqua:atlassian.com/acli").repo, None);
+    }
+
+    #[test]
+    fn core_backend_resolves_mapped_repo() {
+        assert_eq!(
+            upstream_for_backend("core:node").repo,
+            repo("nodejs", "node")
+        );
+    }
+
+    #[test]
+    fn core_backend_without_canonical_repo_resolves_nothing() {
+        assert_eq!(upstream_for_backend("core:java").repo, None);
+        assert_eq!(upstream_for_backend("core:dotnet").repo, None);
+    }
+
+    #[test]
+    fn plugin_backends_are_skipped() {
+        // プラグインのリポジトリであってツール本体ではない。
+        assert_eq!(upstream_for_backend("asdf:luizm/asdf-shfmt").repo, None);
+        assert_eq!(
+            upstream_for_backend("vfox:mise-plugins/vfox-1password").repo,
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_backend_resolves_nothing() {
+        assert_eq!(upstream_for_backend("conda:numpy").repo, None);
+    }
+
+    #[test]
+    fn backend_without_separator_resolves_nothing() {
+        assert_eq!(upstream_for_backend("bogus").repo, None);
+    }
+
+    #[test]
+    fn npm_repository_url_form() {
+        assert_eq!(
+            repo_from_npm("git+https://github.com/textlint/textlint.git"),
+            repo("textlint", "textlint")
+        );
+    }
+
+    #[test]
+    fn npm_repository_shorthand_form() {
+        assert_eq!(
+            repo_from_npm("github:sindresorhus/got"),
+            repo("sindresorhus", "got")
+        );
+    }
+
+    #[test]
+    fn npm_repository_on_other_host_is_none() {
+        assert_eq!(repo_from_npm("https://gitlab.com/owner/repo"), None);
     }
 }

--- a/src/bin/upkeep/outdated/mod.rs
+++ b/src/bin/upkeep/outdated/mod.rs
@@ -1,7 +1,7 @@
 //! `outdated`: brew / mise / cargo でアップデート可能なパッケージを一覧表示する。
 //!
 //! `--explain` は取得できたリリースノートを [`claude::summarize`] で日本語要約する。
-//! 解決できる対象の範囲は [`explain::resolve`] を参照。
+//! 解決の流れは [`explain::resolve`] を参照。
 
 mod brew;
 mod cargo;
@@ -9,7 +9,10 @@ mod claude;
 mod explain;
 mod mise;
 mod package;
+mod registry;
+mod release;
 mod render;
+mod upstream;
 
 use super::banner::header;
 use super::command::command_exists;

--- a/src/bin/upkeep/outdated/registry.rs
+++ b/src/bin/upkeep/outdated/registry.rs
@@ -1,0 +1,131 @@
+//! パッケージレジストリへの `repository` 問い合わせ。
+
+use std::process::Command;
+
+use serde::Deserialize;
+
+/// crates.io がパッケージの `repository` として名指しする URL。
+pub fn crates_io(name: &str) -> Option<String> {
+    let raw = fetch(&format!("https://crates.io/api/v1/crates/{name}"))?;
+    parse_crates_io(&raw)
+}
+
+/// npm registry がパッケージの `repository.url` として名指しする URL。
+pub fn npm(name: &str) -> Option<String> {
+    let raw = fetch(&format!("https://registry.npmjs.org/{name}"))?;
+    parse_npm(&raw)
+}
+
+/// `User-Agent` が無いと crates.io が 403 を返すので必ず付ける。
+fn fetch(url: &str) -> Option<String> {
+    let output = Command::new("curl")
+        .args([
+            "-sS",
+            "-f",
+            "--max-time",
+            "10",
+            "-H",
+            "User-Agent: dotfiles-upkeep (https://github.com/toshiki670/dotfiles)",
+            url,
+        ])
+        .output()
+        .ok()?;
+
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[derive(Deserialize)]
+struct CrateResponse {
+    #[serde(rename = "crate")]
+    krate: CrateInfo,
+}
+
+#[derive(Deserialize)]
+struct CrateInfo {
+    repository: Option<String>,
+}
+
+fn parse_crates_io(raw: &str) -> Option<String> {
+    serde_json::from_str::<CrateResponse>(raw)
+        .ok()?
+        .krate
+        .repository
+}
+
+#[derive(Deserialize)]
+struct NpmResponse {
+    repository: Option<NpmRepository>,
+}
+
+/// npm の `repository` はオブジェクト形と短縮文字列形の両方が使われる。
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum NpmRepository {
+    Object { url: String },
+    Shorthand(String),
+}
+
+fn parse_npm(raw: &str) -> Option<String> {
+    match serde_json::from_str::<NpmResponse>(raw).ok()?.repository? {
+        NpmRepository::Object { url } => Some(url),
+        NpmRepository::Shorthand(url) => Some(url),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_crates_io_repository() {
+        let raw = r#"{"crate":{"repository":"https://github.com/rustsec/rustsec"}}"#;
+        assert_eq!(
+            parse_crates_io(raw),
+            Some("https://github.com/rustsec/rustsec".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_crates_io_repository_is_none() {
+        assert_eq!(parse_crates_io(r#"{"crate":{}}"#), None);
+    }
+
+    #[test]
+    fn null_crates_io_repository_is_none() {
+        assert_eq!(parse_crates_io(r#"{"crate":{"repository":null}}"#), None);
+    }
+
+    #[test]
+    fn invalid_crates_io_json_is_none() {
+        assert_eq!(parse_crates_io("not json"), None);
+    }
+
+    #[test]
+    fn extracts_npm_repository_object() {
+        let raw =
+            r#"{"repository":{"type":"git","url":"git+https://github.com/textlint/textlint.git"}}"#;
+        assert_eq!(
+            parse_npm(raw),
+            Some("git+https://github.com/textlint/textlint.git".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_npm_repository_shorthand() {
+        let raw = r#"{"repository":"github:sindresorhus/got"}"#;
+        assert_eq!(parse_npm(raw), Some("github:sindresorhus/got".to_string()));
+    }
+
+    #[test]
+    fn missing_npm_repository_is_none() {
+        assert_eq!(parse_npm(r#"{"name":"x"}"#), None);
+    }
+
+    #[test]
+    fn invalid_npm_json_is_none() {
+        assert_eq!(parse_npm("not json"), None);
+    }
+}

--- a/src/bin/upkeep/outdated/release.rs
+++ b/src/bin/upkeep/outdated/release.rs
@@ -1,0 +1,88 @@
+//! GitHub リリースノートの取得。
+
+use std::process::Command;
+
+use serde::Deserialize;
+
+use super::upstream::Repo;
+
+/// GitHub の1リリース（本文とページ URL）。
+pub struct ReleaseNotes {
+    pub body: String,
+    pub url: String,
+}
+
+/// 最新リリース（タグ省略）の本文と URL を取得する。
+///
+/// `current`→`latest` 間に複数リリースがあっても集約はしない
+/// （パッケージマネージャのバージョン文字列と GitHub タグの命名規則を機械的に突き合わせる
+/// 処理は信頼できないため。直近の変更として最新リリース1件を要約すれば実用上十分）。
+pub fn fetch(repo: &Repo) -> Option<ReleaseNotes> {
+    let output = Command::new("gh")
+        .args([
+            "release",
+            "view",
+            "--repo",
+            &repo.slug(),
+            "--json",
+            "body,url",
+        ])
+        .output()
+        .ok()?;
+
+    output
+        .status
+        .success()
+        .then(|| parse(&String::from_utf8_lossy(&output.stdout)))
+        .flatten()
+}
+
+#[derive(Deserialize)]
+struct GhReleaseView {
+    body: String,
+    url: String,
+}
+
+/// `gh release view --json body,url` の出力から [`ReleaseNotes`] を作る。本文が空なら
+/// 要約する材料が無いので `None` にする。
+fn parse(raw: &str) -> Option<ReleaseNotes> {
+    let view: GhReleaseView = serde_json::from_str(raw.trim()).ok()?;
+    let body = view.body.trim().to_string();
+    (!body.is_empty()).then_some(ReleaseNotes {
+        body,
+        url: view.url,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_release_notes() {
+        let raw = r#"{"body":"What's Changed","url":"https://github.com/rustsec/rustsec/releases/tag/v1.0.0"}"#;
+        let got = parse(raw).unwrap();
+        assert_eq!(got.body, "What's Changed");
+        assert_eq!(
+            got.url,
+            "https://github.com/rustsec/rustsec/releases/tag/v1.0.0"
+        );
+    }
+
+    #[test]
+    fn empty_body_is_none() {
+        let raw = r#"{"body":"","url":"https://github.com/rustsec/rustsec/releases/tag/v1.0.0"}"#;
+        assert!(parse(raw).is_none());
+    }
+
+    #[test]
+    fn whitespace_only_body_is_none() {
+        let raw = r#"{"body":"  \n ","url":"https://github.com/x/y/releases/tag/v1"}"#;
+        assert!(parse(raw).is_none());
+    }
+
+    #[test]
+    fn invalid_release_json_is_none() {
+        assert!(parse("not json").is_none());
+    }
+}

--- a/src/bin/upkeep/outdated/render.rs
+++ b/src/bin/upkeep/outdated/render.rs
@@ -18,7 +18,10 @@ pub fn format_package_line(pkg: &OutdatedPackage, explanation: Option<&Explanati
         Some(Explanation::Summary { text, source_url }) => {
             format!("{base}\n    要約: {text}\n    出典: {source_url}")
         }
-        Some(Explanation::Unavailable) => format!("{base}\n    変更内容不明"),
+        Some(Explanation::Unavailable { reference_url }) => match reference_url {
+            Some(url) => format!("{base}\n    変更内容不明\n    参考: {url}"),
+            None => format!("{base}\n    変更内容不明"),
+        },
         Some(Explanation::GenerationFailed) => format!("{base}\n    要約失敗（claude 生成エラー）"),
     }
 }
@@ -59,8 +62,23 @@ mod tests {
     }
 
     #[test]
-    fn with_unavailable() {
-        let got = format_package_line(&sample(), Some(&Explanation::Unavailable));
+    fn with_unavailable_and_reference() {
+        let explanation = Explanation::Unavailable {
+            reference_url: Some("https://ghostty.org/".into()),
+        };
+        let got = format_package_line(&sample(), Some(&explanation));
+        assert_eq!(
+            got,
+            "[brew] bat: 0.24.0 -> 0.25.0\n    変更内容不明\n    参考: https://ghostty.org/"
+        );
+    }
+
+    #[test]
+    fn with_unavailable_and_no_reference() {
+        let explanation = Explanation::Unavailable {
+            reference_url: None,
+        };
+        let got = format_package_line(&sample(), Some(&explanation));
         assert_eq!(got, "[brew] bat: 0.24.0 -> 0.25.0\n    変更内容不明");
     }
 

--- a/src/bin/upkeep/outdated/upstream.rs
+++ b/src/bin/upkeep/outdated/upstream.rs
@@ -1,0 +1,174 @@
+//! パッケージの上流（リリースノートの所在）。
+//!
+//! リポジトリと配布元が名指しするページは独立に取れる。aqua backend のようにリポジトリ
+//! しか分からないものも、GNU 系 formula のようにページしか分からないものもある。
+
+/// GitHub の1リポジトリ。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Repo {
+    pub owner: String,
+    pub name: String,
+}
+
+impl Repo {
+    /// `<owner>/<name>` を分解して作る。どちらかが空なら `None`。
+    pub fn from_slug(slug: &str) -> Option<Self> {
+        let (owner, name) = slug.trim_end_matches('/').split_once('/')?;
+        let name = name.split('/').next()?;
+        (!owner.is_empty() && !name.is_empty()).then(|| Repo {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
+
+    /// `github.com/<owner>/<name>` を含む URL から作る。`.git` 接尾とそれ以降のパスは
+    /// 落とす。GitHub 以外のホストは `None`。
+    pub fn from_url(url: &str) -> Option<Self> {
+        let slug = url.split("github.com/").nth(1)?;
+        let mut repo = Self::from_slug(slug)?;
+        repo.name = repo.name.trim_end_matches(".git").to_string();
+        (!repo.name.is_empty()).then_some(repo)
+    }
+
+    pub fn slug(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+
+    pub fn url(&self) -> String {
+        format!("https://github.com/{}", self.slug())
+    }
+}
+
+/// パッケージマネージャのメタデータから引けた上流。
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Upstream {
+    /// リリースノートを取りに行ける GitHub リポジトリ。
+    pub repo: Option<Repo>,
+    /// 配布元が名指ししたプロジェクトページ。
+    pub homepage: Option<String>,
+}
+
+impl Upstream {
+    /// 要約を出せなかったときに利用者へ示す URL。
+    ///
+    /// 配布元が名指しした `homepage` を優先する。リポジトリのページはこちらで組み立てた
+    /// ものなので、名指しされた URL がある限りそちらを立てる。
+    pub fn reference_url(&self) -> Option<String> {
+        self.homepage
+            .clone()
+            .or_else(|| self.repo.as_ref().map(Repo::url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo(owner: &str, name: &str) -> Repo {
+        Repo {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_plain_github_url() {
+        assert_eq!(
+            Repo::from_url("https://github.com/rustsec/rustsec"),
+            Some(repo("rustsec", "rustsec"))
+        );
+    }
+
+    #[test]
+    fn parses_git_suffixed_url() {
+        assert_eq!(
+            Repo::from_url("https://github.com/kbknapp/cargo-outdated.git"),
+            Some(repo("kbknapp", "cargo-outdated"))
+        );
+    }
+
+    #[test]
+    fn parses_npm_git_prefixed_url() {
+        assert_eq!(
+            Repo::from_url("git+https://github.com/textlint/textlint.git"),
+            Some(repo("textlint", "textlint"))
+        );
+    }
+
+    #[test]
+    fn parses_monorepo_subpath_url() {
+        assert_eq!(
+            Repo::from_url("https://github.com/owner/monorepo/tree/main/crates/pkg"),
+            Some(repo("owner", "monorepo"))
+        );
+    }
+
+    #[test]
+    fn parses_release_asset_url() {
+        assert_eq!(
+            Repo::from_url(
+                "https://github.com/steipete/CodexBar/releases/download/v0.45.2/CodexBar.zip"
+            ),
+            Some(repo("steipete", "CodexBar"))
+        );
+    }
+
+    #[test]
+    fn non_github_host_is_none() {
+        assert_eq!(Repo::from_url("https://gitlab.com/owner/repo"), None);
+    }
+
+    #[test]
+    fn malformed_url_is_none() {
+        assert_eq!(Repo::from_url("https://github.com/owner-only"), None);
+    }
+
+    #[test]
+    fn bare_git_suffix_is_none() {
+        assert_eq!(Repo::from_url("https://github.com/owner/.git"), None);
+    }
+
+    #[test]
+    fn parses_slug() {
+        assert_eq!(Repo::from_slug("jqlang/jq"), Some(repo("jqlang", "jq")));
+    }
+
+    #[test]
+    fn slug_without_separator_is_none() {
+        assert_eq!(Repo::from_slug("acli"), None);
+    }
+
+    #[test]
+    fn builds_repo_url() {
+        assert_eq!(repo("jqlang", "jq").url(), "https://github.com/jqlang/jq");
+    }
+
+    #[test]
+    fn reference_url_prefers_named_homepage() {
+        let upstream = Upstream {
+            repo: Some(repo("steipete", "CodexBar")),
+            homepage: Some("https://codexbar.app/".to_string()),
+        };
+        assert_eq!(
+            upstream.reference_url(),
+            Some("https://codexbar.app/".to_string())
+        );
+    }
+
+    #[test]
+    fn reference_url_falls_back_to_repo_page() {
+        let upstream = Upstream {
+            repo: Some(repo("jqlang", "jq")),
+            homepage: None,
+        };
+        assert_eq!(
+            upstream.reference_url(),
+            Some("https://github.com/jqlang/jq".to_string())
+        );
+    }
+
+    #[test]
+    fn reference_url_is_none_when_nothing_resolved() {
+        assert_eq!(Upstream::default().reference_url(), None);
+    }
+}

--- a/tests/upkeep/mod.rs
+++ b/tests/upkeep/mod.rs
@@ -59,3 +59,16 @@ pub(crate) fn write_stubs(bin: &Path, names: &[&str]) {
 pub(crate) fn stdout_stub_body(env_var: &str) -> String {
     format!("#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' \"${env_var}\"\n")
 }
+
+/// 第1引数（サブコマンド）で分岐して、対応する環境変数の中身を stdout に出すスタブ本体。
+///
+/// `brew outdated` と `brew info`、`mise outdated` と `mise tool` のように、同じコマンドが
+/// 引数違いで複数回呼ばれるものを1つのスタブで賄う。どの分岐にも一致しない呼び出しは
+/// exit 1 にして、テストが意図しない引数で呼んでいることに気づけるようにする。
+pub(crate) fn dispatch_stub_body(cases: &[(&str, &str)]) -> String {
+    let arms: String = cases
+        .iter()
+        .map(|(subcommand, env_var)| format!("  {subcommand}) printf '%s\\n' \"${env_var}\" ;;\n"))
+        .collect();
+    format!("#!/bin/sh\ncat >/dev/null\ncase \"$1\" in\n{arms}  *) exit 1 ;;\nesac\n")
+}

--- a/tests/upkeep/outdated.rs
+++ b/tests/upkeep/outdated.rs
@@ -11,10 +11,14 @@ use predicates::prelude::*;
 use rstest::rstest;
 use tempfile::TempDir;
 
-use crate::{EMPTY_PATH, stdout_stub_body, stub_body, write_exec};
+use crate::{EMPTY_PATH, dispatch_stub_body, stdout_stub_body, stub_body, write_exec};
 
 const BREW_JSON: &str = r#"{"formulae":[{"name":"bat","installed_versions":["0.24.0"],"current_version":"0.25.0","pinned":false,"pinned_version":null}],"casks":[]}"#;
 const MISE_JSON: &str = r#"{"jq":{"name":"jq","requested":"1.6","current":"1.6","bump":"1.8","latest":"1.8.2","source":{"type":"mise.toml","path":"/tmp/mise.toml"}}}"#;
+const BREW_INFO_JSON: &str = r#"{"formulae":[{"homepage":"https://github.com/sharkdp/bat","urls":{"stable":{"url":"https://github.com/sharkdp/bat/archive/refs/tags/v0.26.1.tar.gz"}}}],"casks":[]}"#;
+const BREW_INFO_NON_GITHUB_JSON: &str = r#"{"formulae":[{"homepage":"https://ffmpeg.org/","urls":{"stable":{"url":"https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz"}}}],"casks":[]}"#;
+const MISE_TOOL_AQUA_JSON: &str = r#"{"backend":"aqua:jqlang/jq"}"#;
+const MISE_TOOL_PLUGIN_JSON: &str = r#"{"backend":"asdf:mise-plugins/asdf-jq"}"#;
 const CARGO_TABLE: &str =
     "Package      Installed  Latest   Needs update\ncargo-audit  v0.17.0    v0.18.0  Yes";
 const CRATES_IO_JSON: &str = r#"{"crate":{"repository":"https://github.com/rustsec/rustsec"}}"#;
@@ -46,6 +50,12 @@ impl Fixture {
     /// `name` を、環境変数 `env_var` の中身をそのまま返すスタブとして置く。
     fn stub_stdout(&self, name: &str, env_var: &str) -> &Self {
         write_exec(&self.bin, name, &stdout_stub_body(env_var));
+        self
+    }
+
+    /// `name` を、サブコマンドで返す環境変数を切り替えるスタブとして置く。
+    fn stub_dispatch(&self, name: &str, cases: &[(&str, &str)]) -> &Self {
+        write_exec(&self.bin, name, &dispatch_stub_body(cases));
         self
     }
 
@@ -83,7 +93,7 @@ fn no_updates_available() {
 #[test]
 fn lists_brew_only() {
     let fx = fixture();
-    fx.stub_stdout("brew", "BREW_JSON");
+    fx.stub_dispatch("brew", &[("outdated", "BREW_JSON")]);
 
     outdated()
         .env("PATH", &fx.bin)
@@ -96,7 +106,7 @@ fn lists_brew_only() {
 #[test]
 fn lists_mise_only() {
     let fx = fixture();
-    fx.stub_stdout("mise", "MISE_JSON");
+    fx.stub_dispatch("mise", &[("outdated", "MISE_JSON")]);
 
     outdated()
         .env("PATH", &fx.bin)
@@ -140,8 +150,8 @@ fn skips_cargo_when_install_update_missing() {
 #[test]
 fn lists_all_three_sources() {
     let fx = fixture();
-    fx.stub_stdout("brew", "BREW_JSON")
-        .stub_stdout("mise", "MISE_JSON")
+    fx.stub_dispatch("brew", &[("outdated", "BREW_JSON")])
+        .stub_dispatch("mise", &[("outdated", "MISE_JSON")])
         .cargo_stub();
 
     outdated()
@@ -159,7 +169,7 @@ fn lists_all_three_sources() {
 #[test]
 fn explain_without_claude_warns_and_falls_back() {
     let fx = fixture();
-    fx.stub_stdout("brew", "BREW_JSON");
+    fx.stub_dispatch("brew", &[("outdated", "BREW_JSON")]);
     // claude を置かない。
 
     outdated()
@@ -197,19 +207,116 @@ fn explain_summarizes_cargo_package() {
 }
 
 #[test]
-fn explain_shows_unavailable_for_non_cargo_source() {
+fn explain_summarizes_brew_package() {
     let fx = fixture();
-    fx.stub_stdout("brew", "BREW_JSON")
-        .stub_stdout("claude", "CLAUDE_JSON");
+    fx.stub_dispatch(
+        "brew",
+        &[("outdated", "BREW_JSON"), ("info", "BREW_INFO_JSON")],
+    )
+    .stub_stdout("gh", "GH_RELEASE_JSON")
+    .stub_stdout("claude", "CLAUDE_JSON");
 
     outdated()
         .arg("--explain")
         .env("PATH", &fx.bin)
         .env("BREW_JSON", BREW_JSON)
+        .env("BREW_INFO_JSON", BREW_INFO_JSON)
+        .env("GH_RELEASE_JSON", GH_RELEASE_JSON)
         .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
         .assert()
         .success()
-        .stdout(predicate::str::contains("変更内容不明"));
+        .stdout(predicate::str::contains("[brew] bat: 0.24.0 -> 0.25.0"))
+        .stdout(predicate::str::contains("要約: 新機能Xを追加"));
+}
+
+#[test]
+fn explain_summarizes_mise_tool_via_backend() {
+    let fx = fixture();
+    fx.stub_dispatch(
+        "mise",
+        &[("outdated", "MISE_JSON"), ("tool", "MISE_TOOL_JSON")],
+    )
+    .stub_stdout("gh", "GH_RELEASE_JSON")
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("MISE_JSON", MISE_JSON)
+        .env("MISE_TOOL_JSON", MISE_TOOL_AQUA_JSON)
+        .env("GH_RELEASE_JSON", GH_RELEASE_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[mise] jq: 1.6 -> 1.8.2"))
+        .stdout(predicate::str::contains("要約: 新機能Xを追加"));
+}
+
+#[test]
+fn explain_shows_homepage_when_upstream_is_not_github() {
+    let fx = fixture();
+    fx.stub_dispatch(
+        "brew",
+        &[("outdated", "BREW_JSON"), ("info", "BREW_INFO_JSON")],
+    )
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("BREW_JSON", BREW_JSON)
+        .env("BREW_INFO_JSON", BREW_INFO_NON_GITHUB_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("変更内容不明"))
+        .stdout(predicate::str::contains("参考: https://ffmpeg.org/"));
+}
+
+#[test]
+fn explain_shows_bare_unavailable_when_backend_is_out_of_scope() {
+    let fx = fixture();
+    // asdf backend が名指すのはプラグインであってツール本体ではないので解決しない。
+    fx.stub_dispatch(
+        "mise",
+        &[("outdated", "MISE_JSON"), ("tool", "MISE_TOOL_JSON")],
+    )
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("MISE_JSON", MISE_JSON)
+        .env("MISE_TOOL_JSON", MISE_TOOL_PLUGIN_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("変更内容不明"))
+        .stdout(predicate::str::contains("参考:").not());
+}
+
+#[test]
+fn explain_shows_repo_page_when_release_is_missing() {
+    let fx = fixture();
+    fx.stub_dispatch(
+        "mise",
+        &[("outdated", "MISE_JSON"), ("tool", "MISE_TOOL_JSON")],
+    )
+    .stub("gh", FAILING_STUB)
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("MISE_JSON", MISE_JSON)
+        .env("MISE_TOOL_JSON", MISE_TOOL_AQUA_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("変更内容不明"))
+        .stdout(predicate::str::contains(
+            "参考: https://github.com/jqlang/jq",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`upkeep outdated --explain` のリリースノート解決を、cargo バイナリだけでなく brew と mise の
メタデータからも引くようにする。取得先は配布元が名指しした URL に限り、推測も検索もしない。

- **brew**: `brew info --json=v2` の配布物 URL → homepage の順に GitHub を探す。cask の
  homepage は製品サイト（`https://codexbar.app/`）でリポジトリを指さないことが多い一方、
  配布物 URL は GitHub のリリース資産を直に指すため、配布物 URL を先に見る。
- **mise**: `mise tool --json` の `backend` で分岐する（`aqua:` / `github:` / `ubi:` /
  `cargo:` / `npm:` / `core:`）。候補を複数返す `mise registry` ではなくインストール済みの
  backend が一つに定まる `mise tool` を使う。`asdf:` / `vfox:` が名指すのはプラグインの
  リポジトリであってツール本体ではないので対象外にする。`core:` は正典リポジトリが一つに
  定まる11ツールの写像を持つ（`java` は Adoptium / Zulu 等のビルド、`dotnet` は SDK と
  ランタイムで定まらないため持たない）。
- **解決できなかった対象**: 「変更内容不明」に参考 URL を併記する。配布元が名指しした
  homepage を、こちらで組み立てたリポジトリ URL より優先する。

`explain.rs` は上流特定 → リリース取得 → 要約のオーケストレーションだけに絞った（231行 →
43行）。GitHub リポジトリ型を `upstream.rs`、`gh release view` を `release.rs`、crates.io /
npm registry への問い合わせを `registry.rs` へ切り出し、PM 固有の解決は各 PM のモジュールが
持つ。

`brew info` はパッケージ単位で呼ぶ。複数名を1回で受け付ける形もあるが、`--explain` の所要
時間は `claude -p` が支配するため呼び出し回数の削減は効かない。

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --all-targets -- -D warnings` /
  `cargo nextest run`（395件）/ `cargo doc --no-deps --bin upkeep --document-private-items`
  すべてグリーン
- [x] ユニットテスト: brew info の formula/cask 解析（配布物 URL 優先・homepage フォール
  バック・非 GitHub 上流・同名の formula と cask）、mise の backend 分岐（aqua のドメイン形
  除外・プラグイン backend 除外・`core:` 写像・未知 backend）、npm `repository` の2形式、
  GitHub URL 解析（`git+https://`・リリース資産・`.git` 接尾・monorepo サブパス）、参考 URL
  の優先順位
- [x] E2E: brew / mise 経由の要約成功、非 GitHub 上流での homepage 併記、対象外 backend での
  参考 URL 無し、Release 取得失敗時のリポジトリページ併記。同じコマンドが引数違いで複数回
  呼ばれる（`brew outdated` と `brew info`、`mise outdated` と `mise tool`）ため、第1引数で
  分岐するスタブを追加した
- [x] 実データ: brew 8件のうち6件が要約され、リポジトリは解決できたが GitHub Releases が無い
  `certifi` と `luajit` は参考 URL へ落ちた（変更前は8件すべて「変更内容不明」）。`luajit` は
  組み立てたリポジトリ URL ではなく名指しされた `luajit.org` が出ることも確認。mise は該当が
  無かったため `jq = "1"` を固定した一時 `mise.toml` で走らせ、`mise outdated` のキーが
  `mise tool` にそのまま通り `aqua:jqlang/jq` 経由で要約されることを確認

## 既知の問題

要約の中身が「〜を要約した」というメタ報告になる（#672）。`claude.rs` は本 PR で触っておらず
既存の欠陥だが、要約対象が cargo だけだったこれまでは露出が小さく、本 PR で見えるようになった。

Closes #671
