### PR TITLE
chore: release v0.71.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.71.11] - 2026-08-07
+### Features
+- Work-map の図を mermaid へ置き換え、build 時検証を入れる ([#695](https://github.com/toshiki670/dotfiles/pull/695)) ([`22c7ef2`](https://github.com/toshiki670/dotfiles/commit/22c7ef2151eaac692f5d49eccda860f331d49707))
+
+
 ## [0.71.10] - 2026-08-05
 ### Features
 - Outdated --explain で current→latest 間の全リリースを要約する ([#692](https://github.com/toshiki670/dotfiles/pull/692)) ([`a872d4b`](https://github.com/toshiki670/dotfiles/commit/a872d4b760e8a309b819973507069af4e0994574))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dotfiles"
-version = "0.71.10"
+version = "0.71.11"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition     = { workspace = true }
 license     = { workspace = true }
 name        = "dotfiles"
 repository  = { workspace = true }
-version     = "0.71.10"
+version     = "0.71.11"
 
 [dependencies]
 clap          = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `dotfiles`: 0.71.10 -> 0.71.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.71.11] - 2026-08-07

### Features
- Work-map の図を mermaid へ置き換え、build 時検証を入れる ([#695](https://github.com/toshiki670/dotfiles/pull/695)) ([`22c7ef2`](https://github.com/toshiki670/dotfiles/commit/22c7ef2151eaac692f5d49eccda860f331d49707))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).