### PR TITLE
fix(upkeep): outdated --explain の要約が行為の報告になるのを直す

### DIFF
--- a/src/bin/upkeep/outdated/claude.rs
+++ b/src/bin/upkeep/outdated/claude.rs
@@ -1,9 +1,15 @@
 //! `--explain` 用の `claude -p` 要約呼び出し。
 //!
-//! モデルは `sonnet` 固定にする。`--explain` は opt-in かつ対象は「更新可能な cargo
-//! パッケージ」のみ（呼び出し頻度が低くコスト差は無視できる）である一方、要約はアップ
-//! グレードして安全かを判断する材料になるため、breaking change 等の見落としの実害が
-//! ある。この条件では低コストより要約精度を優先する。
+//! モデルは `sonnet` 固定にする。`--explain` は opt-in かつ対象は更新可能なパッケージ
+//! だけ（呼び出し頻度が低くコスト差は無視できる）である一方、要約はアップグレードして
+//! 安全かを判断する材料になるため、breaking change 等の見落としの実害がある。この条件
+//! では低コストより要約精度を優先する。
+//!
+//! 素朴に呼ぶと、リリースノートの中身ではなく「要約して回答した」という行為の報告が返る
+//! （同一入力の10試行で8件。毎回ではないので1回の実行では判定できない）。出力フィールドを
+//! 成果物で名指しする・`--tools` を空にする・`--safe-mode` で `~/.claude` とプロジェクト
+//! 設定の注入を止める、の3つがそれぞれ単独でほぼ抑えるので重ねてある。3つ目は要約を
+//! 呼び出し元の設定から切り離す意味もあり、入力トークンも半分になる。
 
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -21,8 +27,7 @@ Even if the text is a single terse line (e.g. one commit-message-like sentence),
 summarize that line as-is; do not refuse or comment on its format.";
 
 /// 構造化出力を強制するスキーマ。
-const OUTPUT_SCHEMA: &str =
-    r#"{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}"#;
+const OUTPUT_SCHEMA: &str = r#"{"type":"object","properties":{"release_notes_ja":{"type":"string"}},"required":["release_notes_ja"]}"#;
 
 /// リリースノート本文を claude -p で日本語要約する。
 ///
@@ -40,6 +45,9 @@ pub fn summarize(release_notes: &str) -> Option<String> {
             OUTPUT_SCHEMA,
             "--output-format",
             "json",
+            "--safe-mode",
+            "--tools",
+            "",
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -76,7 +84,7 @@ pub fn summarize(release_notes: &str) -> Option<String> {
     }
 }
 
-/// `--output-format json` の結果 envelope。`summary` フィールドだけ拾う。
+/// `--output-format json` の結果 envelope。要約本文だけ拾う。
 #[derive(Deserialize)]
 struct Envelope {
     is_error: bool,
@@ -88,7 +96,7 @@ struct Envelope {
 
 #[derive(Deserialize)]
 struct StructuredOutput {
-    summary: String,
+    release_notes_ja: String,
 }
 
 /// claude の envelope から要約テキストを取り出す。
@@ -106,7 +114,7 @@ fn parse_summary(raw: &str) -> Result<String, String> {
 
     envelope
         .structured_output
-        .map(|output| output.summary)
+        .map(|output| output.release_notes_ja)
         .ok_or_else(|| "missing structured_output".to_string())
 }
 
@@ -116,7 +124,7 @@ mod tests {
 
     #[test]
     fn parses_success_envelope() {
-        let raw = r#"{"type":"result","is_error":false,"structured_output":{"summary":"新機能Xを追加、バグYを修正"}}"#;
+        let raw = r#"{"type":"result","is_error":false,"structured_output":{"release_notes_ja":"新機能Xを追加、バグYを修正"}}"#;
         assert_eq!(parse_summary(raw).unwrap(), "新機能Xを追加、バグYを修正");
     }
 

--- a/src/bin/upkeep/outdated/mod.rs
+++ b/src/bin/upkeep/outdated/mod.rs
@@ -44,9 +44,14 @@ pub fn run(explain: bool) {
         eprintln!("⚠️  claude コマンドが見つかりません。要約なしで一覧のみ表示します。");
     }
 
-    for pkg in &packages {
+    for (i, pkg) in packages.iter().enumerate() {
         let explanation = attempt_explain.then(|| explain::resolve(pkg));
-        println!("{}", render::format_package_line(pkg, explanation.as_ref()));
+        let block = render::format_package_line(pkg, explanation.as_ref());
+        // 解説付きは1件が複数行になる。空行を挟まないとどこまでが1パッケージか読めない。
+        if attempt_explain && i > 0 {
+            println!();
+        }
+        println!("{block}");
     }
 
     header("Done");

--- a/src/bin/upkeep/outdated/render.rs
+++ b/src/bin/upkeep/outdated/render.rs
@@ -3,6 +3,24 @@
 use super::explain::Explanation;
 use super::package::OutdatedPackage;
 
+/// パッケージ行にぶら下がる解説の字下げ。
+const INDENT: &str = "    ";
+
+/// 要約本文の2行目以降を1行目と同じ深さへ揃える。カラム 0 に来るのをパッケージ行だけに
+/// 保つため（空行には余白を残さない）。
+fn align(text: &str) -> String {
+    let mut lines = text.split('\n');
+    let mut out = lines.next().unwrap_or_default().to_string();
+    for line in lines {
+        out.push('\n');
+        if !line.trim().is_empty() {
+            out.push_str(INDENT);
+            out.push_str(line);
+        }
+    }
+    out
+}
+
 /// `[source] name: current -> latest` の1行。`--explain` 時は解説を続く行に足す。
 pub fn format_package_line(pkg: &OutdatedPackage, explanation: Option<&Explanation>) -> String {
     let base = format!(
@@ -16,13 +34,16 @@ pub fn format_package_line(pkg: &OutdatedPackage, explanation: Option<&Explanati
     match explanation {
         None => base,
         Some(Explanation::Summary { text, source_url }) => {
-            format!("{base}\n    要約: {text}\n    出典: {source_url}")
+            let text = align(text);
+            format!("{base}\n{INDENT}要約: {text}\n{INDENT}出典: {source_url}")
         }
         Some(Explanation::Unavailable { reference_url }) => match reference_url {
-            Some(url) => format!("{base}\n    変更内容不明\n    参考: {url}"),
-            None => format!("{base}\n    変更内容不明"),
+            Some(url) => format!("{base}\n{INDENT}変更内容不明\n{INDENT}参考: {url}"),
+            None => format!("{base}\n{INDENT}変更内容不明"),
         },
-        Some(Explanation::GenerationFailed) => format!("{base}\n    要約失敗（claude 生成エラー）"),
+        Some(Explanation::GenerationFailed) => {
+            format!("{base}\n{INDENT}要約失敗（claude 生成エラー）")
+        }
     }
 }
 
@@ -58,6 +79,19 @@ mod tests {
         assert_eq!(
             got,
             "[brew] bat: 0.24.0 -> 0.25.0\n    要約: 新機能追加\n    出典: https://github.com/sharkdp/bat/releases/tag/v0.25.0"
+        );
+    }
+
+    #[test]
+    fn multiline_summary_is_aligned_and_leaves_blank_lines_bare() {
+        let explanation = Explanation::Summary {
+            text: "1行目\n\n2段落目".into(),
+            source_url: "https://example.com/r/v1".into(),
+        };
+        let got = format_package_line(&sample(), Some(&explanation));
+        assert_eq!(
+            got,
+            "[brew] bat: 0.24.0 -> 0.25.0\n    要約: 1行目\n\n    2段落目\n    出典: https://example.com/r/v1"
         );
     }
 

--- a/tests/upkeep/mod.rs
+++ b/tests/upkeep/mod.rs
@@ -60,6 +60,14 @@ pub(crate) fn stdout_stub_body(env_var: &str) -> String {
     format!("#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' \"${env_var}\"\n")
 }
 
+/// [`stdout_stub_body`] に呼び出し引数の記録を足したもの。渡した引数そのものを検証したい
+/// ときだけ使う。
+pub(crate) fn recording_stdout_stub_body(name: &str, env_var: &str) -> String {
+    format!(
+        "#!/bin/sh\ncat >/dev/null\nprintf '{name} %s\\n' \"$*\" >> \"$UPKEEP_LOG\"\nprintf '%s\\n' \"${env_var}\"\n"
+    )
+}
+
 /// 第1引数（サブコマンド）で分岐して、対応する環境変数の中身を stdout に出すスタブ本体。
 ///
 /// `brew outdated` と `brew info`、`mise outdated` と `mise tool` のように、同じコマンドが

--- a/tests/upkeep/outdated.rs
+++ b/tests/upkeep/outdated.rs
@@ -247,6 +247,53 @@ fn explain_isolates_the_claude_invocation() {
     }
 }
 
+/// 解説付きは1件が複数行になるので、パッケージ同士は空行で区切る。
+#[test]
+fn explain_separates_packages_with_a_blank_line() {
+    let fx = fixture();
+    fx.stub_dispatch(
+        "brew",
+        &[("outdated", "BREW_JSON"), ("info", "BREW_INFO_JSON")],
+    )
+    .stub_dispatch(
+        "mise",
+        &[("outdated", "MISE_JSON"), ("tool", "MISE_TOOL_JSON")],
+    )
+    .stub_stdout("gh", "GH_RELEASE_JSON")
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("BREW_JSON", BREW_JSON)
+        .env("BREW_INFO_JSON", BREW_INFO_JSON)
+        .env("MISE_JSON", MISE_JSON)
+        .env("MISE_TOOL_JSON", MISE_TOOL_AQUA_JSON)
+        .env("GH_RELEASE_JSON", GH_RELEASE_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\n\n[mise] jq"));
+}
+
+/// 解説なしの一覧は1行ずつなので、空行で間延びさせない。
+#[test]
+fn list_without_explain_has_no_blank_lines_between_packages() {
+    let fx = fixture();
+    fx.stub_dispatch("brew", &[("outdated", "BREW_JSON")])
+        .stub_dispatch("mise", &[("outdated", "MISE_JSON")]);
+
+    outdated()
+        .env("PATH", &fx.bin)
+        .env("BREW_JSON", BREW_JSON)
+        .env("MISE_JSON", MISE_JSON)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "[brew] bat: 0.24.0 -> 0.25.0\n[mise] jq: 1.6 -> 1.8.2",
+        ));
+}
+
 #[test]
 fn explain_summarizes_brew_package() {
     let fx = fixture();

--- a/tests/upkeep/outdated.rs
+++ b/tests/upkeep/outdated.rs
@@ -23,8 +23,7 @@ const CARGO_TABLE: &str =
     "Package      Installed  Latest   Needs update\ncargo-audit  v0.17.0    v0.18.0  Yes";
 const CRATES_IO_JSON: &str = r#"{"crate":{"repository":"https://github.com/rustsec/rustsec"}}"#;
 const GH_RELEASE_JSON: &str = r#"{"body":"What's Changed\n\n* Fix bug X","url":"https://github.com/rustsec/rustsec/releases/tag/v1.0.0"}"#;
-const CLAUDE_SUMMARY_JSON: &str =
-    r#"{"type":"result","is_error":false,"structured_output":{"summary":"新機能Xを追加"}}"#;
+const CLAUDE_SUMMARY_JSON: &str = r#"{"type":"result","is_error":false,"structured_output":{"release_notes_ja":"新機能Xを追加"}}"#;
 const CLAUDE_ERROR_JSON: &str = r#"{"is_error":true,"errors":["boom"]}"#;
 const FAILING_STUB: &str = "#!/bin/sh\nexit 1\n";
 

--- a/tests/upkeep/outdated.rs
+++ b/tests/upkeep/outdated.rs
@@ -11,7 +11,10 @@ use predicates::prelude::*;
 use rstest::rstest;
 use tempfile::TempDir;
 
-use crate::{EMPTY_PATH, dispatch_stub_body, stdout_stub_body, stub_body, write_exec};
+use crate::{
+    EMPTY_PATH, dispatch_stub_body, recording_stdout_stub_body, stdout_stub_body, stub_body,
+    write_exec,
+};
 
 const BREW_JSON: &str = r#"{"formulae":[{"name":"bat","installed_versions":["0.24.0"],"current_version":"0.25.0","pinned":false,"pinned_version":null}],"casks":[]}"#;
 const MISE_JSON: &str = r#"{"jq":{"name":"jq","requested":"1.6","current":"1.6","bump":"1.8","latest":"1.8.2","source":{"type":"mise.toml","path":"/tmp/mise.toml"}}}"#;
@@ -36,19 +39,31 @@ fn outdated() -> Command {
 struct Fixture {
     _root: TempDir,
     bin: PathBuf,
+    log: PathBuf,
 }
 
 fn fixture() -> Fixture {
     let root = TempDir::new().unwrap();
     let bin = root.path().join("bin");
     fs::create_dir_all(&bin).unwrap();
-    Fixture { _root: root, bin }
+    let log = root.path().join("calls.log");
+    Fixture {
+        _root: root,
+        bin,
+        log,
+    }
 }
 
 impl Fixture {
     /// `name` を、環境変数 `env_var` の中身をそのまま返すスタブとして置く。
     fn stub_stdout(&self, name: &str, env_var: &str) -> &Self {
         write_exec(&self.bin, name, &stdout_stub_body(env_var));
+        self
+    }
+
+    /// `name` を、呼び出し引数を `$UPKEEP_LOG` に残す [`Fixture::stub_stdout`] として置く。
+    fn stub_stdout_recording(&self, name: &str, env_var: &str) -> &Self {
+        write_exec(&self.bin, name, &recording_stdout_stub_body(name, env_var));
         self
     }
 
@@ -203,6 +218,33 @@ fn explain_summarizes_cargo_package() {
         .stdout(predicate::str::contains(
             "出典: https://github.com/rustsec/rustsec/releases/tag/v1.0.0",
         ));
+}
+
+/// 要約の呼び出しは、呼び出し元の設定とツールを持ち込まない形で行う。持ち込むと要約では
+/// なく「要約して回答した」という行為の報告が返るため、この引数自体が修正の本体になる。
+#[test]
+fn explain_isolates_the_claude_invocation() {
+    let fx = fixture();
+    fx.cargo_stub();
+    fx.stub_stdout("curl", "CRATES_IO_JSON")
+        .stub_stdout("gh", "GH_RELEASE_JSON")
+        .stub_stdout_recording("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("UPKEEP_LOG", &fx.log)
+        .env("CARGO_TABLE", CARGO_TABLE)
+        .env("CRATES_IO_JSON", CRATES_IO_JSON)
+        .env("GH_RELEASE_JSON", GH_RELEASE_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success();
+
+    let log = fs::read_to_string(&fx.log).unwrap_or_default();
+    for expected in ["--safe-mode", "--tools", "release_notes_ja"] {
+        assert!(log.contains(expected), "missing {expected}:\n{log}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
`outdated --explain` の要約が、リリースノートの中身ではなく「リリースノートを要約して
回答した」という行為の報告になっていた。

入力を jq 1.8.2 のリリースノート本文に固定し、`outdated/claude.rs` の `Command` 呼び出しを
バイト等価で再現して条件を1軸ずつ振って切り分けた。症状は毎回ではなく発生率の問題で、
参照条件では10試行中8件だった。

効いたのは3つで、いずれも単独でほぼ抑える。重ねて入れる。

- 出力フィールドを `summary` から成果物を名指しする `release_notes_ja` へ変更（0/10）
- `--tools ""` で使えるツールを無くす（単独では出荷構成で1/10残る）
- `--safe-mode` で `~/.claude` とプロジェクト設定の注入を止める

3点セットで出荷構成 0/10。実バイナリでも確認済み。

`--safe-mode` は入力トークンも半減させ（同一入力で $0.396 → $0.192）、要約の内容を
呼び出し元の `~/.claude` の中身から切り離す。

Issue が挙げていた「継承される環境」「`Keep it concise` の圧力」はどちらも反証した。
前者は完全に取り除いても率が変わらず（Fisher 正確検定で p ≈ 0.6）、後者は削ると 9/10 と
むしろ高い。よって system prompt は触らない。切り分けの詳細は #672 のコメントに残した。

## 表示

実行結果を見て、あわせて `--explain` の読みにくさも直した。

- 解説付きは1件が複数行になるため、パッケージ同士を空行で区切る（解説なしの一覧は1行ずつ
  なので詰めたまま）
- 要約が複数行のとき、2行目以降がカラム 0 から始まってパッケージ行と見分けが付かなかった。
  1行目と同じ深さへ揃え、カラム 0 に来るのをパッケージ行だけに保つ

なお `--explain` は1件ずつ直列に解決していて遅い（メタデータ取得だけで 9.5 秒、`claude` 1回が
約 14.5 秒）。並列化は #675 へ切り出した。

Closes #672
