### PR TITLE
chore: release v0.71.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.71.10] - 2026-08-05
+### Features
+- Outdated --explain で current→latest 間の全リリースを要約する ([#692](https://github.com/toshiki670/dotfiles/pull/692)) ([`a872d4b`](https://github.com/toshiki670/dotfiles/commit/a872d4b760e8a309b819973507069af4e0994574))
+
+
 ## [0.71.9] - 2026-08-03
 ### Features
 - Work-map skill を追加する ([#688](https://github.com/toshiki670/dotfiles/pull/688)) ([`549abec`](https://github.com/toshiki670/dotfiles/commit/549abece556a4fdac8efc039af27893a8c60fb37))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.71.9"
+version = "0.71.10"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.71.9"
+version     = "0.71.10"
 
 [dependencies]
 clap          = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `dotfiles`: 0.71.9 -> 0.71.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.71.10] - 2026-08-05

### Features
- Outdated --explain で current→latest 間の全リリースを要約する ([#692](https://github.com/toshiki670/dotfiles/pull/692)) ([`a872d4b`](https://github.com/toshiki670/dotfiles/commit/a872d4b760e8a309b819973507069af4e0994574))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).