### PR TITLE
chore: release v0.71.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.71.9] - 2026-08-03
+### Features
+- Work-map skill を追加する ([#688](https://github.com/toshiki670/dotfiles/pull/688)) ([`549abec`](https://github.com/toshiki670/dotfiles/commit/549abece556a4fdac8efc039af27893a8c60fb37))
+
+
 ## [0.71.8] - 2026-07-28
 ### Features
 - Memory-tidy に feedback を抽象度で束ねる手順を追加する ([#680](https://github.com/toshiki670/dotfiles/pull/680)) ([`29ead04`](https://github.com/toshiki670/dotfiles/commit/29ead04d46b9872b644bf80a95fd1d58f4fd6097))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.71.8"
+version = "0.71.9"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.71.8"
+version     = "0.71.9"
 
 [dependencies]
 clap          = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `dotfiles`: 0.71.8 -> 0.71.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.71.9] - 2026-08-03

### Features
- Work-map skill を追加する ([#688](https://github.com/toshiki670/dotfiles/pull/688)) ([`549abec`](https://github.com/toshiki670/dotfiles/commit/549abece556a4fdac8efc039af27893a8c60fb37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).