### PR TITLE
fix(claude): work-map の日本語可否表と外部参照の誤爆を直す

### DIFF
--- a/configs/claude/skills/work-map/SKILL.md
+++ b/configs/claude/skills/work-map/SKILL.md
@@ -93,8 +93,9 @@ venn-beta
 
 | 型 | 日本語 |
 | --- | --- |
-| flowchart / sequence / class / er / gitGraph | そのまま通る |
+| flowchart / sequence / class / er | そのまま通る |
 | `architecture-beta` | ラベルを引用符で囲む（`["通知基盤"]`）。囲まないと Lexer error |
+| `gitGraph` | ブランチ名を引用符で囲む（`branch "開発"`）。`checkout` / `merge` の参照側も同じ。`id:` / `tag:` はそのまま通る |
 | `sankey-beta` | ノード名に日本語が使えない。使うなら ASCII |
 | `venn-beta` | set 名に日本語が使えない。ラベル（`["…"]`）は通る |
 

--- a/configs/claude/skills/work-map/assets/build.sh
+++ b/configs/claude/skills/work-map/assets/build.sh
@@ -63,6 +63,7 @@ tmp="$work/page.html"
 # 断片が持ち込む欠陥を先に弾く。ブラウザを起こすより桁で速い。
 python3 - "$content" <<'PY' || exit 1
 import re, sys
+from html.parser import HTMLParser
 
 frag = open(sys.argv[1], encoding='utf-8').read()
 bad = []
@@ -94,14 +95,46 @@ for block in re.findall(r'<pre[^>]*\bclass="[^"]*\bmermaid\b[^"]*"[^>]*>(.*?)</p
             bad.append(f'{head} は使わない — {LOSES[head]}')
         break
 
-for pat, why in [
-    (r'<link\b', '<link>'),
-    (r'@import\b', '@import'),
-    (r'\bsrc="(?!data:)', 'src= の外部参照'),
-    (r'url\((?![\'"]?data:)[\'"]?https?:', 'url() の外部参照'),
-]:
-    if re.search(pat, frag):
-        bad.append(f'外部参照: {why}')
+# 外部参照は markup の構造で見る。文字列で探すと、図のラベルや本文に書いた
+# url(…) や src="…" を、実際に効く属性・CSS と区別できずに弾く
+def css_refs(css):
+    # scheme は CSS でも属性でも大小を区別しない
+    return [f'url({u})' for u in re.findall(r'url\(\s*[\'"]?(https?:[^)\'"\s]*)', css, re.I)]
+
+class Refs(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.found = []
+        self.in_style = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'style':
+            self.in_style += 1
+        if tag == 'link':
+            self.found.append('<link>')
+        for name, value in attrs:
+            if not value:
+                continue
+            if name == 'src' and not value.lower().startswith('data:'):
+                self.found.append(f'src="{value[:60]}"')
+            elif name == 'style':
+                self.found += css_refs(value)
+
+    def handle_endtag(self, tag):
+        if tag == 'style' and self.in_style:
+            self.in_style -= 1
+
+    def handle_data(self, data):
+        if self.in_style:
+            if '@import' in data:
+                self.found.append('@import')
+            self.found += css_refs(data)
+
+
+refs = Refs()
+refs.feed(frag)
+refs.close()
+bad += [f'外部参照: {r}' for r in refs.found]
 
 for b in dict.fromkeys(bad):
     print(f'  {b}', file=sys.stderr)


### PR DESCRIPTION
#699 の S2。#697 が「あわせて直る記載の誤り」として挙げた2件を、実測に合わせて直した。

## `gitGraph` の日本語

可否表は `gitGraph` を「そのまま通る」側に置いていたが、ブランチ名に日本語を書くと Lexer error になる。引用符で囲めば通り、ラベルとして描かれる。

| 書き方 | 結果 |
| --- | --- |
| `branch 開発` | 構文エラー |
| `branch "開発"` | 通る（`main` / `開発` / `初回` / `リリース` が SVG に出る） |
| `branch "開発"` ＋ `checkout 開発` | 構文エラー |
| `branch "開発"` ＋ `merge 開発` | 構文エラー |
| `commit id: "初回"` / `commit tag: "リリース"` | そのまま通る |

宣言側だけでなく参照側にも要るので、`architecture-beta` と同じ「引用符で囲む」行へ分けた。同じ表に並ぶ `flowchart` / `sequence` / `class` / `er` も測り、こちらは「そのまま通る」のままにしている。

## 外部参照の誤爆

断片の事前検査が文字列一致だったため、**書いてあるだけの `url(…)` と、実際に効く CSS を区別できていなかった**。

```html
<pre class="mermaid">
flowchart LR
  a["CSS の url(https://example.com/a.png) を消す"] --> b["自己完結"]
</pre>
```

これが `外部参照: url() の外部参照` で止まる。図のラベルはテキストなので通信は起きない。同じ理由で、本文に `@import` や `src="…"` と書いたときも止まっていた。

正規表現の調整では届かない。テキストか属性かは markup の構造にあり、文字列の並びには現れないため。`html.parser` で解析して、**開始タグの属性値・`style` 属性・`<style>` の中身**だけを見る。

`href` は見ない。SKILL.md が出所にテキストリンクを張れと書いているので、`<a href="https://…">` は通す必要がある。

### 副産物として塞がった穴

`<pre>` は raw text 要素ではないので、解析器は mermaid の断片の中もタグとして見る。これまで `src="` のダブルクォートしか見ていなかったぶんが静的側で止まるようになった。

| 断片 | 前 | 後 |
| --- | --- | --- |
| ラベル内の `<img src='https://…'>`（シングルクォート） | 静的検査は素通り、実通信検査が捕捉 | 静的検査で停止 |
| `url(HTTPS://…)`・`URL(…)` | 素通り | 停止 |

`<` を含む mermaid のトークン（`注文 <|-- 明細`、`<<interface>>`）が後続の外部参照を飲み込まないかも測った。飲み込まない。

## 検証

実物の `bash assets/build.sh` に断片を通した。14件すべて期待どおり、`mise run check` は 0。

| 通るべき（誤爆側） | 弾くべき（真陽性側） |
| --- | --- |
| ラベルの `url(https://…)` | `style` 属性の `url(https://…)`・`URL(HTTPS://…)` |
| 本文の `@import` / `src="…"` の言及 | `<link href="https://…">` |
| `<a href="https://…">` のテキストリンク | `<style>@import url("https://…")</style>` |
| `data:` URI（`DATA:` も） | `<img src="https://…">` |
| SKILL.md 掲載の venn 例 | ラベル内の `<img src='https://…'>` |
| `gitGraph`（引用符あり） | `<` トークンの後に置いた `<img src>` |
| | `kanban`（役目の塞ぎ）・`branch 開発` |

## 途中で直した自分の記載

**「CSS の外部参照は実通信検査に見えない」と報告したが、誤りだった。** 静的検査を外した複製と元の build を比べたとき、断片の側も同時に違っていた（CSS 参照だけの断片には mermaid 図が無い）。`check.js` は `figures.some(…)` で描画完了を待つので、図が無いと空配列で即抜け、通信が記録される前にサンプルする。図を1つ足しただけの対照で覆った。

そのタイミングの穴自体は残っている。図の無いページでは実通信検査が当てにならない。本PRの構造検査が静的側で捕まえるぶん実害は小さく、S2 の対象外なので触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
