### PR TITLE
perf(upkeep): outdated --explain の解決を並行化する

### DIFF
--- a/src/bin/upkeep/outdated/claude.rs
+++ b/src/bin/upkeep/outdated/claude.rs
@@ -31,10 +31,10 @@ const OUTPUT_SCHEMA: &str = r#"{"type":"object","properties":{"release_notes_ja"
 
 /// リリースノート本文を claude -p で日本語要約する。
 ///
-/// `claude` の起動失敗・空出力・パース失敗はすべて警告して `None` を返す
-/// （呼び出し元は要約なしで続行する）。
-pub fn summarize(release_notes: &str) -> Option<String> {
-    let mut child = match Command::new("claude")
+/// 失敗しても標準エラーへは出さない。解決は複数パッケージ分が並行に走るので、ここで出すと
+/// どのパッケージの失敗か分からなくなる（呼び出し元がパッケージ行へ添えて表示する）。
+pub fn summarize(release_notes: &str) -> Result<String, String> {
+    let mut child = Command::new("claude")
         .args([
             "-p",
             "--model",
@@ -53,35 +53,22 @@ pub fn summarize(release_notes: &str) -> Option<String> {
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => {
-            eprintln!(
-                "⚠️  要約の生成に失敗しました。claude コマンドが利用可能か確認してください。"
-            );
-            return None;
-        }
-    };
+        .map_err(|e| format!("claude を起動できませんでした: {e}"))?;
 
     if let Some(mut stdin) = child.stdin.take() {
         let _ = stdin.write_all(release_notes.as_bytes());
         // stdin はここで drop され閉じる。
     }
 
-    let output = child.wait_with_output().ok()?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("claude の終了を待てませんでした: {e}"))?;
     let raw = String::from_utf8_lossy(&output.stdout).into_owned();
     if raw.trim().is_empty() {
-        eprintln!("⚠️  要約の生成に失敗しました。claude コマンドが利用可能か確認してください。");
-        return None;
+        return Err("claude の出力が空でした".to_string());
     }
 
-    match parse_summary(&raw) {
-        Ok(summary) => Some(summary),
-        Err(msg) => {
-            eprintln!("⚠️  要約の生成に失敗しました: {msg}");
-            None
-        }
-    }
+    parse_summary(&raw)
 }
 
 /// `--output-format json` の結果 envelope。要約本文だけ拾う。

--- a/src/bin/upkeep/outdated/explain.rs
+++ b/src/bin/upkeep/outdated/explain.rs
@@ -11,8 +11,8 @@ pub enum Explanation {
     /// リリースノート本文を機械的に解決できなかった。`reference_url` は、それでも
     /// 利用者が一次情報へ辿れるようメタデータから引けた URL。
     Unavailable { reference_url: Option<String> },
-    /// リリースノートは取得できたが claude による要約に失敗した。
-    GenerationFailed,
+    /// リリースノートは取得できたが claude による要約に失敗した。`reason` は失敗の内訳。
+    GenerationFailed { reason: String },
     /// 要約成功。`source_url` は要約元のリリースページ
     /// （誤りが疑わしいときにユーザーが自分で一次情報を確認できるようにするため）。
     Summary { text: String, source_url: String },
@@ -34,10 +34,10 @@ pub fn resolve(pkg: &OutdatedPackage) -> Explanation {
     };
 
     match super::claude::summarize(&notes.body) {
-        Some(text) => Explanation::Summary {
+        Ok(text) => Explanation::Summary {
             text,
             source_url: notes.url,
         },
-        None => Explanation::GenerationFailed,
+        Err(reason) => Explanation::GenerationFailed { reason },
     }
 }

--- a/src/bin/upkeep/outdated/mod.rs
+++ b/src/bin/upkeep/outdated/mod.rs
@@ -1,13 +1,15 @@
 //! `outdated`: brew / mise / cargo でアップデート可能なパッケージを一覧表示する。
 //!
 //! `--explain` は取得できたリリースノートを [`claude::summarize`] で日本語要約する。
-//! 解決の流れは [`explain::resolve`] を参照。
+//! 1件の解決の流れは [`explain::resolve`]、複数件の走らせ方は [`ordered::resolve_each`]
+//! を参照。
 
 mod brew;
 mod cargo;
 mod claude;
 mod explain;
 mod mise;
+mod ordered;
 mod package;
 mod registry;
 mod release;
@@ -44,14 +46,20 @@ pub fn run(explain: bool) {
         eprintln!("⚠️  claude コマンドが見つかりません。要約なしで一覧のみ表示します。");
     }
 
-    for (i, pkg) in packages.iter().enumerate() {
-        let explanation = attempt_explain.then(|| explain::resolve(pkg));
-        let block = render::format_package_line(pkg, explanation.as_ref());
-        // 解説付きは1件が複数行になる。空行を挟まないとどこまでが1パッケージか読めない。
-        if attempt_explain && i > 0 {
-            println!();
+    if attempt_explain {
+        let mut printed_any = false;
+        ordered::resolve_each(&packages, |pkg, explanation| {
+            // 解説付きは1件が複数行になる。空行を挟まないとどこまでが1パッケージか読めない。
+            if printed_any {
+                println!();
+            }
+            printed_any = true;
+            println!("{}", render::format_package_line(pkg, Some(&explanation)));
+        });
+    } else {
+        for pkg in &packages {
+            println!("{}", render::format_package_line(pkg, None));
         }
-        println!("{block}");
     }
 
     header("Done");

--- a/src/bin/upkeep/outdated/ordered.rs
+++ b/src/bin/upkeep/outdated/ordered.rs
@@ -1,0 +1,108 @@
+//! 複数パッケージの `--explain` 解決を並行に走らせ、検出順で1件ずつ返す。
+//!
+//! 待ちはすべてサブプロセスの終了待ちなので、OS スレッドをそのまま待たせれば足りる。
+//! 非同期ランタイムは持ち込まない。
+//!
+//! 完了順はばらつくが、表示は検出順に固定する。実行ごとに並びが変わると読めないため。
+//! ただし全件そろうまで待つと体感が悪化するので、先頭から途切れずに揃った分だけ流す。
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::thread;
+
+use super::explain::{self, Explanation};
+use super::package::OutdatedPackage;
+
+/// 同時に走らせる解決の本数。
+///
+/// 1件の解決は最大1回 `claude -p` を呼ぶので、この値がそのまま claude の同時呼び出し数の
+/// 上限になる。全体の所要時間は最も遅い1件に張り付くため、これ以上増やしてもほとんど縮まない。
+const LANES: usize = 4;
+
+/// パッケージを並行に解決し、確定した先頭から `on_ready` へ検出順で渡す。
+pub fn resolve_each(
+    packages: &[OutdatedPackage],
+    mut on_ready: impl FnMut(&OutdatedPackage, Explanation),
+) {
+    let next = AtomicUsize::new(0);
+    let (tx, rx) = mpsc::channel();
+
+    thread::scope(|scope| {
+        for _ in 0..LANES.min(packages.len()) {
+            let tx = tx.clone();
+            let next = &next;
+            scope.spawn(move || {
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(pkg) = packages.get(index) else {
+                        break;
+                    };
+                    let _ = tx.send((index, explain::resolve(pkg)));
+                }
+            });
+        }
+        // 送信側の元を手放す。全 worker が終えた時点で rx が閉じ、下の for が抜ける。
+        drop(tx);
+
+        let mut buffer = InOrder::new(packages.len());
+        for (index, explanation) in rx {
+            for (index, explanation) in buffer.accept(index, explanation) {
+                on_ready(&packages[index], explanation);
+            }
+        }
+    });
+}
+
+/// 完了順に届く結果を、検出順へ並べ直す。
+struct InOrder<T> {
+    slots: Vec<Option<T>>,
+    next: usize,
+}
+
+impl<T> InOrder<T> {
+    fn new(len: usize) -> Self {
+        Self {
+            slots: (0..len).map(|_| None).collect(),
+            next: 0,
+        }
+    }
+
+    /// `index` 番目の結果を受け取り、先頭から途切れずに揃った分を返す。
+    fn accept(&mut self, index: usize, value: T) -> Vec<(usize, T)> {
+        self.slots[index] = Some(value);
+
+        let mut ready = Vec::new();
+        while let Some(value) = self.slots.get_mut(self.next).and_then(Option::take) {
+            ready.push((self.next, value));
+            self.next += 1;
+        }
+        ready
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holds_results_until_the_head_arrives() {
+        let mut buffer = InOrder::new(3);
+        assert!(buffer.accept(2, "c").is_empty());
+        assert!(buffer.accept(1, "b").is_empty());
+        assert_eq!(buffer.accept(0, "a"), vec![(0, "a"), (1, "b"), (2, "c")]);
+    }
+
+    #[test]
+    fn releases_each_result_as_soon_as_its_turn_comes() {
+        let mut buffer = InOrder::new(3);
+        assert_eq!(buffer.accept(0, "a"), vec![(0, "a")]);
+        assert!(buffer.accept(2, "c").is_empty());
+        assert_eq!(buffer.accept(1, "b"), vec![(1, "b"), (2, "c")]);
+    }
+
+    #[test]
+    fn single_result_is_released_immediately() {
+        let mut buffer = InOrder::new(1);
+        assert_eq!(buffer.accept(0, "only"), vec![(0, "only")]);
+    }
+}

--- a/src/bin/upkeep/outdated/render.rs
+++ b/src/bin/upkeep/outdated/render.rs
@@ -41,8 +41,8 @@ pub fn format_package_line(pkg: &OutdatedPackage, explanation: Option<&Explanati
             Some(url) => format!("{base}\n{INDENT}変更内容不明\n{INDENT}参考: {url}"),
             None => format!("{base}\n{INDENT}変更内容不明"),
         },
-        Some(Explanation::GenerationFailed) => {
-            format!("{base}\n{INDENT}要約失敗（claude 生成エラー）")
+        Some(Explanation::GenerationFailed { reason }) => {
+            format!("{base}\n{INDENT}要約失敗: {reason}")
         }
     }
 }
@@ -118,10 +118,13 @@ mod tests {
 
     #[test]
     fn with_generation_failed() {
-        let got = format_package_line(&sample(), Some(&Explanation::GenerationFailed));
+        let explanation = Explanation::GenerationFailed {
+            reason: "claude の出力が空でした".into(),
+        };
+        let got = format_package_line(&sample(), Some(&explanation));
         assert_eq!(
             got,
-            "[brew] bat: 0.24.0 -> 0.25.0\n    要約失敗（claude 生成エラー）"
+            "[brew] bat: 0.24.0 -> 0.25.0\n    要約失敗: claude の出力が空でした"
         );
     }
 }

--- a/tests/upkeep/outdated.rs
+++ b/tests/upkeep/outdated.rs
@@ -30,6 +30,30 @@ const CLAUDE_SUMMARY_JSON: &str = r#"{"type":"result","is_error":false,"structur
 const CLAUDE_ERROR_JSON: &str = r#"{"is_error":true,"errors":["boom"]}"#;
 const FAILING_STUB: &str = "#!/bin/sh\nexit 1\n";
 
+/// `sleep` を使うスタブ本体を組み立てる。テストの PATH はスタブディレクトリだけに絞って
+/// あるので、スタブ自身が `sleep` を引ける PATH をここで補う。
+fn sleeping_stub_body(body: &str) -> String {
+    format!("#!/bin/sh\nPATH=/usr/bin:/bin\nexport PATH\ncat >/dev/null\n{body}")
+}
+
+/// brew 側（`sharkdp/bat`）のリリース取得だけを遅らせる `gh`。
+fn slow_for_brew_gh_stub() -> String {
+    sleeping_stub_body(concat!(
+        "case \"$*\" in\n  *sharkdp/bat*) sleep 0.5 ;;\nesac\n",
+        "printf '%s\\n' \"$GH_RELEASE_JSON\"\n"
+    ))
+}
+
+/// 呼び出しの開始と終了を `$UPKEEP_LOG` に刻む `gh`。区間が重なるかで並行性を見る。
+fn overlap_probe_gh_stub() -> String {
+    sleeping_stub_body(concat!(
+        "printf 'start\\n' >> \"$UPKEEP_LOG\"\n",
+        "sleep 0.5\n",
+        "printf 'end\\n' >> \"$UPKEEP_LOG\"\n",
+        "printf '%s\\n' \"$GH_RELEASE_JSON\"\n"
+    ))
+}
+
 fn outdated() -> Command {
     let mut cmd = Command::cargo_bin("upkeep").unwrap();
     cmd.arg("outdated");
@@ -443,5 +467,77 @@ fn explain_shows_generation_failed_when_claude_errors() {
         .env("CLAUDE_JSON", CLAUDE_ERROR_JSON)
         .assert()
         .success()
-        .stdout(predicate::str::contains("要約失敗（claude 生成エラー）"));
+        .stdout(predicate::str::contains("要約失敗: boom"));
+}
+
+/// 並行に解決すると完了順はばらつく。表示は検出順（brew → mise）に固定する。
+#[test]
+fn explain_keeps_detection_order_when_resolution_finishes_out_of_order() {
+    let fx = fixture();
+    fx.stub_dispatch(
+        "brew",
+        &[("outdated", "BREW_JSON"), ("info", "BREW_INFO_JSON")],
+    )
+    .stub_dispatch(
+        "mise",
+        &[("outdated", "MISE_JSON"), ("tool", "MISE_TOOL_JSON")],
+    )
+    // 先に検出される brew のリリース取得だけを遅らせ、mise を先に完了させる。
+    .stub("gh", &slow_for_brew_gh_stub())
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    let assert = outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("BREW_JSON", BREW_JSON)
+        .env("BREW_INFO_JSON", BREW_INFO_JSON)
+        .env("MISE_JSON", MISE_JSON)
+        .env("MISE_TOOL_JSON", MISE_TOOL_AQUA_JSON)
+        .env("GH_RELEASE_JSON", GH_RELEASE_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let brew = stdout.find("[brew] bat").expect("brew line missing");
+    let mise = stdout.find("[mise] jq").expect("mise line missing");
+    assert!(brew < mise, "detection order not preserved:\n{stdout}");
+}
+
+/// パッケージ間に依存は無いので、解決は重ねて走らせる。
+#[test]
+fn explain_resolves_packages_concurrently() {
+    let fx = fixture();
+    fx.stub_dispatch(
+        "brew",
+        &[("outdated", "BREW_JSON"), ("info", "BREW_INFO_JSON")],
+    )
+    .stub_dispatch(
+        "mise",
+        &[("outdated", "MISE_JSON"), ("tool", "MISE_TOOL_JSON")],
+    )
+    .stub("gh", &overlap_probe_gh_stub())
+    .stub_stdout("claude", "CLAUDE_JSON");
+
+    outdated()
+        .arg("--explain")
+        .env("PATH", &fx.bin)
+        .env("UPKEEP_LOG", &fx.log)
+        .env("BREW_JSON", BREW_JSON)
+        .env("BREW_INFO_JSON", BREW_INFO_JSON)
+        .env("MISE_JSON", MISE_JSON)
+        .env("MISE_TOOL_JSON", MISE_TOOL_AQUA_JSON)
+        .env("GH_RELEASE_JSON", GH_RELEASE_JSON)
+        .env("CLAUDE_JSON", CLAUDE_SUMMARY_JSON)
+        .assert()
+        .success();
+
+    // 直列なら start,end,start,end になる。重なっていれば両方の start が先に並ぶ。
+    let log = fs::read_to_string(&fx.log).unwrap_or_default();
+    let events: Vec<&str> = log.lines().collect();
+    assert_eq!(
+        events,
+        ["start", "start", "end", "end"],
+        "gh calls did not overlap:\n{log}"
+    );
 }


### PR DESCRIPTION
## 背景

`outdated --explain` はパッケージを1件ずつ直列に解決していた。1件の解決は「上流の特定 → `gh release view` → `claude -p` で要約」で、すべてサブプロセスの終了待ちになる。所要時間は全件の総和になり、要約対象が増えるほど線形に伸びる。パッケージ間に依存は無い。

## 変更

最大4件を OS スレッドで並行に解決する。

- **非同期ランタイムは入れない。** 待ちが非同期 IO ではなくサブプロセスの終了である以上、tokio を持ち込む利点が無い。`std::thread` + `mpsc` は `src/bin/dotfiles/apply/cmd.rs` に前例がある。
- **表示は検出順に固定する。** 完了順はばらつくが、実行ごとに `[brew]` → `[mise]` → `[cargo]` の並びが変わると読めない。全件そろうまで待つと体感が悪化するので、先頭から途切れずに揃った分だけ順次流す。
- **要約失敗の警告を `Explanation` の値へ移した。** 直列のときは警告が該当パッケージの直後に出ていたが、並行化すると任意のタイミングで標準エラーへ割り込み、どのパッケージの失敗か分からなくなる。理由を値に載せ、パッケージ行へ添えて表示する。

## 実測

実機（更新可能 10 件・うち要約対象 7 件）:

| | 所要 |
| --- | --- |
| 直列（変更前） | 281.0 秒 |
| 並行（本 PR・上限 4） | 76.7 秒 |

いずれも要約失敗 0 件で、パッケージの表示順は変更前と一致した。単発の `claude -p` は同一入力でも 7〜72 秒とばらつくため比そのものは目安で、構造的な性質のほうが確か: 直列は全件の総和、並行は最も遅い1件に張り付く。

### 同時実行数を 4 にした理由

- `claude -p` を 8 本同時に投げても 8/8 成功し、レート制限には当たらなかった。
- 上限 8 で同じ実機計測をすると 66.3 秒で、4 の 76.7 秒に対し明確な改善は出なかった（単発のばらつきの範囲内）。全体の所要時間が最も遅い1件に張り付くため、増やしてもほとんど縮まない。

## 検討したが採らなかったもの

要約モデルの Haiku への格下げは、可能だが採らない。

`--model haiku` は正しく効く（実コードパスで全ターン haiku）。実測は各1回で、haiku $0.0086 / 13.0 秒、sonnet $0.0150 / 11.0 秒。単発の `claude -p` は同一入力でも大きくばらつくため、この差から速さの優劣は言えない。

採らない理由は2つ。モデル選定は要約精度とコストの軸にあり、本 PR が解いた待ち時間とは別軸であること。そして要約はアップグレードして安全かを判断する材料なので精度を優先する、という判断が `claude.rs` の doc に既にあり、対象が7件程度では節約の絶対額が小さくこれを覆す材料にならないこと。

## テスト

- 検出順が保たれること: brew 側のリリース取得だけを遅らせて mise を先に完了させても、表示は brew → mise になる。
- 解決が重なること: `gh` 呼び出しの開始と終了を記録し、区間が重なる（`start,start,end,end`）ことを確認する。

いずれも実装を反転させると落ちることを確認済み（上限を 1 にすると `start,end,start,end` になり、順序バッファを外すと表示順が崩れる）。

Closes #675
