### PR TITLE
chore: release v0.71.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.71.7] - 2026-07-26
+### Features
+- Outdated --explain のリリースノート解決を brew / mise へ広げる ([#673](https://github.com/toshiki670/dotfiles/pull/673)) ([`e9f2a0b`](https://github.com/toshiki670/dotfiles/commit/e9f2a0b60b621ba0dc9975c25f68399d4c4f9aee))
+### Fixes
+- Outdated --explain の要約が行為の報告になるのを直す ([#674](https://github.com/toshiki670/dotfiles/pull/674)) ([`d0534d1`](https://github.com/toshiki670/dotfiles/commit/d0534d118738bf3151b4e1f5a646e07132a3e190))
+### Performance
+- Outdated --explain の解決を並行化する ([#676](https://github.com/toshiki670/dotfiles/pull/676)) ([`afeb0c0`](https://github.com/toshiki670/dotfiles/commit/afeb0c03abdeb8c32a2dfc7c28b3ce3baf3f3e79))
+
+
 ## [0.71.6] - 2026-07-20
 ### Features
 - Outdated サブコマンドで更新可能なパッケージを一覧表示する ([#668](https://github.com/toshiki670/dotfiles/pull/668)) ([`f02a728`](https://github.com/toshiki670/dotfiles/commit/f02a728941c90d2d9b19ea0d03cfa685b0f7cd0b))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.71.6"
+version = "0.71.7"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.71.6"
+version     = "0.71.7"
 
 [dependencies]
 clap          = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `dotfiles`: 0.71.6 -> 0.71.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.71.7] - 2026-07-26

### Features
- Outdated --explain のリリースノート解決を brew / mise へ広げる ([#673](https://github.com/toshiki670/dotfiles/pull/673)) ([`e9f2a0b`](https://github.com/toshiki670/dotfiles/commit/e9f2a0b60b621ba0dc9975c25f68399d4c4f9aee))
### Fixes
- Outdated --explain の要約が行為の報告になるのを直す ([#674](https://github.com/toshiki670/dotfiles/pull/674)) ([`d0534d1`](https://github.com/toshiki670/dotfiles/commit/d0534d118738bf3151b4e1f5a646e07132a3e190))
### Performance
- Outdated --explain の解決を並行化する ([#676](https://github.com/toshiki670/dotfiles/pull/676)) ([`afeb0c0`](https://github.com/toshiki670/dotfiles/commit/afeb0c03abdeb8c32a2dfc7c28b3ce3baf3f3e79))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).